### PR TITLE
docs(core): improve Doxygen comments

### DIFF
--- a/include/imguix/core/events/LangChangeEvent.hpp
+++ b/include/imguix/core/events/LangChangeEvent.hpp
@@ -8,27 +8,31 @@
 namespace ImGuiX::Events {
 
     /// \brief Emitted to request a language change.
-    ///
-    /// Применение должно выполняться «между кадрами».
-    /// Если используется динамический атлас шрифтов — его перезагрузка тоже между кадрами.
+    /// Should be applied between frames.
+    /// When using a dynamic font atlas, reload it between frames as well.
     class LangChangeEvent : public Pubsub::Event {
     public:
-        std::string lang;         ///< Целевой язык: "ru", "en", "uk", "pt-BR", "es", "vi".
-        bool        apply_to_all; ///< true = применить ко всем окнам; false = только к указанному окну.
-        int         window_id;    ///< ID окна, если apply_to_all == false. Иначе игнорируется.
+        std::string lang;         ///< Target language code such as "ru", "en", "uk", "pt-BR", "es", or "vi".
+        bool        apply_to_all; ///< true to apply to all windows; false to apply only to a specific window.
+        int         window_id;    ///< ID of the target window when apply_to_all is false; ignored otherwise.
 
-        /// \brief Конструктор.
+        /// \brief Constructs a language change event.
+        /// \param language Language code to set.
+        /// \param to_all Apply to all windows if true.
+        /// \param target_window_id ID of the target window when to_all is false.
         LangChangeEvent(std::string language, bool to_all = true, int target_window_id = -1)
             : lang(std::move(language))
             , apply_to_all(to_all)
             , window_id(target_window_id) {}
 
-        /// \brief Удобный фабричный метод: ко всем окнам.
+        /// \brief Factory helper that targets all windows.
         static LangChangeEvent ForAll(std::string language) {
             return LangChangeEvent(std::move(language), /*to_all=*/true, /*target_window_id=*/-1);
         }
 
-        /// \brief Удобный фабричный метод: только к одному окну.
+        /// \brief Factory helper that targets a single window.
+        /// \param language Language code to set.
+        /// \param target_window_id ID of the window that should change its language.
         static LangChangeEvent ForWindow(std::string language, int target_window_id) {
             return LangChangeEvent(std::move(language), /*to_all=*/false, target_window_id);
         }

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -148,20 +148,22 @@ namespace ImGuiX {
         sf::RenderWindow& getRenderTarget() override;
 #       endif
 
-        /// \brief Сделать контекст окна (GL/OS + ImGui) текущим.
-        /// Вызывать ТОЛЬКО между кадрами (до ImGui::NewFrame()).
+        /// \brief Makes the window context current for rendering.
+        /// Call only between frames before ImGui::NewFrame().
         virtual void setCurrentWindow();
 
-        /// \brief
+        /// \brief Requests the window to switch its UI language.
+        /// \param lang Language code to apply.
         virtual void requestLanguageChange(const std::string& lang) {};
-        
-        /// \brief
+
+        /// \brief Computes the file path for storing ImGui ini settings.
+        /// \return Absolute path to the ini file.
         std::string iniPath() const;
-        
-        /// \brief
+
+        /// \brief Prepares ImGui to use the window-specific ini file.
         void initIni();
 
-        /// \brief
+        /// \brief Loads ImGui settings from the ini file if not already loaded.
         void loadIni();
 
         /// \brief Saves ImGui ini settings to disk.
@@ -191,9 +193,9 @@ namespace ImGuiX {
 
         ApplicationControl& m_application;  ///< Reference to the owning application.
         std::vector<std::unique_ptr<Controller>> m_controllers; ///< Attached controllers.
-        std::string m_ini_path;             ///< 
+        std::string m_ini_path;             ///< Path to the window-specific ImGui ini file.
         bool m_is_ini_once = false;         ///< Ensures imgui ini is saved only once.
-        bool m_is_ini_loaded = false;       ///< 
+        bool m_is_ini_loaded = false;       ///< Indicates whether ini settings have been loaded.
     };
 
 } // namespace imguix

--- a/include/imguix/core/window/WindowManager.hpp
+++ b/include/imguix/core/window/WindowManager.hpp
@@ -53,16 +53,16 @@ namespace ImGuiX {
         /// \brief Forwards present to all windows.
         void presentAll();
         
-        /// \brief 
+        /// \brief Initializes ImGui ini handling for all windows.
         void initIniAll();
-        
-        /// \brief 
+
+        /// \brief Loads ImGui settings for all windows.
         void loadIniAll();
-        
-        /// \brief 
+
+        /// \brief Saves ImGui settings for all windows immediately.
         void saveIniNowAll();
-        
-        /// \brief 
+
+        /// \brief Periodically saves ImGui settings for all windows.
         void saveIniAll();
         
         /// \brief Returns the number of managed windows.
@@ -73,7 +73,7 @@ namespace ImGuiX {
         /// \return true if no window remains open.
         bool allWindowsClosed() const;
         
-        /// \brief
+        /// \brief Performs backend-specific shutdown tasks.
         void shutdown();
 
     protected:
@@ -81,7 +81,7 @@ namespace ImGuiX {
         std::vector<std::unique_ptr<WindowInstance>> m_pending_add;  ///< Newly created windows waiting to be added.
         std::vector<WindowInstance*> m_pending_init;                 ///< Windows pending initialization.
         ApplicationControl&          m_application;                  ///< Reference to the owning application.
-        std::deque<Events::LangChangeEvent> m_lang_events;           ///< 
+        std::deque<Events::LangChangeEvent> m_lang_events;           ///< Queued language change events.
         int                          m_ini_save_frame_counter{0};    ///< Frame counter for ini saving.
         static constexpr int m_ini_save_interval{300};               ///< Frames between ini saves.
 


### PR DESCRIPTION
## Summary
- document language change event in English
- complete window instance ini helpers
- clarify window manager ini handling and shutdown comments

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_HEADER_ONLY=ON -DIMGUIX_USE_SFML_BACKEND=OFF` *(fails: command hung)*
- `cmake --build build` *(fails: could not load cache)*

------
https://chatgpt.com/codex/tasks/task_e_68a392b12c94832cb68918a2a36d6a5f