### PR TITLE
Add GLFW and SDL2 backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,14 @@ project(ImGuiX LANGUAGES CXX)
 
 option(IMGUIX_BUILD_STATIC_LIB    "Build ImGuiX as a static library" ON)
 option(IMGUIX_USE_SFML_BACKEND   "Use SFML backend for ImGui" ON)
+option(IMGUIX_USE_GLFW_BACKEND   "Use GLFW backend for ImGui" OFF)
+option(IMGUIX_USE_SDL2_BACKEND   "Use SDL2 backend for ImGui" OFF)
 option(IMGUIX_BUILD_EXAMPLES     "Build examples in examples/ directory" ON)
 option(IMGUIX_BUILD_TESTS        "Build tests in tests/ directory" ON)
+
+if(NOT IMGUIX_USE_SFML_BACKEND AND NOT IMGUIX_USE_GLFW_BACKEND AND NOT IMGUIX_USE_SDL2_BACKEND)
+    message(FATAL_ERROR "No ImGui backend selected")
+endif()
 
 # --- Output directories ---
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -29,6 +35,12 @@ if(IMGUIX_BUILD_STATIC_LIB)
     if(IMGUIX_USE_SFML_BACKEND)
         target_link_libraries(imguix PUBLIC imgui sfml-graphics sfml-window sfml-system)
         target_compile_definitions(imguix PUBLIC IMGUIX_USE_SFML)
+    elseif(IMGUIX_USE_GLFW_BACKEND)
+        target_link_libraries(imguix PUBLIC imgui glfw OpenGL::GL)
+        target_compile_definitions(imguix PUBLIC IMGUIX_USE_GLFW)
+    elseif(IMGUIX_USE_SDL2_BACKEND)
+        target_link_libraries(imguix PUBLIC imgui SDL2::SDL2 OpenGLES2::GLESv2)
+        target_compile_definitions(imguix PUBLIC IMGUIX_USE_SDL2 IMGUI_IMPL_OPENGL_ES2)
     endif()
 
     set_target_properties(imguix PROPERTIES OUTPUT_NAME "imguix")
@@ -48,15 +60,17 @@ if(IMGUIX_BUILD_EXAMPLES)
         else()
             target_sources(${EXAMPLE_NAME} PRIVATE ${IMGUIX_HEADERS} ${IMGUIX_SOURCES})
             if(IMGUIX_USE_SFML_BACKEND)
-                target_link_libraries(${TEST_NAME}
-                    PRIVATE
-                        freetype
-                        sfml-graphics-s
-                        sfml-window-s
-                        sfml-system-s
-                        imgui
-                )
+                target_link_libraries(${EXAMPLE_NAME}
+                    PRIVATE freetype sfml-graphics-s sfml-window-s sfml-system-s imgui)
                 target_compile_definitions(${EXAMPLE_NAME} PRIVATE IMGUIX_USE_SFML)
+            elseif(IMGUIX_USE_GLFW_BACKEND)
+                target_link_libraries(${EXAMPLE_NAME}
+                    PRIVATE freetype glfw OpenGL::GL imgui)
+                target_compile_definitions(${EXAMPLE_NAME} PRIVATE IMGUIX_USE_GLFW)
+            elseif(IMGUIX_USE_SDL2_BACKEND)
+                target_link_libraries(${EXAMPLE_NAME}
+                    PRIVATE freetype SDL2::SDL2 OpenGLES2::GLESv2 imgui)
+                target_compile_definitions(${EXAMPLE_NAME} PRIVATE IMGUIX_USE_SDL2 IMGUI_IMPL_OPENGL_ES2)
             endif()
         endif()
 
@@ -75,17 +89,20 @@ if(IMGUIX_BUILD_TESTS)
         set_target_properties(${TEST_NAME} PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests
         )
-        target_compile_definitions(${TEST_NAME} PRIVATE SFML_STATIC)
+        if(IMGUIX_USE_SFML_BACKEND)
+            target_compile_definitions(${TEST_NAME} PRIVATE SFML_STATIC)
+        endif()
 
         target_link_directories(${TEST_NAME} PRIVATE ${CMAKE_BINARY_DIR}/libs)
