### PR TITLE
Add GLFW and SDL2 backends

### DIFF
--- a/include/imguix/core/window/GlfwWindowInstance.ipp
+++ b/include/imguix/core/window/GlfwWindowInstance.ipp
@@ -1,0 +1,115 @@
+#ifdef _WIN32
+#   include <windows.h>
+#endif
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
+#include <GLFW/glfw3.h>
+
+namespace ImGuiX {
+
+    bool WindowInstance::create() {
+        if (m_window || m_is_open) return true;
+        if (!glfwInit()) return false;
+        m_window = glfwCreateWindow(width(), height(), name().c_str(), nullptr, nullptr);
+        if (!m_window) return false;
+        glfwMakeContextCurrent(m_window);
+        IMGUI_CHECKVERSION();
+        if (!ImGui::GetCurrentContext())
+            ImGui::CreateContext();
+        ImGui_ImplGlfw_InitForOpenGL(m_window, true);
+        ImGui_ImplOpenGL3_Init();
+        m_is_open = true;
+        return true;
+    }
+
+    bool WindowInstance::create(int w, int h) {
+        m_width = w;
+        m_height = h;
+        return create();
+    }
+
+    void WindowInstance::handleEvents() {
+        if (!m_window) return;
+        glfwPollEvents();
+        if (glfwWindowShouldClose(m_window)) {
+            Events::WindowClosedEvent evt(id(), name());
+            notify(evt);
+            glfwDestroyWindow(m_window);
+            m_window = nullptr;
+            m_is_open = false;
+        }
+    }
+
+    void WindowInstance::tick() {
+        if (!m_window) return;
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplGlfw_NewFrame();
+        ImGui::NewFrame();
+    }
+
+    void WindowInstance::present() {
+        if (!m_window) return;
+        ImGui::Render();
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        glfwSwapBuffers(m_window);
+    }
+
+    void WindowInstance::setSize(int w, int h) {
+        m_width = w;
+        m_height = h;
+        if (m_window) {
+            glfwSetWindowSize(m_window, w, h);
+        }
+    }
+
+    void WindowInstance::restore() {
+        if (m_window) glfwRestoreWindow(m_window);
+    }
+
+    void WindowInstance::minimize() {
+        if (m_window) glfwIconifyWindow(m_window);
+    }
+
+    void WindowInstance::maximize() {
+        if (m_window) glfwMaximizeWindow(m_window);
+    }
+
+    void WindowInstance::close() {
+        m_is_open = false;
+        if (m_window) {
+            Events::WindowClosedEvent evt(id(), name());
+            notify(evt);
+            glfwDestroyWindow(m_window);
+            m_window = nullptr;
+        }
+    }
+
+    bool WindowInstance::setActive(bool active) {
+        if (m_window) {
+            glfwMakeContextCurrent(active ? m_window : nullptr);
+            m_is_active = active;
+        }
+        return m_is_active;
+    }
+
+    bool WindowInstance::isActive() const {
+        if (m_window)
+            return glfwGetWindowAttrib(m_window, GLFW_FOCUSED);
+        return m_is_active;
+    }
+
+    void WindowInstance::setVisible(bool visible) {
+        m_is_visible = visible;
+        if (m_window) {
+            if (visible) glfwShowWindow(m_window);
+            else glfwHideWindow(m_window);
+        }
+    }
+
+    bool WindowInstance::isOpen() const {
+        return m_is_open && m_window && !glfwWindowShouldClose(m_window);
+    }
+
+} // namespace ImGuiX
+

