### PR TITLE
docs: improve comments and translations

### DIFF
--- a/build-test-sdl2-ems.bat
+++ b/build-test-sdl2-ems.bat
@@ -1,12 +1,12 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-:: Получаем путь к директории текущего скрипта (предположим, что это и есть папка с ImGuiX)
+:: Get the directory of this script (assumed to be the ImGuiX folder)
 set IMGUIX_PATH=%~dp0
-:: Убираем завершающий слэш, если есть
+:: Remove trailing slash if present
 if "%IMGUIX_PATH:~-1%"=="\" set IMGUIX_PATH=%IMGUIX_PATH:~0,-1%
 
-:: Чтение emsdk и build path из конфигурационного файла
+:: Read emsdk and build path from configuration file
 set EMSDK_CONF_FILE=%~dp0\emsdk-path.txt
 if not exist "%EMSDK_CONF_FILE%" (
     echo emsdk-path.txt not found at %EMSDK_CONF_FILE%
@@ -35,17 +35,17 @@ if "%BUILD_PATH%"=="" (
     exit /b
 )
 
-:: Проверка, начинается ли путь с буквы диска (например, C:) или с "\\"
+:: Check if the path begins with a drive letter (e.g., C:) or with "\\"
 echo Checking BUILD_PATH...
 
-:: Если путь НЕ начинается с "X:\", то это относительный путь
+:: If the path does NOT start with "X:\" it's considered relative
 echo %BUILD_PATH% | findstr /B /R "^[A-Za-z]:\\\|^\\\\">nul
 if errorlevel 1 (
     echo BUILD_PATH is relative, prepending script path...
     set "BUILD_PATH=%~dp0%BUILD_PATH%"
 )
 
-:: Убираем возможный завершающий слэш
+:: Strip possible trailing slash
 if "%BUILD_PATH:~-1%"=="\" set "BUILD_PATH=%BUILD_PATH:~0,-1%"
 
 echo Using EMSDK_PATH: %EMSDK_PATH%
@@ -57,7 +57,7 @@ call emsdk_env.bat
 if errorlevel 1 exit /b %errorlevel%
 cd /d %IMGUIX_PATH%
 
-:: Создание директории сборки
+:: Create build directory
 if not exist "%BUILD_PATH%" mkdir "%BUILD_PATH%"
 
 echo Starting compilation...
@@ -91,7 +91,7 @@ if errorlevel 1 (
     exit /b %errorlevel%
 )
 
-:: Выводим сообщение об успешной сборке
+:: Display success message
 echo Compilation successful! The build is located in %BUILD_PATH%.
 echo You can now run the application in your browser.
 PAUSE

--- a/include/imguix/controllers/StrategicController.hpp
+++ b/include/imguix/controllers/StrategicController.hpp
@@ -56,12 +56,18 @@ namespace ImGuiX::Controllers {
             }
         }
 
-        /// \brief
+        /// \brief Draws content using the active strategy.
+        ///
+        /// Calls \ref drawStrategyContent to forward rendering to the currently
+        /// selected strategy.
         void drawContent() override {
             drawStrategyContent();
         }
 
-        /// \brief
+        /// \brief Draws UI using the active strategy.
+        ///
+        /// Calls \ref drawStrategyUi to display widgets from the selected
+        /// strategy controller.
         void drawUi() override {
             drawStrategyUi();
         }

