### PR TITLE
Add SDL2 emscripten build support

### DIFF
--- a/build-emscripten-sdl2.bat
+++ b/build-emscripten-sdl2.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+cd /d E:\_repoz\emsdk
+if errorlevel 1 exit /b %errorlevel%
+call emsdk_env.bat
+if errorlevel 1 exit /b %errorlevel%
+cd /d E:\_repoz\ImGuiX
+
+set BUILD_DIR=build-emscripten-sdl2
+if not exist %BUILD_DIR% mkdir %BUILD_DIR%
+
+emcc tests/imgui-backend.cpp -DIMGUIX_USE_SDL2_BACKEND ^
+    -Iinclude -Ilibs/imgui -Ilibs/imgui/backends ^
+    -s USE_SDL=2 -s USE_WEBGL2=1 -s WASM=1 ^
+    -o %BUILD_DIR%/imgui-backend.js > %BUILD_DIR%/build_log.txt 2>&1
+if errorlevel 1 (
+    echo Compilation failed with error code %errorlevel%.
+    pause
+    exit /b %errorlevel%
+)
+
+copy /Y emscripten-index.html %BUILD_DIR%\index.html >nul
+
+pause

--- a/emscripten-index.html
+++ b/emscripten-index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>ImGui Backend SDL2</title>
+    <style>
+        body { margin: 0; overflow: hidden; }
+        canvas { width: 100vw; height: 100vh; display: block; }
+    </style>
+</head>
+<body>
+    <canvas id="canvas"></canvas>
+    <script src="imgui-backend.js"></script>
+</body>
+</html>

--- a/run-emscripten-sdl2.bat
+++ b/run-emscripten-sdl2.bat
@@ -1,0 +1,6 @@
+@echo off
+cd /d E:\_repoz\emsdk
+call emsdk_env.bat
+cd /d E:\_repoz\ImGuiX\build-emscripten-sdl2
+emrun index.html
+PAUSE

--- a/tests/imgui-backend.cpp
+++ b/tests/imgui-backend.cpp
@@ -101,45 +101,63 @@ int main() {
 #include <imgui_impl_opengl3.h>
 #include <SDL.h>
 #include <SDL_opengles2.h>
+#ifdef __EMSCRIPTEN__
+#   include <emscripten.h>
+#endif
+
+static SDL_Window* g_window = nullptr;
+static SDL_GLContext g_gl_ctx = nullptr;
+static bool g_running = true;
+
+static void main_loop(void*) {
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+        ImGui_ImplSDL2_ProcessEvent(&event);
+        if (event.type == SDL_QUIT) {
+#ifdef __EMSCRIPTEN__
+            emscripten_cancel_main_loop();
+#endif
+            g_running = false;
+        }
+    }
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplSDL2_NewFrame();
+    ImGui::NewFrame();
+    ImGui::ShowDemoWindow();
+    ImGui::Render();
+    glClear(GL_COLOR_BUFFER_BIT);
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    SDL_GL_SwapWindow(g_window);
+}
 
 int main() {
     if (SDL_Init(SDL_INIT_VIDEO) != 0)
         return -1;
-    SDL_Window* window = SDL_CreateWindow("ImGui SDL2", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    g_window = SDL_CreateWindow("ImGui SDL2", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
-    SDL_GLContext gl_ctx = SDL_GL_CreateContext(window);
-    SDL_GL_MakeCurrent(window, gl_ctx);
+    g_gl_ctx = SDL_GL_CreateContext(g_window);
+    SDL_GL_MakeCurrent(g_window, g_gl_ctx);
 
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
-    ImGui_ImplSDL2_InitForOpenGL(window, gl_ctx);
+    ImGui_ImplSDL2_InitForOpenGL(g_window, g_gl_ctx);
     ImGui_ImplOpenGL3_Init("#version 100");
 
-    bool running = true;
-    while (running) {
-        SDL_Event event;
-        while (SDL_PollEvent(&event))
-        {
-            ImGui_ImplSDL2_ProcessEvent(&event);
-            if (event.type == SDL_QUIT)
-                running = false;
-        }
-        ImGui_ImplOpenGL3_NewFrame();
-        ImGui_ImplSDL2_NewFrame();
-        ImGui::NewFrame();
-        ImGui::ShowDemoWindow();
-        ImGui::Render();
-        glClear(GL_COLOR_BUFFER_BIT);
-        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-        SDL_GL_SwapWindow(window);
+#ifdef __EMSCRIPTEN__
+    emscripten_set_main_loop_arg(main_loop, nullptr, 0, true);
+#else
+    while (g_running) {
+        main_loop(nullptr);
     }
+#endif
 
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplSDL2_Shutdown();
     ImGui::DestroyContext();
-    SDL_GL_DeleteContext(gl_ctx);
-    SDL_DestroyWindow(window);
+    SDL_GL_DeleteContext(g_gl_ctx);
+    SDL_DestroyWindow(g_window);
     SDL_Quit();
 }
 


### PR DESCRIPTION
## Summary
- update SDL2 backend test with emscripten loop
- add build script for emscripten
- add run script and HTML template

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SDL2_BACKEND=ON -DIMGUIX_BUILD_TESTS=OFF` *(fails: SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c4a1cdf0832cae2250fcc0eb33e8