--- a/include/imguix/core/window/Sdl2WindowInstance.ipp
+++ b/include/imguix/core/window/Sdl2WindowInstance.ipp
@@ -1,0 +1,123 @@
+#include <imgui_impl_sdl2.h>
+#include <imgui_impl_opengl3.h>
+#include <SDL.h>
+#include <SDL_opengles2.h>
+
+namespace ImGuiX {
+
+    bool WindowInstance::create() {
+        if (m_window || m_is_open) return true;
+        if (SDL_Init(SDL_INIT_VIDEO) != 0) return false;
+        m_window = SDL_CreateWindow(name().c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                                   width(), height(), SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+        if (!m_window) return false;
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+        m_gl_context = SDL_GL_CreateContext(m_window);
+        SDL_GL_MakeCurrent(m_window, m_gl_context);
+        IMGUI_CHECKVERSION();
+        if (!ImGui::GetCurrentContext())
+            ImGui::CreateContext();
+        ImGui_ImplSDL2_InitForOpenGL(m_window, m_gl_context);
+        ImGui_ImplOpenGL3_Init("#version 100");
+        m_is_open = true;
+        return true;
+    }
+
+    bool WindowInstance::create(int w, int h) {
+        m_width = w;
+        m_height = h;
+        return create();
+    }
+
+    void WindowInstance::handleEvents() {
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            ImGui_ImplSDL2_ProcessEvent(&event);
+            if (event.type == SDL_QUIT) {
+                Events::WindowClosedEvent evt(id(), name());
+                notify(evt);
+                SDL_DestroyWindow(m_window);
+                SDL_GL_DeleteContext(m_gl_context);
+                m_window = nullptr;
+                m_gl_context = nullptr;
+                m_is_open = false;
+            }
+        }
+    }
+
+    void WindowInstance::tick() {
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplSDL2_NewFrame();
+        ImGui::NewFrame();
+    }
+
+    void WindowInstance::present() {
+        ImGui::Render();
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        SDL_GL_SwapWindow(m_window);
+    }
+
+    void WindowInstance::setSize(int w, int h) {
+        m_width = w;
+        m_height = h;
+        if (m_window) SDL_SetWindowSize(m_window, w, h);
+    }
+
+    void WindowInstance::restore() {
+        if (m_window) SDL_RestoreWindow(m_window);
+    }
+
+    void WindowInstance::minimize() {
+        if (m_window) SDL_MinimizeWindow(m_window);
+    }
+
+    void WindowInstance::maximize() {
+        if (m_window) SDL_MaximizeWindow(m_window);
+    }
+
+    void WindowInstance::close() {
+        m_is_open = false;
+        if (m_window) {
+            Events::WindowClosedEvent evt(id(), name());
+            notify(evt);
+            SDL_DestroyWindow(m_window);
+            SDL_GL_DeleteContext(m_gl_context);
+            m_window = nullptr;
+            m_gl_context = nullptr;
+        }
+    }
+
+    bool WindowInstance::setActive(bool active) {
+        if (m_window) {
+            if (active)
+                SDL_GL_MakeCurrent(m_window, m_gl_context);
+            else
+                SDL_GL_MakeCurrent(m_window, nullptr);
+            m_is_active = active;
+        }
+        return m_is_active;
+    }
+
+    bool WindowInstance::isActive() const {
+        if (m_window)
+            return SDL_GetWindowFlags(m_window) & SDL_WINDOW_INPUT_FOCUS;
+        return m_is_active;
+    }
+
+    void WindowInstance::setVisible(bool visible) {
+        m_is_visible = visible;
+        if (m_window) {
+            if (visible) SDL_ShowWindow(m_window);
+            else SDL_HideWindow(m_window);
+        }
+    }
+
+    bool WindowInstance::isOpen() const {
+        return m_is_open && m_window != nullptr;
+    }
+
+} // namespace ImGuiX
+
+

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -10,6 +10,17 @@
 #   include <imgui-SFML.h>
 #   include <SFML/Graphics.hpp>
 #endif
