### PR TITLE
Add generic backend test entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,34 +66,30 @@ endif()
 
 # --- Build tests ---
 if(IMGUIX_BUILD_TESTS)
-    file(GLOB TESTS "tests/*.cpp")
-    foreach(TEST_FILE ${TESTS})
-        get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+    set(TEST_SRC tests/imgui-backend.cpp)
+    add_executable(imgui-backend ${TEST_SRC})
+    target_include_directories(imgui-backend PRIVATE ${CMAKE_BINARY_DIR}/include)
+    set_target_properties(imgui-backend PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests
+    )
+    target_compile_definitions(imgui-backend PRIVATE SFML_STATIC)
 
-        add_executable(${TEST_NAME} ${TEST_FILE})
-        target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_BINARY_DIR}/include)
-        set_target_properties(${TEST_NAME} PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests
-        )
-        target_compile_definitions(${TEST_NAME} PRIVATE SFML_STATIC)
+    target_link_directories(imgui-backend PRIVATE ${CMAKE_BINARY_DIR}/libs)
+    target_link_libraries(imgui-backend
+        PRIVATE
+            freetype
+            sfml-graphics-s
+            sfml-window-s
+            sfml-system-s
+            imgui
+    )
+    if (WIN32)
+        target_link_libraries(imgui-backend PRIVATE opengl32 gdi32 user32 kernel32 winmm)
+    elseif(UNIX)
+        target_link_libraries(imgui-backend PRIVATE GL)
+    endif()
 
-        target_link_directories(${TEST_NAME} PRIVATE ${CMAKE_BINARY_DIR}/libs)
-        target_link_libraries(${TEST_NAME}
-            PRIVATE
-                freetype
-                sfml-graphics-s
-                sfml-window-s
-                sfml-system-s
-                imgui
-        )
-        if (WIN32)
-            target_link_libraries(${TEST_NAME} PRIVATE opengl32 gdi32 user32 kernel32 winmm)
-        elseif(UNIX)
-            target_link_libraries(${TEST_NAME} PRIVATE GL)
-        endif()
-        
-        copy_imgui_fonts(${TEST_NAME})
-    endforeach()
+    copy_imgui_fonts(imgui-backend)
 
     # Also define SFML_STATIC in imgui if it was not set earlier
     target_compile_definitions(imgui PUBLIC SFML_STATIC)

--- a/libs/cmake/sfml-wrapper.cmake
+++ b/libs/cmake/sfml-wrapper.cmake
@@ -11,18 +11,18 @@ set(SFML_BUILD_TEST_SUITE OFF CACHE BOOL "" FORCE)
 set(SFML_USE_SYSTEM_DEPS OFF CACHE BOOL "" FORCE)
 set(SFML_ENABLE_PCH OFF CACHE BOOL "" FORCE)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sfml)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/SFML)
 
 message(STATUS "[ImGuiX] SFML built as a submodule.")
 
 # --- Copy SFML headers to build/include/SFML ---
 file(GLOB_RECURSE SFML_HEADERS
-    "${CMAKE_CURRENT_SOURCE_DIR}/sfml/include/SFML/*.hpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/sfml/include/SFML/*.inl"
+    "${CMAKE_CURRENT_SOURCE_DIR}/SFML/include/SFML/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/SFML/include/SFML/*.inl"
 )
 
 foreach(HDR ${SFML_HEADERS})
-    file(RELATIVE_PATH REL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/sfml/include" "${HDR}")
+    file(RELATIVE_PATH REL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/SFML/include" "${HDR}")
     configure_file(${HDR} "${CMAKE_BINARY_DIR}/include/${REL_PATH}" COPYONLY)
 endforeach()
 

--- a/tests/imgui-backend.cpp
+++ b/tests/imgui-backend.cpp
@@ -1,0 +1,9 @@
+#if defined(IMGUIX_USE_SFML_BACKEND)
+#include "imgui-sfml.cpp"
+#elif defined(IMGUIX_USE_GLFW_BACKEND)
+#include "imgui-glfw.cpp"
+#elif defined(IMGUIX_USE_SDL2_BACKEND)
+#include "imgui-sdl2.cpp"
+#else
+int main() {}
+#endif

--- a/tests/imgui-glfw.cpp
+++ b/tests/imgui-glfw.cpp
@@ -1,0 +1,2 @@
+#define IMGUIX_USE_GLFW_BACKEND
+#include "imgui-backend.cpp"

--- a/tests/imgui-sdl2.cpp
+++ b/tests/imgui-sdl2.cpp
@@ -1,0 +1,2 @@
+#define IMGUIX_USE_SDL2_BACKEND
+#include "imgui-backend.cpp"


### PR DESCRIPTION
## Summary
- consolidate backend tests through `imgui-backend.cpp`
- provide thin wrappers for GLFW/SDL2
- update CMake to build only `imgui-backend.cpp`
- fix SFML submodule path in wrapper script

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_SFML_BACKEND=ON` *(fails: Could NOT find X11)*
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_GLFW_BACKEND=ON` *(fails: Could NOT find X11)*
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_SDL2_BACKEND=ON` *(fails: Could NOT find X11)*

------
https://chatgpt.com/codex/tasks/task_e_686c7df8d984832ca4a1d6f141362632