### PR TITLE
Add cross-platform Application and Emscripten loop

### DIFF
--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -85,8 +85,24 @@ namespace ImGuiX {
         std::vector<std::unique_ptr<Model>> m_models;  ///< Owned model objects.
         std::vector<Model*> m_pending_models;          ///< Models waiting for initialization.
 
+        int m_ini_save_frame_counter{0};                ///< Frame counter for ini saving.
+        static constexpr int m_ini_save_interval{300};  ///< Frames between ini saves.
+
         /// \brief Main application loop.
         void mainLoop();
+
+        /// \brief Single iteration of the main loop.
+        /// \return false if the loop should terminate.
+        bool loopIteration();
+
+        /// \brief Called before entering the main loop.
+        void startLoop();
+
+        /// \brief Called after exiting the main loop.
+        void endLoop();
+
+        /// \brief Saves ImGui ini settings to disk.
+        void saveIniSettings();
 
         /// \brief Checks if all windows have been closed.
         /// \return True if no windows remain open.


### PR DESCRIPTION
## Summary
- split Application loop into separate methods
- add optional IDBFS support and emscripten main loop
- expose new loop control methods and ini frame counter

## Testing
- `cmake .. -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_SFML_BACKEND=ON` *(fails: imgui and freetype files missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875bff5b764832c87320ff6fb0f034f