+#ifdef IMGUIX_USE_GLFW_BACKEND
+#   include <imgui_impl_glfw.h>
+#   include <imgui_impl_opengl3.h>
+#   include <GLFW/glfw3.h>
+#endif
+#ifdef IMGUIX_USE_SDL2_BACKEND
+#   include <imgui_impl_sdl2.h>
+#   include <imgui_impl_opengl3.h>
+#   include <SDL.h>
+#   include <SDL_opengles2.h>
+#endif
 
 namespace ImGuiX {
 
@@ -92,6 +103,11 @@ namespace ImGuiX {
     protected:
 #       ifdef IMGUIX_USE_SFML_BACKEND
         sf::RenderWindow m_window;
+#       elif defined(IMGUIX_USE_GLFW_BACKEND)
+        GLFWwindow* m_window = nullptr;
+#       elif defined(IMGUIX_USE_SDL2_BACKEND)
+        SDL_Window* m_window = nullptr;
+        SDL_GLContext m_gl_context = nullptr;
 #       endif
         int m_window_id;
         std::string m_window_name;
@@ -111,6 +127,10 @@ namespace ImGuiX {
 #   include "WindowInstance.ipp"
 #   ifdef IMGUIX_USE_SFML_BACKEND
 #       include "SfmlWindowInstance.ipp"
+#   elif defined(IMGUIX_USE_GLFW_BACKEND)
+#       include "GlfwWindowInstance.ipp"
+#   elif defined(IMGUIX_USE_SDL2_BACKEND)
+#       include "Sdl2WindowInstance.ipp"
 #   endif
 #endif
 

--- a/tests/test-core-application.cpp
+++ b/tests/test-core-application.cpp
@@ -53,7 +53,84 @@ int main() {
     return 0;
 }
 
+#elif defined(IMGUIX_USE_GLFW_BACKEND)
+
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
+#include <GLFW/glfw3.h>
+
+class DemoController : public ImGuiX::Controller {
+public:
+    using Controller::Controller;
+
+    void drawContent() override {}
+
+    void drawUi() override {
+        ImGui::Begin("Hello, world!");
+        ImGui::Button("Look at this pretty button");
+        ImGui::End();
+        ImGui::ShowDemoWindow();
+    }
+};
+
+class DemoWindow : public ImGuiX::WindowInstance {
+public:
+    DemoWindow(int id, ImGuiX::ApplicationControl& app, std::string name)
+        : WindowInstance(id, app, std::move(name)) {}
+
+    void onInit() override {
+        createController<DemoController>();
+        create(800, 600);
+    }
+};
+
+int main() {
+    ImGuiX::Application app;
+    app.createWindow<DemoWindow>("Main Window");
+    app.run();
+    return 0;
+}
+
+#elif defined(IMGUIX_USE_SDL2_BACKEND)
+
+#include <imgui_impl_sdl2.h>
+#include <imgui_impl_opengl3.h>
+#include <SDL.h>
+
+class DemoController : public ImGuiX::Controller {
+public:
+    using Controller::Controller;
+
+    void drawContent() override {}
+
+    void drawUi() override {
+        ImGui::Begin("Hello, world!");
+        ImGui::Button("Look at this pretty button");
+        ImGui::End();
+        ImGui::ShowDemoWindow();
+    }
+};
+
+class DemoWindow : public ImGuiX::WindowInstance {
+public:
+    DemoWindow(int id, ImGuiX::ApplicationControl& app, std::string name)
+        : WindowInstance(id, app, std::move(name)) {}
+
+    void onInit() override {
+        createController<DemoController>();
+        create(800, 600);
+    }
+};
+
+int main() {
+    ImGuiX::Application app;
+    app.createWindow<DemoWindow>("Main Window");
+    app.run();
+    return 0;
+}
+
 #else
+
 
 /// \brief Простой контроллер для теста.
 class DummyController : public ImGuiX::Controller {


### PR DESCRIPTION
## Summary
- add GLFW/Sdl2 implementations for `WindowInstance`
- include new backend ipps in header-only build
- extend `test-core-application` with GLFW and SDL2 examples

## Testing
- `cmake -S . -B build -DIMGUIX_USE_GLFW_BACKEND=ON -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_BUILD_STATIC_LIB=OFF` *(fails: configure_file Problem configuring file)*

------
https://chatgpt.com/codex/tasks/task_e_68705f041a4c832c8f550c85365651c8