### PR TITLE
feat(pubsub): add timeout callback

### DIFF
--- a/include/imguix/core/pubsub.hpp
+++ b/include/imguix/core/pubsub.hpp
@@ -25,7 +25,9 @@
 
 #include "pubsub/Event.hpp"
 #include "pubsub/EventListener.hpp"
+#include "pubsub/awaiters.hpp"
 #include "pubsub/EventBus.hpp"
+#include "pubsub/cancellation.hpp"
 #include "pubsub/EventAwaiter.hpp"
 #include "pubsub/EventMediator.hpp"
 

--- a/include/imguix/core/pubsub/EventAwaiter.hpp
+++ b/include/imguix/core/pubsub/EventAwaiter.hpp
@@ -5,13 +5,19 @@
 /// \file EventAwaiter.hpp
 /// \brief RAII helper to wait for a single event that matches a predicate and then auto-unsubscribe.
 
+#include <chrono>
+
+#include "cancellation.hpp"
+#include "awaiters.hpp"
+#include "EventBus.hpp"
+
 namespace ImGuiX::Pubsub {
 
-    /// \brief Minimal awaiter interface for mediator bookkeeping.
-    struct IAwaiter {
-        virtual void cancel() noexcept = 0;
-        virtual bool isActive() const noexcept = 0;
-        virtual ~IAwaiter() = default;
+    struct AwaitOptions {
+        std::chrono::steady_clock::duration timeout{}; ///< 0 => no timeout
+        CancellationToken token{};                     ///< empty => no external cancellation
+        bool single_shot{true};
+        std::function<void()> on_timeout{};            ///< called when timeout expires
     };
 
     /// \class EventAwaiter
@@ -21,7 +27,7 @@ namespace ImGuiX::Pubsub {
     /// until cancelled or, if single-shot, after the first match.
     template <typename EventType>
     class EventAwaiter : public EventListener,
-                         public IAwaiter,
+                         public IAwaiterEx,
                          public std::enable_shared_from_this<EventAwaiter<EventType>> {
         static_assert(std::is_base_of<Event, EventType>::value,
                       "EventType must derive from ImGuiX::Pubsub::Event");
@@ -32,16 +38,16 @@ namespace ImGuiX::Pubsub {
         /// \brief Creates and subscribes a new awaiter.
         /// \param bus Event bus to subscribe on.
         /// \param pred Predicate to filter events. If empty, all events match.
-        /// \param onMatch Callback invoked when a matching event is received.
-        /// \param singleShot Whether the awaiter should automatically cancel after first match.
+        /// \param on_match Callback invoked when a matching event is received.
+        /// \param opt Await options controlling timeout/cancellation and single-shot behavior.
         /// \return Shared pointer keeping the awaiter alive.
         [[nodiscard]] static std::shared_ptr<EventAwaiter> create(
                 EventBus& bus,
                 Predicate predicate,
-                Callback onMatch,
-                bool singleShot = true) {
+                Callback on_match,
+                AwaitOptions opt = {}) {
             auto self = std::shared_ptr<EventAwaiter>(new EventAwaiter(
-                bus, std::move(predicate), std::move(onMatch), singleShot
+                bus, std::move(predicate), std::move(on_match), std::move(opt)
             ));
             self->subscribeInternal();
             return self;
@@ -52,12 +58,7 @@ namespace ImGuiX::Pubsub {
         }
 
         /// \brief Cancels the awaiter (unsubscribe). Idempotent.
-        void cancel() noexcept override {
-            bool expected = false;
-            if (!m_cancelled.compare_exchange_strong(expected, true)) return;
-            m_bus.template unsubscribe<EventType>(this);
-            m_retain_self.reset();
-        }
+        void cancel() noexcept override;
 
         ~EventAwaiter() override { cancel(); }
 
@@ -68,22 +69,23 @@ namespace ImGuiX::Pubsub {
         EventAwaiter(EventBus& bus,
                      Predicate predicate,
                      Callback on_match,
-                     bool single_shot)
+                     AwaitOptions opt)
             : m_bus(bus),
               m_predicate(std::move(predicate)),
               m_on_match(std::move(on_match)),
-              m_single_shot(single_shot) {}
-
-        void subscribeInternal() {
-            if (m_single_shot) m_retain_self = this->shared_from_this(); // keep until first hit
-            auto weakSelf = this->weak_from_this();
-            m_bus.subscribe<EventType>(this, [weakSelf](const EventType& ev){
-                if (auto self = weakSelf.lock()) self->handleEvent(ev);
-            });
+              m_opt(std::move(opt)) {
+            m_on_timeout = std::move(m_opt.on_timeout);
+            if (m_opt.timeout.count() > 0) {
+                m_has_deadline = true;
+                m_deadline = std::chrono::steady_clock::now() + m_opt.timeout;
+            }
         }
+
+        void subscribeInternal();
 
         void handleEvent(const EventType& ev) {
             if (m_cancelled.load(std::memory_order_relaxed)) return;
+            if (m_opt.token && m_opt.token.isCancelled()) { cancel(); return; }
 
             // Stabilize lifetime during callback
             auto hold = this->shared_from_this();
@@ -93,19 +95,53 @@ namespace ImGuiX::Pubsub {
             if (!matched) return;
 
             // For single-shot: unsubscribe BEFORE user callback to avoid reentrancy surprises
-            if (m_single_shot) cancel();
+            if (m_opt.single_shot) cancel();
 
             if (m_on_match) m_on_match(ev);
+        }
+
+        void pollTimeout() noexcept override {
+            if (!isActive()) return;
+            if (m_opt.token && m_opt.token.isCancelled()) {
+                auto hold = this->shared_from_this();
+                cancel();
+                return;
+            }
+            if (m_has_deadline && std::chrono::steady_clock::now() >= m_deadline) {
+                auto hold = this->shared_from_this();
+                cancel();
+                if (m_on_timeout) m_on_timeout();
+            }
         }
 
     private:
         EventBus&  m_bus;
         Predicate  m_predicate;
         Callback   m_on_match;
-        const bool m_single_shot{true};
+        std::function<void()> m_on_timeout; ///< fired when timeout elapses
+        AwaitOptions m_opt{};
+        bool m_has_deadline{false};
+        std::chrono::steady_clock::time_point m_deadline{};
         std::atomic<bool> m_cancelled{false};
         std::shared_ptr<EventAwaiter> m_retain_self; ///< Keeps this object alive until cancellation
     };
+
+    template <typename EventType>
+    inline void EventAwaiter<EventType>::cancel() noexcept {
+        bool expected = false;
+        if (!m_cancelled.compare_exchange_strong(expected, true)) return;
+        m_bus.template unsubscribe<EventType>(this);
+        m_retain_self.reset();
+    }
+
+    template <typename EventType>
+    inline void EventAwaiter<EventType>::subscribeInternal() {
+        if (m_opt.single_shot) m_retain_self = this->shared_from_this(); // keep until first hit
+        auto weak_self = this->weak_from_this();
+        m_bus.subscribe<EventType>(this, [weak_self](const EventType& ev){
+            if (auto self = weak_self.lock()) self->handleEvent(ev);
+        });
+    }
 
 } // namespace ImGuiX::Pubsub
 

--- a/include/imguix/core/pubsub/EventBus.hpp
+++ b/include/imguix/core/pubsub/EventBus.hpp
@@ -5,6 +5,8 @@
 /// \file EventBus.hpp
 /// \brief Contains the EventBus class for event-based communication between modules.
 
+#include "awaiters.hpp"
+
 namespace ImGuiX::Pubsub {
 
     /// \class EventBus
@@ -68,6 +70,9 @@ namespace ImGuiX::Pubsub {
         /// Should be called from the main thread to process events safely.
         void process();
 
+        /// \brief Registers an awaiter for timeout/cancellation polling.
+        void registerAwaiter(const std::shared_ptr<IAwaiterEx>& aw);
+
     private:
         std::unordered_map<std::type_index, callback_list_t> m_event_callbacks; ///< Event type -> callbacks
         std::unordered_map<std::type_index, listener_list_t> m_event_listeners; ///< Event type -> listeners
@@ -75,6 +80,11 @@ namespace ImGuiX::Pubsub {
         mutable std::mutex m_queue_mutex; ///< Mutex for thread-safe queue operations
         mutable std::mutex m_subscriptions_mutex;
         std::queue<std::unique_ptr<Event>> m_event_queue; ///< Queue for asynchronous event processing
+
+        std::vector<std::weak_ptr<IAwaiterEx>> m_awaiters; ///< Awaiters to poll
+        mutable std::mutex m_awaiters_mutex;
+
+        void pollAwaitersInternal();
     };
 
 } // namespace ImGuiX::Pubsub

--- a/include/imguix/core/pubsub/awaiters.hpp
+++ b/include/imguix/core/pubsub/awaiters.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#ifndef _IMGUIX_PUBSUB_AWAITERS_HPP_INCLUDED
+#define _IMGUIX_PUBSUB_AWAITERS_HPP_INCLUDED
+
+/// \file awaiters.hpp
+/// \brief Interfaces for cancelable event awaiters.
+
+namespace ImGuiX::Pubsub {
+
+    /// \brief Minimal awaiter interface for mediator bookkeeping.
+    struct IAwaiter {
+        virtual void cancel() noexcept = 0;
+        virtual bool isActive() const noexcept = 0;
+        virtual ~IAwaiter() = default;
+    };
+
+    /// \brief Extended awaiter interface with timeout polling.
+    struct IAwaiterEx : public IAwaiter {
+        virtual void pollTimeout() noexcept = 0;
+        ~IAwaiterEx() override = default;
+    };
+
+} // namespace ImGuiX::Pubsub
+
+#endif // _IMGUIX_PUBSUB_AWAITERS_HPP_INCLUDED

--- a/include/imguix/core/pubsub/cancellation.hpp
+++ b/include/imguix/core/pubsub/cancellation.hpp
@@ -1,0 +1,54 @@
+#pragma once
+#ifndef _IMGUIX_PUBSUB_CANCELLATION_HPP_INCLUDED
+#define _IMGUIX_PUBSUB_CANCELLATION_HPP_INCLUDED
+
+#include <atomic>
+#include <memory>
+
+/// \file cancellation.hpp
+/// \brief Lightweight cancellation primitives for awaiters.
+
+namespace ImGuiX::Pubsub {
+
+/// \class CancellationToken
+/// \brief Passive handle queried by awaiters for cancellation status.
+class CancellationToken {
+public:
+    /// \brief Checks whether cancellation was requested.
+    bool isCancelled() const noexcept {
+        return m_state && m_state->flag.load(std::memory_order_relaxed);
+    }
+
+    /// \brief Indicates whether this token is valid.
+    explicit operator bool() const noexcept { return static_cast<bool>(m_state); }
+
+private:
+    struct State { std::atomic_bool flag{false}; };
+    std::shared_ptr<State> m_state;
+    friend class CancellationSource;
+};
+
+/// \class CancellationSource
+/// \brief Owner object that can request cancellation on associated tokens.
+class CancellationSource {
+public:
+    /// \brief Creates a new cancellation source with fresh state.
+    CancellationSource() : m_state(std::make_shared<CancellationToken::State>()) {}
+
+    /// \brief Returns a token linked to this source.
+    CancellationToken token() const noexcept {
+        CancellationToken t; t.m_state = m_state; return t;
+    }
+
+    /// \brief Signals cancellation to all linked tokens.
+    void cancel() noexcept {
+        if (m_state) m_state->flag.store(true, std::memory_order_relaxed);
+    }
+
+private:
+    std::shared_ptr<CancellationToken::State> m_state;
+};
+
+} // namespace ImGuiX::Pubsub
+
+#endif // _IMGUIX_PUBSUB_CANCELLATION_HPP_INCLUDED

--- a/tests/test-event-await.cpp
+++ b/tests/test-event-await.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+#include "imguix/core/pubsub.hpp"
+
+using namespace ImGuiX::Pubsub;
+using namespace std::chrono_literals;
+
+struct TestEvent : Event {
+    std::type_index type() const override { return typeid(TestEvent); }
+    const char* name() const override { return "TestEvent"; }
+};
+
+int main() {
+    EventBus bus;
+    EventMediator med(bus);
+
+    // 1. Timeout fires + on_timeout
+    bool called = false; int timeout_calls = 0;
+    auto aw1 = med.awaitEach<TestEvent>([](const TestEvent&){ return true; },
+        [&](const TestEvent&){ called = true; }, 5ms, [&]{ ++timeout_calls; });
+    for (int i = 0; i < 3; ++i) {
+        std::this_thread::sleep_for(2ms);
+        bus.process();
+    }
+    if (called || timeout_calls != 1 || aw1->isActive()) { std::cerr << "Timeout test failed\n"; return 1; }
+
+    // 2. External cancel (no timeout callback)
+    called = false; timeout_calls = 0;
+    CancellationSource src2; AwaitOptions opt2; opt2.token = src2.token();
+    opt2.on_timeout = [&]{ ++timeout_calls; };
+    auto aw2 = med.awaitEach<TestEvent>([](const TestEvent&){ return true; },
+        [&](const TestEvent&){ called = true; }, opt2);
+    src2.cancel();
+    bus.process();
+    if (called || timeout_calls != 0 || aw2->isActive()) { std::cerr << "External cancel failed\n"; return 1; }
+
+    // 3. Race cancel vs event (event queued but cancelled before process)
+    called = false;
+    CancellationSource src3; AwaitOptions opt3; opt3.token = src3.token();
+    auto aw3 = med.awaitEach<TestEvent>([](const TestEvent&){ return true; },
+        [&](const TestEvent&){ called = true; }, opt3);
+    bus.notifyAsync(std::make_unique<TestEvent>());
+    src3.cancel();
+    bus.process();
+    if (called || aw3->isActive()) { std::cerr << "Race cancel vs event failed\n"; return 1; }
+
+    // 4. Backward compatibility
+    called = false;
+    med.awaitOnce<TestEvent>([&](const TestEvent&){ called = true; });
+    bus.notifyAsync(std::make_unique<TestEvent>());
+    bus.process();
+    if (!called) { std::cerr << "Backward compatibility failed\n"; return 1; }
+
+    // 5. Multi awaiters + one token
+    called = false; bool calledB = false;
+    CancellationSource src5; AwaitOptions opt5; opt5.token = src5.token();
+    auto aw5a = med.awaitEach<TestEvent>([](const TestEvent&){ return true; },
+        [&](const TestEvent&){ called = true; }, opt5);
+    auto aw5b = med.awaitEach<TestEvent>([](const TestEvent&){ return true; },
+        [&](const TestEvent&){ calledB = true; }, opt5);
+    src5.cancel();
+    bus.process();
+    if (called || calledB || aw5a->isActive() || aw5b->isActive()) {
+        std::cerr << "Multi awaiters cancel failed\n"; return 1;
+    }
+
+    std::cout << "All tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow awaiters to provide an `on_timeout` callback in `AwaitOptions`
- invoke the callback on deadline expiration after cancelling the awaiter
- extend event-await tests to cover timeout callbacks and external cancellation
- add mediator overloads for millisecond timeouts and inline EventAwaiter implementation

## Testing
- `g++ -std=c++20 -Iinclude -DIMGUIX_HEADER_ONLY tests/test-event-system.cpp -o /tmp/test-event-system && g++ -std=c++20 -Iinclude -DIMGUIX_HEADER_ONLY tests/test-event-await.cpp -o /tmp/test-event-await`
- `/tmp/test-event-system <<<'\n' >/tmp/out1`
- `/tmp/test-event-await >/tmp/out2`
- `cat /tmp/out2`


------
https://chatgpt.com/codex/tasks/task_e_68a3ba1098d8832c9042d2057afe128e