-        target_link_libraries(${TEST_NAME}
-            PRIVATE
-                freetype
-                sfml-graphics-s
-                sfml-window-s
-                sfml-system-s
-                imgui
-        )
+
+        if(IMGUIX_USE_SFML_BACKEND)
+            target_link_libraries(${TEST_NAME} PRIVATE freetype sfml-graphics-s sfml-window-s sfml-system-s imgui)
+        elseif(IMGUIX_USE_GLFW_BACKEND)
+            target_link_libraries(${TEST_NAME} PRIVATE freetype glfw OpenGL::GL imgui)
+        elseif(IMGUIX_USE_SDL2_BACKEND)
+            target_link_libraries(${TEST_NAME} PRIVATE freetype SDL2::SDL2 OpenGLES2::GLESv2 imgui)
+        endif()
+
         if (WIN32)
             target_link_libraries(${TEST_NAME} PRIVATE opengl32 gdi32 user32 kernel32 winmm)
         elseif(UNIX)
@@ -95,6 +112,8 @@ if(IMGUIX_BUILD_TESTS)
         copy_imgui_fonts(${TEST_NAME})
     endforeach()
 
-    # Also define SFML_STATIC in imgui if it was not set earlier
-    target_compile_definitions(imgui PUBLIC SFML_STATIC)
+    if(IMGUIX_USE_SFML_BACKEND)
+        # Also define SFML_STATIC in imgui if it was not set earlier
+        target_compile_definitions(imgui PUBLIC SFML_STATIC)
+    endif()
 endif()

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -6,8 +6,16 @@
 # Ensure module paths are relative to this folder
 cmake_minimum_required(VERSION 3.18)
 
-# Include the script that prepares imgui and SFML
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/prepare-imgui-sfml-deps.cmake)
+# Choose backend preparation script
+if(IMGUIX_USE_SFML_BACKEND)
+    include(${CMAKE_CURRENT_LIST_DIR}/cmake/prepare-imgui-sfml-deps.cmake)
+elseif(IMGUIX_USE_GLFW_BACKEND)
+    include(${CMAKE_CURRENT_LIST_DIR}/cmake/prepare-imgui-glfw-deps.cmake)
+elseif(IMGUIX_USE_SDL2_BACKEND)
+    include(${CMAKE_CURRENT_LIST_DIR}/cmake/prepare-imgui-sdl2-deps.cmake)
+else()
+    message(FATAL_ERROR "No backend selected for ImGuiX")
+endif()
 #
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/link_local_libs.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/imgui-fonts.cmake)

--- a/libs/cmake/imgui-glfw-wrapper.cmake
+++ b/libs/cmake/imgui-glfw-wrapper.cmake
@@ -1,0 +1,52 @@
+# libs/cmake/imgui-glfw-wrapper.cmake
+
+set(IMGUI_SRC      ${CMAKE_CURRENT_SOURCE_DIR}/imgui)
+set(FREETYPE_SRC   ${CMAKE_CURRENT_SOURCE_DIR}/freetype)
+
+set(IMGUI_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR})
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR}/backends)
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR}/misc/freetype)
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR}/misc/cpp)
+
+file(GLOB IMGUI_HEADERS "${IMGUI_SRC}/*.h")
+foreach(HDR ${IMGUI_HEADERS})
+    configure_file(${HDR} ${IMGUI_INCLUDE_DIR}/ COPYONLY)
+endforeach()
+configure_file(${IMGUI_SRC}/backends/imgui_impl_glfw.h    ${IMGUI_INCLUDE_DIR}/backends/ COPYONLY)
+configure_file(${IMGUI_SRC}/backends/imgui_impl_opengl3.h ${IMGUI_INCLUDE_DIR}/backends/ COPYONLY)
+configure_file(${IMGUI_SRC}/misc/freetype/imgui_freetype.h ${IMGUI_INCLUDE_DIR}/misc/freetype/ COPYONLY)
+configure_file(${IMGUI_SRC}/misc/cpp/imgui_stdlib.h        ${IMGUI_INCLUDE_DIR}/misc/cpp/ COPYONLY)
+
+set(IMGUI_SOURCES
+    ${IMGUI_SRC}/imgui.cpp
+    ${IMGUI_SRC}/imgui_draw.cpp
+    ${IMGUI_SRC}/imgui_widgets.cpp
+    ${IMGUI_SRC}/imgui_tables.cpp
+    ${IMGUI_SRC}/imgui_demo.cpp
+    ${IMGUI_SRC}/misc/freetype/imgui_freetype.cpp
+    ${IMGUI_SRC}/misc/cpp/imgui_stdlib.cpp
+    ${IMGUI_SRC}/backends/imgui_impl_glfw.cpp
+    ${IMGUI_SRC}/backends/imgui_impl_opengl3.cpp
+)
+
+if (NOT TARGET freetype)
+    add_subdirectory(${FREETYPE_SRC} EXCLUDE_FROM_ALL)
+endif()
+
+find_package(glfw3 REQUIRED)
+find_package(OpenGL REQUIRED)
+
+add_library(imgui STATIC ${IMGUI_SOURCES})
+
+target_include_directories(imgui
+    PRIVATE ${FREETYPE_SRC}/include
+            ${IMGUI_SRC}
+            ${IMGUI_SRC}/backends
+)
+
+target_compile_definitions(imgui PRIVATE IMGUI_ENABLE_FREETYPE)
+
+target_link_libraries(imgui PRIVATE glfw OpenGL::GL freetype)
+
+message(STATUS "[ImGuiX] ImGui with GLFW backend built.")

