### PR TITLE
Implement remaining window functions

### DIFF
--- a/include/imguix/core/window/GlfwWindowInstance.ipp
+++ b/include/imguix/core/window/GlfwWindowInstance.ipp
@@ -99,6 +99,20 @@ namespace ImGuiX {
         return m_is_active;
     }
 
+    bool WindowInstance::isMaximized() const {
+        if (m_window)
+            return glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED);
+        return false;
+    }
+
+    void WindowInstance::toggleMaximizeRestore() {
+        if (!m_window) return;
+        if (glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED))
+            glfwRestoreWindow(m_window);
+        else
+            glfwMaximizeWindow(m_window);
+    }
+
     void WindowInstance::setVisible(bool visible) {
         m_is_visible = visible;
         if (m_window) {

--- a/include/imguix/core/window/Sdl2WindowInstance.ipp
+++ b/include/imguix/core/window/Sdl2WindowInstance.ipp
@@ -106,6 +106,20 @@ namespace ImGuiX {
         return m_is_active;
     }
 
+    bool WindowInstance::isMaximized() const {
+        if (m_window)
+            return SDL_GetWindowFlags(m_window) & SDL_WINDOW_MAXIMIZED;
+        return false;
+    }
+
+    void WindowInstance::toggleMaximizeRestore() {
+        if (!m_window) return;
+        if (SDL_GetWindowFlags(m_window) & SDL_WINDOW_MAXIMIZED)
+            SDL_RestoreWindow(m_window);
+        else
+            SDL_MaximizeWindow(m_window);
+    }
+
     void WindowInstance::setVisible(bool visible) {
         m_is_visible = visible;
         if (m_window) {


### PR DESCRIPTION
## Summary
- implement `isMaximized` and `toggleMaximizeRestore` for GLFW backend
- implement `isMaximized` and `toggleMaximizeRestore` for SDL2 backend

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_USE_GLFW_BACKEND=ON -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF` *(fails: Problem configuring file)*

------
https://chatgpt.com/codex/tasks/task_e_687447581bf4832c857fb693e812c2bc