### PR TITLE
refactor(core): encapsulate window lifecycle prep

### DIFF
--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -32,7 +32,7 @@ namespace ImGuiX {
         void run(bool async = false);
 
         /// \brief Creates a new window instance of the specified type.
-        /// \tparam WindowType Type derived from WindowInstance.
+        /// \tparam T Type derived from WindowInstance.
         /// \tparam Args Arguments forwarded to the window constructor.
         /// \return Reference to the created window instance.
         template<typename T, typename... Args>

--- a/include/imguix/core/application/Application.ipp
+++ b/include/imguix/core/application/Application.ipp
@@ -105,17 +105,15 @@ namespace ImGuiX {
         });
 #   endif
 #endif
-        m_window_manager.flushPending();
-        m_window_manager.initializePending();
+        // Ensure initial windows and models are ready before entering loop
+        m_window_manager.prepareFrame();
         initializePendingModels();
     }
 
     bool Application::loopIteration() {
-        m_window_manager.flushPending();
-        m_window_manager.initializePending();
+        // Update window lifecycles before rendering the frame
+        m_window_manager.prepareFrame();
         initializePendingModels();
-
-        m_window_manager.removeClosed();
         if (allWindowsClosed()) {
             m_event_bus.process();
             for (auto& model : m_models) {

--- a/include/imguix/core/window/WindowManager.hpp
+++ b/include/imguix/core/window/WindowManager.hpp
@@ -26,14 +26,11 @@ namespace ImGuiX {
         /// \brief Adds a new window to the manager.
         void addWindow(std::unique_ptr<WindowInstance> window);
 
-        /// \brief Moves pending windows into the active list.
-        void flushPending();
-
-        /// \brief Calls onInit() on newly added windows.
-        void initializePending();
-
-        /// \brief Removes windows that are no longer open.
-        void removeClosed();
+        /// \brief Prepares window state before each frame.
+        ///
+        /// Moves pending windows into the active list, initializes them,
+        /// and removes windows that have been closed since the last frame.
+        void prepareFrame();
 
         /// \brief Closes all managed windows.
         void closeAll();
@@ -79,6 +76,15 @@ namespace ImGuiX {
 
         /// \brief Periodically saves ImGui settings for all windows.
         void saveIniAll();
+
+        /// \brief Moves pending windows into the active list.
+        void flushPending();
+
+        /// \brief Calls onInit() on newly added windows.
+        void initializePending();
+
+        /// \brief Removes windows that are no longer open.
+        void removeClosed();
 
     protected:
         std::vector<std::unique_ptr<WindowInstance>> m_windows;      ///< Managed windows.

--- a/include/imguix/core/window/WindowManager.ipp
+++ b/include/imguix/core/window/WindowManager.ipp
@@ -21,6 +21,13 @@ namespace ImGuiX {
             m_lang_events.push_back(event->asRef<Events::LangChangeEvent>());
         }
     }
+
+    void WindowManager::prepareFrame() {
+        // Handle lifecycle transitions before processing a frame.
+        flushPending();        // move pending windows into the active list
+        initializePending();   // run onInit on newly added windows
+        removeClosed();        // purge windows that have been closed
+    }
     
     void WindowManager::flushPending() {
         for (auto& window : m_pending_add) {
@@ -137,6 +144,7 @@ namespace ImGuiX {
     }
 
     void WindowManager::removeClosed() {
+        // Remove-erase idiom to drop null or closed windows.
         m_windows.erase(
             std::remove_if(m_windows.begin(), m_windows.end(),
                            [](const std::unique_ptr<WindowInstance>& w) {


### PR DESCRIPTION
## Summary
- centralize window lifecycle updates and cleanup inside `WindowManager::prepareFrame`
- revise Doxygen comments for Application and WindowManager APIs
- clarify loop lifecycle comments in `Application`

## Testing
- `cmake -S . -B build` *(fails: SFML component 'System' missing)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68a3f51d9c08832cab067271fa25cce1