--- a/include/imguix/core/resource/ResourceRegistry.ipp
+++ b/include/imguix/core/resource/ResourceRegistry.ipp
@@ -15,7 +15,7 @@ namespace ImGuiX {
         
         std::unique_lock progress_lock(m_progress_mutex);
         if (!m_in_progress.insert(type).second) {
-            return false; // уже в процессе
+            return false; // already in progress
         }
         progress_lock.unlock();
         

--- a/include/imguix/core/window/WindowControl.hpp
+++ b/include/imguix/core/window/WindowControl.hpp
@@ -37,14 +37,12 @@ namespace ImGuiX {
         /// \brief Returns current window height in pixels.
         /// \return Height in pixels.
         virtual int height() const = 0;
-		
-		/// \brief Sets the window icon from an image file (currently SFML only).
-		/// \param path Path to the icon image file (must be .png or .bmp, 32x32 or 64x64 recommended).
-		/// \return True if the icon was loaded and applied successfully.
-        /// \brief Sets the window icon from an image file.
-        /// \param path Path to an image file.
-        /// \return True if the icon was applied successfully.
+
+        /// \brief Sets the window icon from an image file (SFML only).
+        /// \param path Path to the icon image file (PNG/BMP, 32x32 or 64x64 recommended).
+        /// \return True if the icon was loaded and applied successfully.
         virtual bool setWindowIcon(const std::string& path) = 0;
+
 
         /// \brief Enables or disables background clearing between frames.
         /// \param disable True to disable clearing.

--- a/include/imguix/windows/SfmlImGuiFramedWindow.ipp
+++ b/include/imguix/windows/SfmlImGuiFramedWindow.ipp
@@ -1,6 +1,6 @@
 #include <windowsx.h>
 #include <commctrl.h>
-#include <Dwmapi.h>     // Для прозрачности окна: https://gist.github.com/Alia5/5d8c48941d1f73c1ef14967a5ffe33d5
+#include <Dwmapi.h>     // For window transparency: https://gist.github.com/Alia5/5d8c48941d1f73c1ef14967a5ffe33d5
 #include <imgui.h>
 #include <imgui-SFML.h>
 #include <SFML/Window/Mouse.hpp>
@@ -126,7 +126,7 @@ namespace ImGuiX::Windows {
 
     void ImGuiFramedWindow::setupWindowEffects(HWND hwnd) {
         if (hasFlag(m_flags, WindowFlags::EnableTransparency)) {
-            // Прозрачность окна: https://gist.github.com/Alia5/5d8c48941d1f73c1ef14967a5ffe33d5
+            // Enable window transparency: https://gist.github.com/Alia5/5d8c48941d1f73c1ef14967a5ffe33d5
             MARGINS margins;
             margins.cxLeftWidth = -1;
             SetWindowLong(hwnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);

--- a/run-test-sdl2-ems.bat
+++ b/run-test-sdl2-ems.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-:: Чтение emsdk и build path из конфигурационного файла
+:: Read emsdk and build path from configuration file
 set EMSDK_CONF_FILE=%~dp0\emsdk-path.txt
 if not exist "%EMSDK_CONF_FILE%" (
     echo emsdk-path.txt not found at %EMSDK_CONF_FILE%
@@ -30,27 +30,27 @@ if "%BUILD_PATH%"=="" (
     exit /b
 )
 
-:: Проверка, начинается ли путь с буквы диска (например, C:) или с "\\"
+:: Check if the path begins with a drive letter (e.g., C:) or with "\\"
 echo Checking BUILD_PATH...
 
-:: Если путь НЕ начинается с "X:\", то это относительный путь
+:: If the path does NOT start with "X:\" it's considered relative
 echo %BUILD_PATH% | findstr /B /R "^[A-Za-z]:\\\|^\\\\">nul
 if errorlevel 1 (
     echo BUILD_PATH is relative, prepending script path...
     set "BUILD_PATH=%~dp0%BUILD_PATH%"
 )
 
-:: Убираем возможный завершающий слэш
+:: Strip possible trailing slash
 if "%BUILD_PATH:~-1%"=="\" set "BUILD_PATH=%BUILD_PATH:~0,-1%"
 
 echo Using EMSDK_PATH: %EMSDK_PATH%
 echo Using BUILD_PATH: %BUILD_PATH%
 
-:: Активация emsdk
+:: Activate emsdk
 cd /d "%EMSDK_PATH%"
 call emsdk_env.bat
 cd /d "%BUILD_PATH%"
 
-:: Запуск emrun
+:: Run emrun
 emrun --verbose --no_browser --port 8081 index.html > emrun_log.txt 2>&1
 PAUSE

--- a/tests/imgui-backend.cpp
+++ b/tests/imgui-backend.cpp
@@ -137,13 +137,13 @@ static void main_loop(void*) {
         if (event.type == SDL_WINDOWEVENT && 
             event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
 			int w, h, dw, dh;
-			SDL_GetWindowSize(g_window, &w, &h); // Физические размеры окна
-			SDL_GL_GetDrawableSize(g_window, &dw, &dh); // Реальные размеры для рендеринга
-			// Получаем DPI экрана
-			float dpi;
-			SDL_GetDisplayDPI(0, &dpi, nullptr, nullptr);  // 0 — индекс дисплея, на котором отображается окно
-			// Масштабирование шрифта с учётом DPI
-			//g_font_scale = static_cast<float>(dh) / static_cast<float>(h) * (dpi / 96.0f);  // 96.0f — стандарт DPI
+                        SDL_GetWindowSize(g_window, &w, &h); // Physical window size
+                        SDL_GL_GetDrawableSize(g_window, &dw, &dh); // Actual size used for rendering
+                        // Obtain screen DPI
+                        float dpi;
+                        SDL_GetDisplayDPI(0, &dpi, nullptr, nullptr);  // 0 is the display index on which the window appears
+                        // Scale font according to DPI
+                        //g_font_scale = static_cast<float>(dh) / static_cast<float>(h) * (dpi / 96.0f);  // 96.0f is the standard DPI
 			g_font_scale = static_cast<float>(dh) / static_cast<float>(h);
 			printf("g_font_scale: %f\n", g_font_scale);
 		}
@@ -183,7 +183,7 @@ int main() {
 
 #   ifdef __EMSCRIPTEN__
     SDL_SetHint(SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR, "#canvas");
-    SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, "0"); // включаем high-DPI
+    SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, "0"); // enable high-DPI support
 	SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
 #   endif
 
@@ -214,10 +214,10 @@ int main() {
         (float)drawable_h / window_h
     );
     
-    // Устанавливаем флаг поддержки vtx offset
+    // Enable vtx offset support flag
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;
 
-    // Настройка шрифта с учётом HiDPI
+    // Font configuration for HiDPI
     float scale = io.DisplayFramebufferScale.y;
     //float font_size = 13.0f * scale * 2.0f;
 	float font_size = 13.0f * 2.0f;
@@ -241,7 +241,7 @@ int main() {
 	style.Colors[ImGuiCol_TabHovered] = style.Colors[ImGuiCol_Tab];
 #   endif
 
-    // Имплементации
+    // Backend implementations
     ImGui_ImplSDL2_InitForOpenGL(g_window, g_gl_ctx);
     ImGui_ImplOpenGL3_Init("#version 100");
 

--- a/tests/test-core-application.cpp
+++ b/tests/test-core-application.cpp
@@ -60,7 +60,7 @@ private:
     std::atomic<bool> m_stop{false};
 };
 
-/// \brief Контроллер, рисующий кнопку в ImGui и круг через SFML.
+/// \brief Controller that draws a button in ImGui and a circle using SFML.
 class DemoController : public ImGuiX::Controller {
 public:
     DemoController(ImGuiX::WindowControl& window, ImGuiX::Application& app)
@@ -109,7 +109,7 @@ private:
     int m_seconds{0};
 };
 
-/// \brief Окно, к которому привязан DemoController.
+/// \brief Window that hosts the DemoController.
 class DemoWindow : public ImGuiX::WindowInstance {
 public:
 
@@ -213,21 +213,21 @@ int main() {
 #else
 
 
-/// \brief Простой контроллер для теста.
+/// \brief Simple controller for testing.
 class DummyController : public ImGuiX::Controller {
 public:
     using Controller::Controller;
 
     void drawContent() override {
-        // Ничего не рисуем
+        // Draw nothing
     }
 
     void drawUi() override {
-        // Ничего не рисуем
+        // Draw nothing
     }
 };
 
-/// \brief Простое окно с тиком и отрисовкой.
+/// \brief Simple window with ticking and rendering.
 class DummyWindow : public ImGuiX::WindowInstance {
 public:
     DummyWindow(int id, std::string name, ImGuiX::ApplicationControl& app)
@@ -236,7 +236,7 @@ public:
 
 int main() {
     ImGuiX::Application app;
-    app.run(false); // запуск синхронно
+    app.run(false); // run synchronously
     return 0;
 }
 

--- a/tests/test-event-system.cpp
+++ b/tests/test-event-system.cpp
@@ -6,7 +6,7 @@
 
 using namespace ImGuiX::Pubsub;
 
-// Пример конкретного события
+// Example of a concrete event
 class MyEvent : public Event {
 public:
     std::string message;
@@ -51,22 +51,22 @@ public:
     }
 };
 
-// Главный тест
+// Main test
 int main() {
     EventBus bus;
     MyListener listener(bus);
 
-    // Подписка на MyEvent
+    // Subscribe to MyEvent
     listener.subscribe<MyEvent>();
 
-    // Подписка на MyEvent через callback
+    // Subscribe to MyEvent via callback
     bool callback_received = false;
     listener.subscribe<MyEvent>([&callback_received](const MyEvent& e) {
         std::cout << "Callback received: " << e.message << "\n";
         callback_received = true;
     });
 
-    // Уведомление напрямую
+    // Direct notification
     MyEvent event("Hello world!");
     listener.notify(event);
 
@@ -76,7 +76,7 @@ int main() {
         return 1;
     }
 
-    // Проверка асинхронной очереди
+    // Test asynchronous queue
     auto async_event = std::make_unique<MyEvent>("From async queue");
     listener.notifyAsync(std::move(async_event));
     bus.process();

--- a/tests/test-resource-registry.cpp
+++ b/tests/test-resource-registry.cpp
@@ -11,14 +11,14 @@ struct DummyResource {
 int main() {
     ResourceRegistry registry;
 
-    // Регистрация ресурса
+    // Register a resource
     bool registered = registry.registerResource<DummyResource>([]() {
         return std::make_unique<DummyResource>(DummyResource{"MyResource"});
     });
 
     std::cout << "Resource registered: " << std::boolalpha << registered << "\n";
 
-    // Попытка получить ресурс
+    // Attempt to retrieve the resource
     auto& res = registry.getResource<DummyResource>();
     std::cout << "Resource retrieved: " << res.name << "\n";
     
@@ -29,7 +29,7 @@ int main() {
         std::cout << "Resource not found!\n";
     }
 
-    // Проверка повторной регистрации
+    // Test duplicate registration
     bool duplicate = registry.registerResource<DummyResource>([] {
         return std::make_unique<DummyResource>(DummyResource{"Duplicate"});
     });


### PR DESCRIPTION
## Summary
- add missing Doxygen comments for strategy controller
- fix duplicate comments in WindowControl
- translate Russian comments in SFML frame window
- translate batch script comments
- translate test comments and update resource registry notes

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=ON -DIMGUIX_BUILD_TESTS=OFF` *(fails: source directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878ce84001c832c948378e9d969b5c6