--- a/libs/cmake/imgui-sdl2-gles-wrapper.cmake
+++ b/libs/cmake/imgui-sdl2-gles-wrapper.cmake
@@ -1,0 +1,52 @@
+# libs/cmake/imgui-sdl2-gles-wrapper.cmake
+
+set(IMGUI_SRC      ${CMAKE_CURRENT_SOURCE_DIR}/imgui)
+set(FREETYPE_SRC   ${CMAKE_CURRENT_SOURCE_DIR}/freetype)
+
+set(IMGUI_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR})
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR}/backends)
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR}/misc/freetype)
+file(MAKE_DIRECTORY ${IMGUI_INCLUDE_DIR}/misc/cpp)
+
+file(GLOB IMGUI_HEADERS "${IMGUI_SRC}/*.h")
+foreach(HDR ${IMGUI_HEADERS})
+    configure_file(${HDR} ${IMGUI_INCLUDE_DIR}/ COPYONLY)
+endforeach()
+configure_file(${IMGUI_SRC}/backends/imgui_impl_sdl2.h     ${IMGUI_INCLUDE_DIR}/backends/ COPYONLY)
+configure_file(${IMGUI_SRC}/backends/imgui_impl_opengl3.h  ${IMGUI_INCLUDE_DIR}/backends/ COPYONLY)
+configure_file(${IMGUI_SRC}/misc/freetype/imgui_freetype.h ${IMGUI_INCLUDE_DIR}/misc/freetype/ COPYONLY)
+configure_file(${IMGUI_SRC}/misc/cpp/imgui_stdlib.h        ${IMGUI_INCLUDE_DIR}/misc/cpp/ COPYONLY)
+
+set(IMGUI_SOURCES
+    ${IMGUI_SRC}/imgui.cpp
+    ${IMGUI_SRC}/imgui_draw.cpp
+    ${IMGUI_SRC}/imgui_widgets.cpp
+    ${IMGUI_SRC}/imgui_tables.cpp
+    ${IMGUI_SRC}/imgui_demo.cpp
+    ${IMGUI_SRC}/misc/freetype/imgui_freetype.cpp
+    ${IMGUI_SRC}/misc/cpp/imgui_stdlib.cpp
+    ${IMGUI_SRC}/backends/imgui_impl_sdl2.cpp
+    ${IMGUI_SRC}/backends/imgui_impl_opengl3.cpp
+)
+
+if (NOT TARGET freetype)
+    add_subdirectory(${FREETYPE_SRC} EXCLUDE_FROM_ALL)
+endif()
+
+find_package(SDL2 REQUIRED)
+find_package(OpenGLES2 REQUIRED)
+
+add_library(imgui STATIC ${IMGUI_SOURCES})
+
+target_include_directories(imgui
+    PRIVATE ${FREETYPE_SRC}/include
+            ${IMGUI_SRC}
+            ${IMGUI_SRC}/backends
+)
+
+target_compile_definitions(imgui PRIVATE IMGUI_ENABLE_FREETYPE IMGUI_IMPL_OPENGL_ES2)
+
+target_link_libraries(imgui PRIVATE SDL2::SDL2 OpenGLES2::GLESv2 freetype)
+
+message(STATUS "[ImGuiX] ImGui with SDL2 + GLES2 backend built.")

