### PR TITLE
Implement maximize helpers for GLFW and SDL2

### DIFF
--- a/include/imguix/core/window/GlfwWindowInstance.ipp
+++ b/include/imguix/core/window/GlfwWindowInstance.ipp
@@ -75,6 +75,20 @@ namespace ImGuiX {
         if (m_window) glfwMaximizeWindow(m_window);
     }
 
+    bool WindowInstance::isMaximized() const {
+        if (m_window)
+            return glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED);
+        return false;
+    }
+
+    void WindowInstance::toggleMaximizeRestore() {
+        if (!m_window) return;
+        if (isMaximized())
+            glfwRestoreWindow(m_window);
+        else
+            glfwMaximizeWindow(m_window);
+    }
+
     void WindowInstance::close() {
         m_is_open = false;
         if (m_window) {

--- a/include/imguix/core/window/Sdl2WindowInstance.ipp
+++ b/include/imguix/core/window/Sdl2WindowInstance.ipp
@@ -77,6 +77,20 @@ namespace ImGuiX {
         if (m_window) SDL_MaximizeWindow(m_window);
     }
 
+    bool WindowInstance::isMaximized() const {
+        if (m_window)
+            return SDL_GetWindowFlags(m_window) & SDL_WINDOW_MAXIMIZED;
+        return false;
+    }
+
+    void WindowInstance::toggleMaximizeRestore() {
+        if (!m_window) return;
+        if (isMaximized())
+            SDL_RestoreWindow(m_window);
+        else
+            SDL_MaximizeWindow(m_window);
+    }
+
     void WindowInstance::close() {
         m_is_open = false;
         if (m_window) {


### PR DESCRIPTION
## Summary
- extend `WindowInstance` for Linux and additional backends
- add maximize/restore helpers for GLFW and SDL2 implementations

## Testing
- `cmake -DIMGUIX_USE_GLFW_BACKEND=ON -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_BUILD_EXAMPLES=OFF ..` *(fails: missing third-party sources)*

------
https://chatgpt.com/codex/tasks/task_e_687447581bf4832c857fb693e812c2bc