### PR TITLE
fix(utils): add cross-platform stubs

### DIFF
--- a/include/imguix/core/resource/ResourceRegistry.hpp
+++ b/include/imguix/core/resource/ResourceRegistry.hpp
@@ -10,7 +10,11 @@
 #include <unordered_set>
 #include <memory>
 #include <typeindex>
-#include <shared_mutex>
+#if defined(__EMSCRIPTEN__)
+#   include <mutex>
+#else
+#   include <shared_mutex>
+#endif
 #include <optional>
 #include <functional>
 
@@ -62,8 +66,13 @@ namespace ImGuiX {
         std::unordered_map<std::type_index, std::shared_ptr<void>> m_resources; ///< Stored resources by type.
         std::unordered_set<std::type_index> m_in_progress; ///< Types currently being created.
 
+        #if defined(__EMSCRIPTEN__)
+        mutable std::mutex m_resources_mutex; ///< Protects resource map.
+        mutable std::mutex m_progress_mutex;  ///< Protects initialization set.
+        #else
         mutable std::shared_mutex m_resources_mutex; ///< Protects resource map.
         mutable std::shared_mutex m_progress_mutex;  ///< Protects initialization set.
+        #endif
     };
 
 } // namespace ImGuiX

--- a/include/imguix/utils/encoding_utils.hpp
+++ b/include/imguix/utils/encoding_utils.hpp
@@ -125,6 +125,56 @@ namespace ImGuiX::Utils {
     }
 
 } // namespace ImGuiX::Utils
+#else
+#include <string>
+namespace ImGuiX::Utils {
+    namespace detail {
+        template<typename T>
+        inline constexpr bool dependent_false_v = false;
+    }
+
+    template<typename Dummy = void>
+    std::string Utf8ToAnsi(const std::string&) {
+        static_assert(detail::dependent_false_v<Dummy>, "Utf8ToAnsi is not supported on this platform");
+        return {};
+    }
+
+    template<typename Dummy = void>
+    std::string AnsiToUtf8(const std::string&) {
+        static_assert(detail::dependent_false_v<Dummy>, "AnsiToUtf8 is not supported on this platform");
+        return {};
+    }
+
+    template<typename Dummy = void>
+    std::string Utf8ToCp866(const std::string&) {
+        static_assert(detail::dependent_false_v<Dummy>, "Utf8ToCp866 is not supported on this platform");
+        return {};
+    }
+
+    template<typename Dummy = void>
+    bool IsValidUtf8(const char*) {
+        static_assert(detail::dependent_false_v<Dummy>, "IsValidUtf8 is not supported on this platform");
+        return false;
+    }
+
+    template<typename Dummy = void>
+    std::string Cp1251ToUtf8(const std::string&) {
+        static_assert(detail::dependent_false_v<Dummy>, "Cp1251ToUtf8 is not supported on this platform");
+        return {};
+    }
+
+    template<typename Dummy = void>
+    std::string Utf16ToUtf8(void*) {
+        static_assert(detail::dependent_false_v<Dummy>, "Utf16ToUtf8 is not supported on this platform");
+        return {};
+    }
+
+    template<typename Dummy = void>
+    std::wstring Utf8ToUtf16(const std::string&) {
+        static_assert(detail::dependent_false_v<Dummy>, "Utf8ToUtf16 is not supported on this platform");
+        return {};
+    }
+} // namespace ImGuiX::Utils
 
 #endif // defined(_WIN32) || defined(_WIN64)
 


### PR DESCRIPTION
## Summary
- add macOS support for path resolution
- stub out utils for Emscripten
- adjust ResourceRegistry for Emscripten mutexes
- replace SharedLock alias with conditional lock code

## Testing
- `cmake ..` *(fails: No ImGui backend selected)*

------
https://chatgpt.com/codex/tasks/task_e_687566412a3c832c8134e25c2067954b