### PR TITLE
docs: add naming rules and system map diagrams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@
 - [10. Agent Playbooks (Recipes)](#10-agent-playbooks-recipes)
 - [11. Anti-Patterns & Pitfalls](#11-anti-patterns--pitfalls)
 - [12. Code Style: Git Commit Convention](#12-code-style-git-commit-convention)
-- [13. Reference Index](#13-reference-index)
+- [13. Naming & Documentation Conventions](#13-naming--documentation-conventions)
+- [14. Reference Index](#14-reference-index)
 
 ## 1. Mission & Scope
 - Purpose: reference for developers and AI agents working on ImGuiX.
@@ -56,6 +57,24 @@ sequenceDiagram
     Note right of EventBus: queued
     EventBus-->>EventBus: process()
     EventBus->>Controller: notify(Event)
+```
+
+### Module Overview
+```mermaid
+graph LR
+    core[core]
+    windows[windows]
+    controllers[controllers]
+    widgets[widgets]
+    extensions[extensions]
+    utils[utils]
+
+    core --> windows
+    core --> controllers
+    windows --> controllers
+    controllers --> widgets
+    controllers --> extensions
+    controllers --> utils
 ```
 
 ## 3. Architectural Patterns & Invariants
@@ -180,7 +199,33 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) style:
 
 Format: `type(scope): short description` where the scope is optional. Keep messages short and imperative.
 
-## 13. Reference Index
+## 13. Naming & Documentation Conventions
+
+### Variable Naming
+- Prefix `m_` for all class fields (e.g., `m_event_hub`, `m_task_manager`).
+- Optional prefixes `p_` and `str_` when a function or method handles more than five variables or arguments of different types.
+- Boolean variables start with `is`, `has`, `use`, `enable` or `m_is_`, `m_has_`, etc., for fields.
+- Do not use prefixes `b_`, `n_`, or `f_`.
+
+### Doxygen Comments
+- Write all code and Doxygen comments in English.
+- Use `/// \brief` before functions and classes.
+- Avoid starting descriptions with "The".
+
+### File Names
+- Single-class files use `CamelCase` (e.g., `TradeManager.hpp`).
+- Multi-class or utility files use `snake_case` (e.g., `trade_utils.hpp`).
+
+### Entity Names
+- Names of classes, structs, and enums use `CamelCase`.
+- Method names use `snake_case`.
+
+### Method Names
+- Methods are written in `snake_case`.
+- Getter methods may drop the `get_` prefix when returning existing references or values, exposing internal objects, or acting like a property (e.g., `size()`, `empty()`).
+- Keep the `get_` prefix when a method performs computation or when omission could mislead.
+
+## 14. Reference Index
 ### Key Directories
 | Path | Role |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -12,6 +12,45 @@ ImGuiX следует адаптированному под Immediate Mode GUI �
 
 В отличие от классического *MVC*, здесь роли *View* и *Controller* объединены: каждый контроллер отвечает и за логику, и за отрисовку виджетов в одном кадре. Модели взаимодействуют с контроллерами через событийную шину (EventBus), что обеспечивает слабую связанность и гибкую маршрутизацию событий.
 
+### System Map
+
+#### Компоненты
+
+```mermaid
+graph TD
+    A[Application]
+    WM[WindowManager]
+    W[WindowInstance]
+    C[Controller]
+    M[Model]
+    EB[EventBus]
+    RR[ResourceRegistry]
+
+    A-->WM
+    A-->M
+    A-->EB
+    A-->RR
+    WM-->W
+    W-->C
+    C-->EB
+    M-->EB
+    C-->RR
+    M-->RR
+```
+
+#### Поток событий
+
+```mermaid
+sequenceDiagram
+    participant Model
+    participant EventBus
+    participant Controller
+    Model->>EventBus: notifyAsync(Event)
+    Note right of EventBus: queued
+    EventBus-->>EventBus: process()
+    EventBus->>Controller: notify(Event)
+```
+
 ## Особенности
 
 - 💡 Архитектура, вдохновлённая MVC: контроллеры, модель, отображение


### PR DESCRIPTION
## Summary
- document variable prefix rules and boolean naming
- add Doxygen, file naming, and method naming guidelines
- draw system map diagrams for core components, event flow, and module layout, also published in README

## Testing
- `cmake -S . -B build` *(fails: No ImGui backend selected)*
- `cmake -S . -B build -DIMGUIX_USE_GLFW_BACKEND=ON` *(fails: missing backend files and OpenGL library)*

------
https://chatgpt.com/codex/tasks/task_e_689fdc4ba610832cb880000714a59db8