### PR TITLE
Implement window removal and initialization queue

### DIFF
--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -69,8 +69,10 @@ namespace ImGuiX {
         WindowManager m_window_manager;
         std::thread m_main_thread;
         std::atomic<bool> m_is_closing{false};
+        std::atomic<int> m_next_window_id{0};
         std::string m_app_name = "ImGuiX Application";
-		std::vector<std::unique_ptr<Model>> m_models;
+        std::vector<std::unique_ptr<Model>> m_models;
+        std::vector<Model*> m_pending_models;
 
         /// \brief Main application loop.
         void mainLoop();
@@ -78,6 +80,9 @@ namespace ImGuiX {
         /// \brief Checks if all windows have been closed.
         /// \return True if no windows remain open.
         bool allWindowsClosed() const;
+
+        /// \brief Initializes all pending models.
+        void initializePendingModels();
     };
 
 } // namespace ImGuiX
@@ -87,3 +92,4 @@ namespace ImGuiX {
 #endif
 
 #endif // _IMGUIX_CORE_APPLICATION_HPP_INCLUDED
+

--- a/include/imguix/core/model/Model.hpp
+++ b/include/imguix/core/model/Model.hpp
@@ -24,10 +24,13 @@ namespace ImGuiX {
         Model(Model&&) = delete;
         Model& operator=(Model&&) = delete;
 
-		virtual ~Model() = default;
+        virtual ~Model() = default;
 
-		/// \brief Called every frame by the application.
-		virtual void process() = 0;
+                /// \brief Optional initialization callback invoked once.
+        virtual void onInit() {}
+
+                /// \brief Called every frame by the application.
+        virtual void process() = 0;
 
 		/// \brief Requests the application to close gracefully.
 		virtual void close() {

--- a/include/imguix/core/window/WindowManager.hpp
+++ b/include/imguix/core/window/WindowManager.hpp
@@ -23,9 +23,15 @@ namespace ImGuiX {
 
         /// \brief Adds a new window to the manager.
         void addWindow(std::unique_ptr<WindowInstance> window);
-        
+
         /// \brief Calls onInit() on all windows (after they are added).
         void initializeAll();
+
+        /// \brief Calls onInit() on newly added windows.
+        void initializePending();
+
+        /// \brief Removes windows that are no longer open.
+        void removeClosed();
 
         /// \brief Closes all managed windows.
         void closeAll();
@@ -55,6 +61,7 @@ namespace ImGuiX {
 
     protected:
         std::vector<std::unique_ptr<WindowInstance>> m_windows;
+        std::vector<WindowInstance*> m_pending_init;
         ApplicationControl& m_application;
 
         /// \brief Shortcut to the application resource registry.
@@ -68,3 +75,4 @@ namespace ImGuiX {
 #endif
 
 #endif // _IMGUIX_CORE_WINDOW_MANAGER_HPP_INCLUDED
+


### PR DESCRIPTION
## Summary
- manage window lifecycle with unique IDs
- queue new models and windows for `onInit`
- clean up closed windows automatically
- fix whitespace and EOF newlines

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=ON -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_BUILD_TESTS=OFF` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68706b3fe740832cbfb73de4dd0b6858