### PR TITLE
feat(core): add window frame processing

### DIFF
--- a/include/imguix/core/application/Application.ipp
+++ b/include/imguix/core/application/Application.ipp
@@ -135,13 +135,7 @@ namespace ImGuiX {
         }
         m_event_bus.process();
         
-        m_window_manager.handleEvents();
-        m_window_manager.tickAll();
-        m_window_manager.drawContentAll();
-        m_window_manager.drawUiAll();
-        m_window_manager.presentAll();
-        m_window_manager.loadIniAll();
-        m_window_manager.saveIniAll();
+        m_window_manager.processFrame();
 
         return true;
     }

--- a/include/imguix/core/window/WindowManager.hpp
+++ b/include/imguix/core/window/WindowManager.hpp
@@ -38,6 +38,24 @@ namespace ImGuiX {
         /// \brief Closes all managed windows.
         void closeAll();
 
+        /// \brief Initializes ImGui ini handling for all windows.
+        void initIniAll();
+
+        /// \brief Executes a full frame processing sequence.
+        void processFrame();
+
+        /// \brief Returns the number of managed windows.
+        /// \return Number of windows.
+        std::size_t windowCount() const;
+
+        /// \brief Checks whether all windows have been closed.
+        /// \return true if no window remains open.
+        bool allWindowsClosed() const;
+        
+        /// \brief Performs backend-specific shutdown tasks.
+        void shutdown();
+
+    private:
         /// \brief Forwards handle_events to all windows.
         void handleEvents();
 
@@ -52,9 +70,6 @@ namespace ImGuiX {
 
         /// \brief Forwards present to all windows.
         void presentAll();
-        
-        /// \brief Initializes ImGui ini handling for all windows.
-        void initIniAll();
 
         /// \brief Loads ImGui settings for all windows.
         void loadIniAll();
@@ -64,17 +79,6 @@ namespace ImGuiX {
 
         /// \brief Periodically saves ImGui settings for all windows.
         void saveIniAll();
-        
-        /// \brief Returns the number of managed windows.
-        /// \return Number of windows.
-        std::size_t windowCount() const;
-
-        /// \brief Checks whether all windows have been closed.
-        /// \return true if no window remains open.
-        bool allWindowsClosed() const;
-        
-        /// \brief Performs backend-specific shutdown tasks.
-        void shutdown();
 
     protected:
         std::vector<std::unique_ptr<WindowInstance>> m_windows;      ///< Managed windows.
@@ -88,7 +92,7 @@ namespace ImGuiX {
         /// \brief Shortcut to the application resource registry.
         /// \return Reference to the ResourceRegistry owned by the application.
         ResourceRegistry& registry();
-        
+
         void processLanguageEvents();
         WindowInstance*       findWindowById(int id) noexcept;
         const WindowInstance* findWindowById(int id) const noexcept;

--- a/include/imguix/core/window/WindowManager.ipp
+++ b/include/imguix/core/window/WindowManager.ipp
@@ -126,6 +126,16 @@ namespace ImGuiX {
         }
     }
 
+    void WindowManager::processFrame() {
+        handleEvents();
+        tickAll();
+        drawContentAll();
+        drawUiAll();
+        presentAll();
+        loadIniAll();
+        saveIniAll();
+    }
+
     void WindowManager::removeClosed() {
         m_windows.erase(
             std::remove_if(m_windows.begin(), m_windows.end(),


### PR DESCRIPTION
## Summary
- add WindowManager::processFrame to handle all per-frame steps
- hide frame step methods behind private visibility
- use processFrame in Application::loopIteration

## Testing
- `cmake -S . -B build -DIMGUIX_HEADER_ONLY=ON -DIMGUIX_USE_SFML_BACKEND=OFF` *(fails: Cannot find source file: libs/imgui/imgui.cpp)*
- `g++ -std=c++17 -DIMGUIX_HEADER_ONLY -Iinclude -I/usr/include/imgui /tmp/test.cpp -c`


------
https://chatgpt.com/codex/tasks/task_e_68a3bc34f9b0832cbb56ca88687ab7d6