--- a/libs/cmake/prepare-imgui-glfw-deps.cmake
+++ b/libs/cmake/prepare-imgui-glfw-deps.cmake
@@ -1,0 +1,3 @@
+# libs/cmake/prepare-imgui-glfw-deps.cmake
+include(${CMAKE_CURRENT_LIST_DIR}/imgui-glfw-wrapper.cmake)
+message(STATUS "[ImGuiX] All dependencies prepared (GLFW + OpenGL3).")

--- a/libs/cmake/prepare-imgui-sdl2-deps.cmake
+++ b/libs/cmake/prepare-imgui-sdl2-deps.cmake
@@ -1,0 +1,3 @@
+# libs/cmake/prepare-imgui-sdl2-deps.cmake
+include(${CMAKE_CURRENT_LIST_DIR}/imgui-sdl2-gles-wrapper.cmake)
+message(STATUS "[ImGuiX] All dependencies prepared (SDL2 + OpenGL ES2).")

--- a/tests/imgui-glfw.cpp
+++ b/tests/imgui-glfw.cpp
@@ -1,0 +1,39 @@
+#include "imgui.h"
+#include "backends/imgui_impl_glfw.h"
+#include "backends/imgui_impl_opengl3.h"
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+
+int main()
+{
+    if (!glfwInit())
+        return -1;
+    GLFWwindow* window = glfwCreateWindow(640, 480, "ImGui GLFW", nullptr, nullptr);
+    if (!window)
+        return -1;
+    glfwMakeContextCurrent(window);
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui_ImplGlfw_InitForOpenGL(window, true);
+    ImGui_ImplOpenGL3_Init();
+
+    while (!glfwWindowShouldClose(window))
+    {
+        glfwPollEvents();
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplGlfw_NewFrame();
+        ImGui::NewFrame();
+        ImGui::ShowDemoWindow();
+        ImGui::Render();
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        glfwSwapBuffers(window);
+    }
+
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+    glfwDestroyWindow(window);
+    glfwTerminate();
+}

--- a/tests/imgui-sdl2.cpp
+++ b/tests/imgui-sdl2.cpp
@@ -1,0 +1,48 @@
+#include "imgui.h"
+#include "backends/imgui_impl_sdl2.h"
+#include "backends/imgui_impl_opengl3.h"
+#include <SDL.h>
+#include <SDL_opengles2.h>
+
+int main()
+{
+    if (SDL_Init(SDL_INIT_VIDEO) != 0)
+        return -1;
+    SDL_Window* window = SDL_CreateWindow("ImGui SDL2", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    SDL_GLContext gl_ctx = SDL_GL_CreateContext(window);
+    SDL_GL_MakeCurrent(window, gl_ctx);
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui_ImplSDL2_InitForOpenGL(window, gl_ctx);
+    ImGui_ImplOpenGL3_Init("#version 100");
+
+    bool running = true;
+    while (running)
+    {
+        SDL_Event event;
+        while (SDL_PollEvent(&event))
+        {
+            ImGui_ImplSDL2_ProcessEvent(&event);
+            if (event.type == SDL_QUIT)
+                running = false;
+        }
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplSDL2_NewFrame();
+        ImGui::NewFrame();
+        ImGui::ShowDemoWindow();
+        ImGui::Render();
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        SDL_GL_SwapWindow(window);
+    }
+
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+    ImGui::DestroyContext();
+    SDL_GL_DeleteContext(gl_ctx);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+}


### PR DESCRIPTION
## Summary
- support GLFW and SDL2 backends in main CMake
- choose backend in libs `CMakeLists.txt`
- add wrappers for GLFW and SDL2
- provide example test sources for GLFW and SDL2

## Testing
- `cmake -S . -B build` *(fails: imgui submodules missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c691ec6f4832cb4031738be848690