### PR TITLE
docs(core): improve Doxygen comments

### DIFF
--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -34,6 +34,7 @@ namespace ImGuiX {
         /// \brief Creates a new window instance of the specified type.
         /// \tparam T Type derived from WindowInstance.
         /// \tparam Args Arguments forwarded to the window constructor.
+        /// \param args Constructor arguments.
         /// \return Reference to the created window instance.
         template<typename T, typename... Args>
         T& createWindow(Args&&... args);
@@ -41,6 +42,7 @@ namespace ImGuiX {
         /// \brief Creates and registers a model.
         /// \tparam T Class derived from Model.
         /// \tparam Args Arguments forwarded to the constructor.
+        /// \param args Constructor arguments.
         /// \return Reference to the created model.
         template<typename T, typename... Args>
         T& createModel(Args&&... args);
@@ -81,7 +83,7 @@ namespace ImGuiX {
         void mainLoop();
 
         /// \brief Single iteration of the main loop.
-        /// \return false if the loop should terminate.
+        /// \return True to continue the main loop.
         bool loopIteration();
 
         /// \brief Called before entering the main loop.

--- a/include/imguix/core/pubsub/EventBus.hpp
+++ b/include/imguix/core/pubsub/EventBus.hpp
@@ -67,10 +67,11 @@ namespace ImGuiX::Pubsub {
         void notifyAsync(std::unique_ptr<Event> event);
 
         /// \brief Processes queued events.
-        /// Should be called from the main thread to process events safely.
+        /// \thread_safety Not thread-safe; call from main thread.
         void process();
 
         /// \brief Registers an awaiter for timeout/cancellation polling.
+        /// \param aw Awaiter to register.
         void registerAwaiter(const std::shared_ptr<IAwaiterEx>& aw);
 
     private:


### PR DESCRIPTION
## Summary
- document variadic constructor args for Application templates
- clarify loop iteration return meaning
- mark EventBus::process as not thread-safe and document registerAwaiter param

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67bb40c70832ca96401b836ea9158