### PR TITLE
refactor(core): convert FontManager helpers to class methods

### DIFF
--- a/include/imguix/core/fonts/FontManager.hpp
+++ b/include/imguix/core/fonts/FontManager.hpp
@@ -1,16 +1,19 @@
 /// \file FontManager.hpp
-/// \brief Centralized font loading with optional JSON config (ImGui 1.92 + FreeType + SFML).
+/// \brief Centralized font loading with optional JSON config (ImGui 1.92 +
+/// FreeType + SFML).
 /// \note Requires ImGui 1.92+, optional ImGui FreeType.
 ///
 /// Usage modes:
-/// 1) Auto-init from JSON (default): set config path (optional), call bootstrap(), then let init happen after onInit().
-/// 2) Manual: disable auto-init, call beginManual()/addFont...()/buildNow().
+/// 1) Auto-init from JSON (default): set config path (optional), call
+/// bootstrap(), then let init happen after onInit(). 2) Manual: disable
+/// auto-init, call beginManual()/addFont...()/buildNow().
 ///
-/// Threading: all methods that touch ImGuiIO::Fonts must be called on the GUI thread between frames.
+/// Threading: all methods that touch ImGuiIO::Fonts must be called on the GUI
+/// thread between frames.
 #ifndef _IMGUIX_FONTS_FONT_MANAGER_HPP_INCLUDED
 #define _IMGUIX_FONTS_FONT_MANAGER_HPP_INCLUDED
 
-#include <imgui.h>          // ImFont, ImWchar, ImGuiIO
+#include <imgui.h> // ImFont, ImWchar, ImGuiIO
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -19,206 +22,242 @@
 
 namespace ImGuiX::Fonts {
 
-	/// \brief Logical roles for fonts that UI code can request.
-	enum class FontRole {
-		Body,       ///< Primary text font
-		H1,         ///< Markdown level-1 header
-		H2,         ///< Markdown level-2 header
-		H3,         ///< Markdown level-3 header
-		Monospace,  ///< Code blocks / fixed-width
-		Bold,       ///< Bold style
-		Italic,     ///< Italic style
-		BoldItalic, ///< Bold + Italic
-		Icons,      ///< Icon set merged into Body (e.g., ForkAwesome)
-		Emoji       ///< Emoji set merged into Body (mono/bitmap, not color)
-	};
+/// \brief Logical roles for fonts that UI code can request.
+enum class FontRole {
+  Body,       ///< Primary text font
+  H1,         ///< Markdown level-1 header
+  H2,         ///< Markdown level-2 header
+  H3,         ///< Markdown level-3 header
+  Monospace,  ///< Code blocks / fixed-width
+  Bold,       ///< Bold style
+  Italic,     ///< Italic style
+  BoldItalic, ///< Bold + Italic
+  Icons,      ///< Icon set merged into Body (e.g., ForkAwesome)
+  Emoji       ///< Emoji set merged into Body (mono/bitmap, not color)
+};
 
-	/// \brief Single font file descriptor.
-	/// \details size_px is defined for 96 DPI; actual size will be scaled by DPI*ui_scale.
-	struct FontFile {
-		std::string path;             ///< Absolute or relative to BuildParams::base_dir
-		float       size_px = 16.0f;  ///< Base size at 96 DPI
-		bool        merge   = false;  ///< Merge glyphs into previous font (icons/emoji)
-		unsigned    freetype_flags = 0; ///< ImGui FreeType builder flags (0 = default)
-		std::string extra_glyphs;    ///< Optional extra glyphs UTF-8 string with extra symbols
-	};
+/// \brief Single font file descriptor.
+/// \details size_px is defined for 96 DPI; actual size will be scaled by
+/// DPI*ui_scale.
+struct FontFile {
+  std::string path;      ///< Absolute or relative to BuildParams::base_dir
+  float size_px = 16.0f; ///< Base size at 96 DPI
+  bool merge = false;    ///< Merge glyphs into previous font (icons/emoji)
+  unsigned freetype_flags = 0; ///< ImGui FreeType builder flags (0 = default)
+  std::string
+      extra_glyphs; ///< Optional extra glyphs UTF-8 string with extra symbols
+};
 
-	/// \brief Per-locale font pack: files grouped by role + final glyph ranges.
-	struct LocalePack {
-		std::string locale;  ///< e.g., "default", "en", "ru", "ja"
-		std::unordered_map<FontRole, std::vector<FontFile>> roles; ///<
-		std::vector<ImWchar> ranges; ///< Final glyph ranges (0-terminated pairs). If empty, manager will build defaults.
-		std::string inherits;	     ///< Optional inheritance tag (resolved by loader), empty if none.
-		std::string ranges_preset;   ///< 
-	};
+/// \brief Per-locale font pack: files grouped by role + final glyph ranges.
+struct LocalePack {
+  std::string locale; ///< e.g., "default", "en", "ru", "ja"
+  std::unordered_map<FontRole, std::vector<FontFile>> roles; ///<
+  std::vector<ImWchar> ranges; ///< Final glyph ranges (0-terminated pairs). If
+                               ///< empty, manager will build defaults.
+  std::string inherits;      ///< Optional inheritance tag (resolved by loader),
+                             ///< empty if none.
+  std::string ranges_preset; ///<
+};
 
-	/// \brief Parameters that affect atlas build and scaling.
-	struct BuildParams {
-		float       dpi       = 96.0f;                   ///< Logical DPI (96 = 1.0 scale)
-		float       ui_scale  = 1.0f;                    ///< Global UI scaling factor
-		std::string base_dir  = "data/resources/fonts";  ///< Base directory for relative paths
-		bool        use_freetype = true;                 ///< Use ImGui FreeType builder if available
-	};
+/// \brief Parameters that affect atlas build and scaling.
+struct BuildParams {
+  float dpi = 96.0f;     ///< Logical DPI (96 = 1.0 scale)
+  float ui_scale = 1.0f; ///< Global UI scaling factor
+  std::string base_dir =
+      "data/resources/fonts"; ///< Base directory for relative paths
+  bool use_freetype = true;   ///< Use ImGui FreeType builder if available
+};
 
-	/// \brief Result summary for a (re)build operation.
-	struct BuildResult {
-		bool success = false;                ///< True if fonts were built and backend texture updated
-		std::unordered_map<FontRole, ImFont*> fonts; ///< Resolved fonts by role (subset may be present)
-		std::string message;                 ///< Diagnostic info on failure
-	};
+/// \brief Result summary for a (re)build operation.
+struct BuildResult {
+  bool success =
+      false; ///< True if fonts were built and backend texture updated
+  std::unordered_map<FontRole, ImFont *>
+      fonts;           ///< Resolved fonts by role (subset may be present)
+  std::string message; ///< Diagnostic info on failure
+};
 
-	/// \brief Central manager for font atlas lifecycle.
-	/// \details Guarantees a single valid atlas per frame. Rebuild happens only between frames.
-	/// FontManager: централизованная загрузка шрифтов (atlas ImGui + FreeType).
-	/// - Header-only режим: определите IMGUIX_FONTS_HEADER_ONLY до подключения этого заголовка,
-	///   и реализация из FontManager.ipp подтянется автоматически.
-	/// - Иначе соберите отдельный TU, подключив FontManager.ipp в .cpp.
-	/// - Если определён IMGUI_ENABLE_FREETYPE — будет использован FreeType builder.
-	/// - Конфиг по умолчанию: data/resources/fonts/fonts.json (можно переопределить).
-	class FontManager {
-	public:
-		
-		/// \brief Set base directory for relative font paths (affects both JSON and manual mode).
-		void setBaseDir(std::string base_dir);
+/// \brief Central manager for font atlas lifecycle.
+/// \details Guarantees a single valid atlas per frame. Rebuild happens only
+/// between frames. FontManager: централизованная загрузка шрифтов (atlas ImGui
+/// + FreeType).
+/// - Header-only режим: определите IMGUIX_FONTS_HEADER_ONLY до подключения
+/// этого заголовка,
+///   и реализация из FontManager.ipp подтянется автоматически.
+/// - Иначе соберите отдельный TU, подключив FontManager.ipp в .cpp.
+/// - Если определён IMGUI_ENABLE_FREETYPE — будет использован FreeType builder.
+/// - Конфиг по умолчанию: data/resources/fonts/fonts.json (можно
+/// переопределить).
+class FontManager {
+public:
+  /// \brief Set base directory for relative font paths (affects both JSON and
+  /// manual mode).
+  void setBaseDir(std::string base_dir);
 
-		/// \brief Set logical DPI (96 = 1.0 scale). Marks atlas dirty.
-		void setDpi(float dpi);
+  /// \brief Set logical DPI (96 = 1.0 scale). Marks atlas dirty.
+  void setDpi(float dpi);
 
-		/// \brief Set global UI scale. Marks atlas dirty.
-		void setUiScale(float ui_scale);
+  /// \brief Set global UI scale. Marks atlas dirty.
+  void setUiScale(float ui_scale);
 
-		/// \brief Initialize manager with build parameters. Does not build immediately.
-		/// \return true if parameters accepted.
-		bool bootstrap(const BuildParams& params);
+  /// \brief Initialize manager with build parameters. Does not build
+  /// immediately.
+  /// \return true if parameters accepted.
+  bool bootstrap(const BuildParams &params);
 
-		/// \brief Enable/disable auto-initialization from JSON after WindowInstance::onInit().
-		/// Default: true (auto).
-		void setAutoInit(bool enabled);
+  /// \brief Enable/disable auto-initialization from JSON after
+  /// WindowInstance::onInit(). Default: true (auto).
+  void setAutoInit(bool enabled);
 
-		/// \brief Query auto-init flag.
-		bool autoInit() const;
+  /// \brief Query auto-init flag.
+  bool autoInit() const;
 
-		/// \brief Set JSON config path. Default: "data/resources/fonts/fonts.json";.
-		void setConfigPath(std::string path);
+  /// \brief Set JSON config path. Default: "data/resources/fonts/fonts.json";.
+  void setConfigPath(std::string path);
 
-		/// \brief Set active locale. May mark atlas dirty if ranges/fonts differ.
-		void setLocale(std::string locale);
+  /// \brief Set active locale. May mark atlas dirty if ranges/fonts differ.
+  void setLocale(std::string locale);
 
-		/// \brief Set Markdown headline sizes (px @ 96 DPI). Body is the base text size.
-		void setMarkdownSizes(float body_px, float h1_px, float h2_px, float h3_px);
+  /// \brief Set Markdown headline sizes (px @ 96 DPI). Body is the base text
+  /// size.
+  void setMarkdownSizes(float body_px, float h1_px, float h2_px, float h3_px);
 
-		/// \brief Provide/override a locale pack programmatically (used without JSON or to extend it).
-		void setLocalePack(const LocalePack& pack);
+  /// \brief Provide/override a locale pack programmatically (used without JSON
+  /// or to extend it).
+  void setLocalePack(const LocalePack &pack);
 
-		/// \brief Drop all registered packs.
-		void clearPacks();
+  /// \brief Drop all registered packs.
+  void clearPacks();
 
-		// ----------------- Manual mode API (JSON-less) -----------------
+  // ----------------- Manual mode API (JSON-less) -----------------
 
-		/// \brief Start manual configuration (clears pending state; does not touch current atlas).
-		void beginManual();
+  /// \brief Start manual configuration (clears pending state; does not touch
+  /// current atlas).
+  void beginManual();
 
-		/// \brief Add Body font (base chain root). Returns false if AddFont* fails at build time.
-		/// \note This only enqueues; actual AddFont happens inside buildNow()/rebuildIfNeeded().
-		void addFontBody(const FontFile& ff);
+  /// \brief Add Body font (base chain root). Returns false if AddFont* fails at
+  /// build time.
+  /// \note This only enqueues; actual AddFont happens inside
+  /// buildNow()/rebuildIfNeeded().
+  void addFontBody(const FontFile &ff);
 
-		/// \brief Add headline font for H1/H2/H3. If path empty, Body TTF is reused at another size.
-		void addFontHeadline(FontRole role_h, const FontFile& ff);
-		
-		/// \brief Add merged font explicitly as Icons or Emoji (MANUAL mode).
-		/// \note Only FontRole::Icons or FontRole::Emoji are allowed; others are ignored.
-		void addFontMerge(FontRole role, const FontFile& ff);
+  /// \brief Add headline font for H1/H2/H3. If path empty, Body TTF is reused
+  /// at another size.
+  void addFontHeadline(FontRole role_h, const FontFile &ff);
 
-		/// \brief Add merged font (icons/emoji) into Body chain.
-		/// \details Manual mode: merges the file into Body. Role marking:
-		/// if role is not specified, both Icons and Emoji are considered available
-		/// and return Body (merged chain).
-		/// \warning Prefer the role-specific overload above.
-		void addFontMerge(const FontFile& ff);
+  /// \brief Add merged font explicitly as Icons or Emoji (MANUAL mode).
+  /// \note Only FontRole::Icons or FontRole::Emoji are allowed; others are
+  /// ignored.
+  void addFontMerge(FontRole role, const FontFile &ff);
 
-		/// \brief Build atlas immediately from the current manual configuration.
-		/// \warning Must be called on the GUI thread between frames.
-		BuildResult buildNow();
+  /// \brief Add merged font (icons/emoji) into Body chain.
+  /// \details Manual mode: merges the file into Body. Role marking:
+  /// if role is not specified, both Icons and Emoji are considered available
+  /// and return Body (merged chain).
+  /// \warning Prefer the role-specific overload above.
+  void addFontMerge(const FontFile &ff);
 
-		// ----------------- Auto mode / maintenance -----------------
+  /// \brief Build atlas immediately from the current manual configuration.
+  /// \warning Must be called on the GUI thread between frames.
+  BuildResult buildNow();
 
-		/// \brief Initialize from JSON or fallback to minimal defaults if JSON not found.
-		/// \warning Must be called on the GUI thread between frames.
-		BuildResult initFromJsonOrDefaults();
+  // ----------------- Auto mode / maintenance -----------------
 
-		/// \brief Mark atlas dirty (DPI/UI scale/locale/config changed).
-		void markDirty();
+  /// \brief Initialize from JSON or fallback to minimal defaults if JSON not
+  /// found.
+  /// \warning Must be called on the GUI thread between frames.
+  BuildResult initFromJsonOrDefaults();
 
-		/// \brief Rebuild atlas if marked dirty.
-		/// \warning Must be called on the GUI thread between frames.
-		BuildResult rebuildIfNeeded();
+  /// \brief Mark atlas dirty (DPI/UI scale/locale/config changed).
+  void markDirty();
 
-		// ----------------- Accessors -----------------
+  /// \brief Rebuild atlas if marked dirty.
+  /// \warning Must be called on the GUI thread between frames.
+  BuildResult rebuildIfNeeded();
 
-		/// \brief Get font by role. Returns nullptr if not available.
-		ImFont* getFont(FontRole role) const;
+  // ----------------- Accessors -----------------
 
-		/// \brief Returns currently active locale id.
-		const std::string& activeLocale() const;
+  /// \brief Get font by role. Returns nullptr if not available.
+  ImFont *getFont(FontRole role) const;
 
-		/// \brief Returns current build parameters.
-		const BuildParams& params() const;
-		
-		FontManager() = default;
-		~FontManager() = default;
+  /// \brief Returns currently active locale id.
+  const std::string &activeLocale() const;
 
-	private:
+  /// \brief Returns current build parameters.
+  const BuildParams &params() const;
 
-		// Internal helpers are defined in .cpp
-		struct PendingManual {
-			bool active = false;
-			FontFile body{};
-			bool     has_body = false;
-			std::unordered_map<FontRole, FontFile> headlines; ///< H1/H2/H3, Bold, Italic, BoldItalic, Monospace
-			std::vector<FontFile> merges_icons;   ///< explicit Icons
-			std::vector<FontFile> merges_emoji;   ///< explicit Emoji
-			std::vector<FontFile> merges_unknown; ///< legacy addFontMerge(ff)
-			std::vector<ImWchar>  ranges; ///< optional manual ranges
-		};
+  FontManager() = default;
+  ~FontManager() = default;
 
-		BuildParams m_params{};
-		bool        m_auto_init = true;
-		bool        m_dirty     = true;
+private:
+  // Internal helpers are defined in .cpp
+  struct PendingManual {
+    bool active = false;
+    FontFile body{};
+    bool has_body = false;
+    std::unordered_map<FontRole, FontFile>
+        headlines; ///< H1/H2/H3, Bold, Italic, BoldItalic, Monospace
+    std::vector<FontFile> merges_icons;   ///< explicit Icons
+    std::vector<FontFile> merges_emoji;   ///< explicit Emoji
+    std::vector<FontFile> merges_unknown; ///< legacy addFontMerge(ff)
+    std::vector<ImWchar> ranges;          ///< optional manual ranges
+  };
 
-		std::string m_config_path = "data/resources/fonts/fonts.json";
-		std::string m_active_locale = "default";
+  BuildParams m_params{};
+  bool m_auto_init = true;
+  bool m_dirty = true;
 
-		// Markdown sizes (px @ 96 DPI)
-		float m_px_body = 16.0f;
-		float m_px_h1   = 24.0f;
-		float m_px_h2   = 20.0f;
-		float m_px_h3   = 18.0f;
+  std::string m_config_path = "data/resources/fonts/fonts.json";
+  std::string m_active_locale = "default";
 
-		// Resolved fonts after last successful build
-		std::unordered_map<FontRole, ImFont*> m_fonts;
+  // Markdown sizes (px @ 96 DPI)
+  float m_px_body = 16.0f;
+  float m_px_h1 = 24.0f;
+  float m_px_h2 = 20.0f;
+  float m_px_h3 = 18.0f;
 
-		// Locale packs provided by JSON or programmatically
-		std::unordered_map<std::string, LocalePack> m_packs;
+  // Resolved fonts after last successful build
+  std::unordered_map<FontRole, ImFont *> m_fonts;
 
-		// Manual configuration buffer
-		PendingManual m_manual{};
-		
-		/// \brief Read all file to string. Returns empty string on error.
-		inline std::string readTextFile(const std::string& path);
-		
-		/// \brief Add UTF-8 extra glyphs to builder.
-		inline void addExtraGlyphs(ImFontGlyphRangesBuilder& b, const std::string& utf8);
-		
-		// Non-copyable
-		FontManager(const FontManager&) = delete;
-		FontManager& operator=(const FontManager&) = delete;
-	};
+  // Locale packs provided by JSON or programmatically
+  std::unordered_map<std::string, LocalePack> m_packs;
+
+  // Manual configuration buffer
+  PendingManual m_manual{};
+
+  // Internal static helpers
+  static float scalePx(float px_96, const BuildParams &p);
+  static void addLocaleRanges(ImFontGlyphRangesBuilder &b, ImGuiIO &io,
+                              const std::string &locale);
+  static void addNamedRanges(ImFontGlyphRangesBuilder &b, ImGuiIO &io,
+                             const std::string &spec);
+  static void buildRangesFromPack(std::vector<ImWchar> &out,
+                                  const LocalePack *pack,
+                                  const std::string &active_locale);
+  static ImFont *addFontFile(const FontFile &ff, const BuildParams &params,
+                             const std::vector<ImWchar> &ranges,
+                             const std::string &base_dir_abs,
+                             const ImFontConfig &base_cfg);
+  static void setupFreetypeIfNeeded(const BuildParams &params);
+  static bool updateBackendTextureSfml();
+
+  /// \brief Read all file to string. Returns empty string on error.
+  static inline std::string readTextFile(const std::string &path);
+
+  /// \brief Add UTF-8 extra glyphs to builder.
+  static inline void addExtraGlyphs(ImFontGlyphRangesBuilder &b,
+                                    const std::string &utf8);
+
+  // Non-copyable
+  FontManager(const FontManager &) = delete;
+  FontManager &operator=(const FontManager &) = delete;
+};
 
 } // namespace ImGuiX::Fonts
 
 // Include implementation if desired
 #ifdef IMGUIX_HEADER_ONLY
-#   include "FontManager.ipp"
+#include "FontManager.ipp"
 #endif
 
 #endif // _IMGUIX_FONTS_FONT_MANAGER_HPP_INCLUDED

--- a/include/imguix/core/fonts/FontManager.ipp
+++ b/include/imguix/core/fonts/FontManager.ipp
@@ -1,668 +1,760 @@
+#include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <sstream>
-#include <algorithm>
 #include <utility>
-#include <cctype>
 
 #ifdef IMGUIX_FONTS_ENABLE_JSON
-#   include <nlohmann/json.hpp>
+#include <nlohmann/json.hpp>
 #endif
 
 #ifdef IMGUI_ENABLE_FREETYPE
-#  include <imgui_freetype.h>
+#include <imgui_freetype.h>
 #endif
 
 namespace ImGuiX::Fonts {
-    namespace fs = std::filesystem;
+namespace fs = std::filesystem;
 
-    /// ----------------------------
-    /// Inline trivial setters/getters
-    /// ----------------------------
-    inline void FontManager::setAutoInit(bool enabled) { m_auto_init = enabled; }
-    inline bool FontManager::autoInit() const { return m_auto_init; }
+/// ----------------------------
+/// Inline trivial setters/getters
+/// ----------------------------
+inline void FontManager::setAutoInit(bool enabled) { m_auto_init = enabled; }
+inline bool FontManager::autoInit() const { return m_auto_init; }
 
-    inline void FontManager::setConfigPath(std::string path) { m_config_path = std::move(path); }
-    inline void FontManager::setBaseDir(std::string base_dir) { m_params.base_dir = std::move(base_dir); markDirty(); }
+inline void FontManager::setConfigPath(std::string path) {
+  m_config_path = std::move(path);
+}
+inline void FontManager::setBaseDir(std::string base_dir) {
+  m_params.base_dir = std::move(base_dir);
+  markDirty();
+}
 
-    inline void FontManager::setLocale(std::string locale) {
-        if (locale == m_active_locale) return;
-        m_active_locale = std::move(locale);
-        markDirty();
+inline void FontManager::setLocale(std::string locale) {
+  if (locale == m_active_locale)
+    return;
+  m_active_locale = std::move(locale);
+  markDirty();
+}
+
+inline void FontManager::setMarkdownSizes(float body_px, float h1_px,
+                                          float h2_px, float h3_px) {
+  m_px_body = body_px;
+  m_px_h1 = h1_px;
+  m_px_h2 = h2_px;
+  m_px_h3 = h3_px;
+  markDirty();
+}
+
+inline void FontManager::setLocalePack(const LocalePack &pack) {
+  m_packs[pack.locale] = pack;
+  // Not marking dirty automatically; active locale may be different.
+}
+
+inline void FontManager::clearPacks() {
+  m_packs.clear();
+  markDirty();
+}
+
+inline void FontManager::beginManual() {
+  m_manual = {};
+  m_manual.active = true;
+  markDirty();
+}
+
+inline void FontManager::addFontBody(const FontFile &ff) {
+  m_manual.has_body = true;
+  m_manual.body = ff;
+}
+
+inline void FontManager::addFontHeadline(FontRole role_h, const FontFile &ff) {
+  m_manual.headlines[role_h] = ff;
+}
+
+inline void FontManager::addFontMerge(FontRole role, const FontFile &ff) {
+  if (!m_manual.active) {
+    m_manual.active = true;
+  } // допускаем вызов без beginManual()
+  if (role == FontRole::Icons) {
+    m_manual.merges_icons.push_back(ff);
+  } else if (role == FontRole::Emoji) {
+    m_manual.merges_emoji.push_back(ff);
+  } else {
+    // игнорируем некорректные роли чтобы не ломать инварианты
+    return;
+  }
+  markDirty();
+}
+
+inline void FontManager::addFontMerge(const FontFile &ff) {
+  if (!m_manual.active) {
+    m_manual.active = true;
+  }
+  m_manual.merges_unknown.push_back(ff);
+  markDirty();
+}
+
+inline void FontManager::markDirty() { m_dirty = true; }
+
+inline ImFont *FontManager::getFont(FontRole role) const {
+  auto it = m_fonts.find(role);
+  return (it != m_fonts.end()) ? it->second : nullptr;
+}
+
+inline const std::string &FontManager::activeLocale() const {
+  return m_active_locale;
+}
+inline const BuildParams &FontManager::params() const { return m_params; }
+
+/// ----------------------------
+/// Heavy helpers (implementation)
+/// ----------------------------
+
+/// \brief Compute effective pixel size (px @ runtime) given base size at 96
+/// DPI.
+inline float FontManager::scalePx(float px_96, const BuildParams &p) {
+  return px_96 * (p.dpi / 96.0f) * p.ui_scale;
+}
+
+/// \brief Add standard ranges based on locale id.
+/// \note Keep conservative defaults to avoid huge atlases.
+inline void FontManager::addLocaleRanges(ImFontGlyphRangesBuilder &b,
+                                         ImGuiIO &io,
+                                         const std::string &locale) {
+  // Always include default UI symbols
+  b.AddRanges(io.Fonts->GetGlyphRangesDefault());
+
+  // Common add-ons: punctuation seen in many UIs
+  b.AddText(u8"–—…•“”‘’"); // en/em dashes, ellipsis, bullets, quotes
+
+  // Latin-based locales already covered by Default()
+  // Add Cyrillic
+  if (locale == "ru" || locale == "uk" || locale == "bg" || locale == "kk" ||
+      locale == "sr")
+    b.AddRanges(io.Fonts->GetGlyphRangesCyrillic());
+
+  // Vietnamese
+  if (locale == "vi")
+    b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
+
+  // CJK (careful: large)
+  if (locale == "ja")
+    b.AddRanges(io.Fonts->GetGlyphRangesJapanese());
+  else if (locale == "zh" || locale == "zh-CN" || locale == "zh-TW")
+    b.AddRanges(io.Fonts->GetGlyphRangesChineseFull());
+  else if (locale == "ko")
+    b.AddRanges(io.Fonts->GetGlyphRangesKorean());
+
+  // RTL (Arabic/Hebrew) – ImGui does not provide built-ins for all subsets;
+  // user usually supplies proper ranges via JSON LocalePack::ranges or custom
+  // font files.
+  if (locale == "ar" || locale == "fa" || locale == "he") {
+    // Leave to JSON-provided ranges; if absent, fallback stays Latin-only.
+    // You may add custom ranges here if you ship appropriate fonts.
+  }
+}
+
+inline void FontManager::addNamedRanges(ImFontGlyphRangesBuilder &b,
+                                        ImGuiIO &io, const std::string &spec) {
+  auto split = [](const std::string &s) {
+    std::vector<std::string> out;
+    std::string cur;
+    for (char c : s) {
+      if (c == '+') {
+        if (!cur.empty())
+          out.push_back(cur), cur.clear();
+      } else
+        cur.push_back(c);
+    }
+    if (!cur.empty())
+      out.push_back(cur);
+    return out;
+  };
+  for (auto tok : split(spec)) {
+    if (tok == "Default")
+      b.AddRanges(io.Fonts->GetGlyphRangesDefault());
+    else if (tok == "Cyrillic")
+      b.AddRanges(io.Fonts->GetGlyphRangesCyrillic());
+    else if (tok == "Vietnamese")
+      b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
+    else if (tok == "Japanese" || tok == "JapaneseFull")
+      b.AddRanges(io.Fonts->GetGlyphRangesJapanese());
+    else if (tok == "Chinese" || tok == "ChineseFull")
+      b.AddRanges(io.Fonts->GetGlyphRangesChineseFull());
+    else if (tok == "Korean")
+      b.AddRanges(io.Fonts->GetGlyphRangesKorean());
+    else if (tok == "Punct")
+      b.AddText(u8"–—…•“”‘’");
+    // Latin, Greek, Thai, etc. — по мере необходимости
+  }
+}
+
+/// \brief Build glyph ranges from LocalePack + extra glyphs from all FontFiles.
+/// \details Combines named presets (ranges_preset), explicit pairs (ranges),
+///          locale-based defaults, and per-file extra_glyphs (UTF-8).
+inline void FontManager::buildRangesFromPack(std::vector<ImWchar> &out,
+                                             const LocalePack *pack,
+                                             const std::string &active_locale) {
+  ImGuiIO &io = ImGui::GetIO();
+  ImFontGlyphRangesBuilder b;
+
+  if (pack) {
+    // 1) Named presets (e.g., "Default+Cyrillic+Vietnamese+Punct")
+    if (!pack->ranges_preset.empty())
+      addNamedRanges(b, io, pack->ranges_preset);
+
+    // 2) Explicit [start,end] pairs (0-terminated). Ensure terminator.
+    if (!pack->ranges.empty()) {
+      if (pack->ranges.back() == 0) {
+        b.AddRanges(pack->ranges.data());
+      } else {
+        std::vector<ImWchar> tmp = pack->ranges;
+        tmp.push_back(0);
+        b.AddRanges(tmp.data());
+      }
     }
 
-    inline void FontManager::setMarkdownSizes(float body_px, float h1_px, float h2_px, float h3_px) {
-        m_px_body = body_px; m_px_h1 = h1_px; m_px_h2 = h2_px; m_px_h3 = h3_px;
-        markDirty();
-    }
+    // 3) If neither presets nor explicit ranges given, fall back to locale
+    // defaults.
+    if (pack->ranges_preset.empty() && pack->ranges.empty())
+      addLocaleRanges(b, io, active_locale);
 
-    inline void FontManager::setLocalePack(const LocalePack& pack) {
-        m_packs[pack.locale] = pack;
-        // Not marking dirty automatically; active locale may be different.
-    }
+    // 4) Common punctuation (harmless to add twice; builder deduplicates).
+    b.AddText(u8"–—…•“”‘’");
 
-    inline void FontManager::clearPacks() {
-        m_packs.clear();
-        markDirty();
-    }
+    // 5) Per-file extra glyphs (UTF-8) — union across all roles/files.
+    for (const auto &kv : pack->roles)
+      for (const auto &ff : kv.second)
+        if (!ff.extra_glyphs.empty())
+          addExtraGlyphs(b, ff.extra_glyphs);
+  } else {
+    // No pack: locale-based defaults + punctuation.
+    addLocaleRanges(b, io, active_locale);
+    b.AddText(u8"–—…•“”‘’");
+  }
 
-    inline void FontManager::beginManual() {
-        m_manual = {};
-        m_manual.active = true;
-        markDirty();
-    }
+  ImVector<ImWchar> built;
+  b.BuildRanges(&built);
+  out.assign(built.begin(), built.end());
+}
 
-    inline void FontManager::addFontBody(const FontFile& ff) {
-        m_manual.has_body = true;
-        m_manual.body = ff;
-    }
+/// \brief Add a font file to ImGui atlas (respecting merge flag, size scaling
+/// and ranges).
+inline ImFont *FontManager::addFontFile(const FontFile &ff,
+                                        const BuildParams &params,
+                                        const std::vector<ImWchar> &ranges,
+                                        const std::string &base_dir_abs,
+                                        const ImFontConfig &base_cfg) {
+  ImFontConfig cfg = base_cfg;
+  cfg.MergeMode = cfg.MergeMode || ff.merge;
 
-    inline void FontManager::addFontHeadline(FontRole role_h, const FontFile& ff) {
-        m_manual.headlines[role_h] = ff;
+#ifdef IMGUI_ENABLE_FREETYPE
+  cfg.FontBuilderFlags = ff.freetype_flags; // ImGuiFreeTypeBuilderFlags
+#endif
+
+  const float px = (ff.size_px > 0.0f ? ff.size_px : 16.0f);
+  const float eff_px = scalePx(px, params);
+
+  fs::path p = fs::u8path(ff.path);
+  fs::path resolved_p = p.is_absolute() ? p : (fs::u8path(base_dir_abs) / p);
+  const std::string resolved = resolved_p.lexically_normal().u8string();
+
+  return ImGui::GetIO().Fonts->AddFontFromFileTTF(
+      resolved.c_str(), eff_px, &cfg, ranges.empty() ? nullptr : ranges.data());
+}
+
+/// \brief Switch FreeType builder for ImGui if requested and available.
+inline void FontManager::setupFreetypeIfNeeded(const BuildParams &params) {
+#ifdef IMGUI_ENABLE_FREETYPE
+  if (!params.use_freetype)
+    return;
+#if IMGUI_VERSION_NUM >= 19200
+  ImGui::GetIO().Fonts->FontLoader = ImGuiFreeType::GetFontLoader();
+  ImGui::GetIO().Fonts->FontLoaderFlags = 0;
+#else
+  ImGui::GetIO().Fonts->FontBuilderIO = ImGuiFreeType::GetBuilderForFreeType();
+  ImGui::GetIO().Fonts->FontBuilderFlags = 0;
+#endif
+#else
+  (void)params;
+#endif
+}
+
+/// \brief After Fonts->Build(), update backend texture for SFML.
+inline bool FontManager::updateBackendTextureSfml() {
+#if defined(IMGUI_SFML_VERSION_MAJOR) || defined(IMGUI_SFML_VERSION)
+  // ImGui-SFML provides UpdateFontTexture(); some versions return void.
+  ImGui::SFML::UpdateFontTexture();
+  return true;
+#else
+  // If not using SFML backend, user should replace this with their backend
+  // call. We still return true to not fail builds on other backends.
+  return true;
+#endif
+}
+
+/// ----------------------------
+/// Public methods implementation
+/// ----------------------------
+
+inline bool FontManager::bootstrap(const BuildParams &params) {
+  m_params = params;
+  m_dirty = true;
+  return true;
+}
+
+inline BuildResult FontManager::buildNow() {
+  BuildResult br{};
+
+  std::string base_dir_abs;
+#ifdef __EMSCRIPTEN__
+  base_dir_abs = m_params.base_dir; // как есть
+#else
+  base_dir_abs = ImGuiX::Utils::resolveExecPath(m_params.base_dir);
+#endif
+
+  // We support either manual buffer (if active) or the active locale pack.
+  ImGuiIO &io = ImGui::GetIO();
+  io.Fonts->Clear();
+  io.FontDefault = nullptr;
+
+  setupFreetypeIfNeeded(m_params);
+
+  // Build ranges
+  std::vector<ImWchar> ranges;
+  const LocalePack *pack_ptr = nullptr;
+
+  if (!m_manual.active) {
+    auto it = m_packs.find(m_active_locale);
+    if (it == m_packs.end()) {
+      // Try default
+      auto it2 = m_packs.find("default");
+      if (it2 != m_packs.end())
+        pack_ptr = &it2->second;
+    } else {
+      pack_ptr = &it->second;
     }
-    
-    inline void FontManager::addFontMerge(FontRole role, const FontFile& ff) {
-        if (!m_manual.active) { m_manual.active = true; } // допускаем вызов без beginManual()
-        if (role == FontRole::Icons) {
-            m_manual.merges_icons.push_back(ff);
-        } else if (role == FontRole::Emoji) {
-            m_manual.merges_emoji.push_back(ff);
+    buildRangesFromPack(ranges, pack_ptr, m_active_locale);
+  } else {
+    // Manual ranges: use default builder with extra glyphs from manual entries
+    ImFontGlyphRangesBuilder b;
+    addLocaleRanges(b, io, m_active_locale);
+    if (m_manual.has_body)
+      addExtraGlyphs(b, m_manual.body.extra_glyphs);
+    for (const auto &kv : m_manual.headlines)
+      addExtraGlyphs(b, kv.second.extra_glyphs);
+    for (const auto &ff : m_manual.merges)
+      addExtraGlyphs(b, ff.extra_glyphs);
+    ImVector<ImWchar> r;
+    b.BuildRanges(&r);
+    ranges.assign(r.begin(), r.end());
+  }
+
+  // Base config for all fonts
+  ImFontConfig cfg{};
+  cfg.OversampleH = 3;
+  cfg.OversampleV = 1;
+  cfg.PixelSnapH = false;
+
+  m_fonts.clear();
+
+  // Add Body first (either from pack or from manual)
+  ImFont *body = nullptr;
+
+  auto add_role_vec = [&](FontRole role,
+                          const std::vector<FontFile> &vec) -> ImFont * {
+    ImFont *last = nullptr;
+    for (size_t i = 0; i < vec.size(); ++i) {
+      ImFontConfig local = cfg;
+      // Merge mode depends on FontFile::merge; Body chain root usually
+      // merge=false.
+      local.MergeMode =
+          (i > 0) ? (local.MergeMode || vec[i].merge) : vec[i].merge;
+      ImFont *f = addFontFile(vec[i], m_params, ranges, base_dir_abs, local);
+      if (!f) {
+        br.message = "Failed to load font: " + vec[i].path;
+      }
+      last = f;
+    }
+    if (last)
+      m_fonts[role] = last;
+    return last;
+  };
+
+  auto add_single = [&](FontRole role, const FontFile &ff) -> ImFont * {
+    ImFont *f = addFontFile(ff, m_params, ranges, base_dir_abs, cfg);
+    if (f)
+      m_fonts[role] = f;
+    else
+      br.message = "Failed to load font: " + ff.path;
+    return f;
+  };
+
+  // Strategy per mode
+  if (!m_manual.active) {
+    // --- PACK MODE ---
+    // Body
+    if (pack_ptr) {
+      if (auto it = pack_ptr->roles.find(FontRole::Body);
+          it != pack_ptr->roles.end() && !it->second.empty()) {
+        body = add_role_vec(FontRole::Body, it->second);
+      }
+      // Merge Icons / Emoji into the last added (Body chain)
+      if (auto it = pack_ptr->roles.find(FontRole::Icons);
+          it != pack_ptr->roles.end()) {
+        for (const auto &ff : it->second) {
+          FontFile mff = ff;
+          mff.merge = true;
+          ImFont *f = addFontFile(mff, m_params, ranges, base_dir_abs, cfg);
+          (void)f; // merged; no separate role pointer necessary
+        }
+        // record role as present (point to Body for retrieval semantics)
+        if (body)
+          m_fonts[FontRole::Icons] = body;
+      }
+      if (auto it = pack_ptr->roles.find(FontRole::Emoji);
+          it != pack_ptr->roles.end()) {
+        for (const auto &ff : it->second) {
+          FontFile mff = ff;
+          mff.merge = true;
+          ImFont *f = addFontFile(mff, m_params, ranges, base_dir_abs, cfg);
+          (void)f;
+        }
+        if (body)
+          m_fonts[FontRole::Emoji] = body;
+      }
+
+      // Headings H1/H2/H3 (separate instances, may reuse Body TTF path with
+      // different size)
+      auto add_headline = [&](FontRole role, float px_default) -> ImFont * {
+        const FontFile *chosen = nullptr;
+        if (auto it = pack_ptr->roles.find(role);
+            it != pack_ptr->roles.end() && !it->second.empty())
+          chosen = &it->second.front();
+        FontFile ff{};
+        if (chosen) {
+          ff = *chosen;
+          if (ff.size_px <= 0.0f)
+            ff.size_px = px_default;
+        } else if (body) {
+          // reuse first Body file path
+          const auto &bodyv = pack_ptr->roles.at(FontRole::Body);
+          ff = bodyv.front();
+          ff.size_px = px_default;
         } else {
-            // игнорируем некорректные роли чтобы не ломать инварианты
-            return;
+          return nullptr;
         }
-        markDirty();
+        return add_single(role, ff);
+      };
+
+      add_headline(FontRole::H1, m_px_h1);
+      add_headline(FontRole::H2, m_px_h2);
+      add_headline(FontRole::H3, m_px_h3);
+
+      // Bold/Italic/BoldItalic/Monospace
+      auto add_optional_role = [&](FontRole role) -> ImFont * {
+        if (auto it = pack_ptr->roles.find(role);
+            it != pack_ptr->roles.end() && !it->second.empty())
+          return add_single(role, it->second.front());
+        return nullptr;
+      };
+      add_optional_role(FontRole::Bold);
+      add_optional_role(FontRole::Italic);
+      add_optional_role(FontRole::BoldItalic);
+      add_optional_role(FontRole::Monospace);
     }
 
-    inline void FontManager::addFontMerge(const FontFile& ff) {
-        if (!m_manual.active) { m_manual.active = true; }
-        m_manual.merges_unknown.push_back(ff);
-        markDirty();
+    // If still no Body, try a minimal fallback (Roboto + Icons) using base_dir
+    if (!body) {
+      FontFile fb{};
+      fb.path = "Roboto-Medium.ttf";
+      fb.size_px = m_px_body;
+      body = add_single(FontRole::Body, fb);
+
+      FontFile ic{};
+      ic.path = "forkawesome-webfont.ttf";
+      ic.size_px = m_px_body;
+      ic.merge = true;
+      addFontFile(ic, m_params, ranges, base_dir_abs, cfg);
+      if (body)
+        m_fonts[FontRole::Icons] = body;
+
+      // Headings reuse Body path with different sizes
+      FontFile h{};
+      h.path = fb.path;
+      h.size_px = m_px_h1;
+      add_single(FontRole::H1, h);
+      h.size_px = m_px_h2;
+      add_single(FontRole::H2, h);
+      h.size_px = m_px_h3;
+      add_single(FontRole::H3, h);
     }
+  } else {
+    // --- MANUAL MODE ---
+    if (m_manual.has_body) {
+      // Body root
+      body = add_single(FontRole::Body, m_manual.body);
 
-    inline void FontManager::markDirty() { m_dirty = true; }
-
-    inline ImFont* FontManager::getFont(FontRole role) const {
-        auto it = m_fonts.find(role);
-        return (it != m_fonts.end()) ? it->second : nullptr;
-    }
-
-    inline const std::string& FontManager::activeLocale() const { return m_active_locale; }
-    inline const BuildParams& FontManager::params() const { return m_params; }
-
-    /// ----------------------------
-    /// Heavy helpers (implementation)
-    /// ----------------------------
-
-    /// \brief Compute effective pixel size (px @ runtime) given base size at 96 DPI.
-    static inline float _scale_px(float px_96, const BuildParams& p) {
-        return px_96 * (p.dpi / 96.0f) * p.ui_scale;
-    }
-
-    /// \brief Add standard ranges based on locale id.
-    /// \note Keep conservative defaults to avoid huge atlases.
-    static inline void _add_locale_ranges(
-            ImFontGlyphRangesBuilder& b, 
-            ImGuiIO& io, 
-            const std::string& locale
-        ) {
-        // Always include default UI symbols
-        b.AddRanges(io.Fonts->GetGlyphRangesDefault());
-
-        // Common add-ons: punctuation seen in many UIs
-        b.AddText(u8"–—…•“”‘’"); // en/em dashes, ellipsis, bullets, quotes
-
-        // Latin-based locales already covered by Default()
-        // Add Cyrillic
-        if (locale == "ru" || locale == "uk" || locale == "bg" || locale == "kk" || locale == "sr")
-            b.AddRanges(io.Fonts->GetGlyphRangesCyrillic());
-
-        // Vietnamese
-        if (locale == "vi")
-            b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
-
-        // CJK (careful: large)
-        if (locale == "ja")
-            b.AddRanges(io.Fonts->GetGlyphRangesJapanese());
-        else if (locale == "zh" || locale == "zh-CN" || locale == "zh-TW")
-            b.AddRanges(io.Fonts->GetGlyphRangesChineseFull());
-        else if (locale == "ko")
-            b.AddRanges(io.Fonts->GetGlyphRangesKorean());
-
-        // RTL (Arabic/Hebrew) – ImGui does not provide built-ins for all subsets;
-        // user usually supplies proper ranges via JSON LocalePack::ranges or custom font files.
-        if (locale == "ar" || locale == "fa" || locale == "he") {
-            // Leave to JSON-provided ranges; if absent, fallback stays Latin-only.
-            // You may add custom ranges here if you ship appropriate fonts.
+      auto do_merge_vec = [&](const std::vector<FontFile> &vec) {
+        for (auto ff : vec) {
+          ff.merge = true;
+          (void)addFontFile(ff, m_params, ranges, base_dir_abs, cfg);
         }
-    }
+      };
 
-    static inline void _add_named_ranges(ImFontGlyphRangesBuilder& b, ImGuiIO& io, const std::string& spec) {
-        auto split = [](const std::string& s){
-            std::vector<std::string> out; std::string cur;
-            for (char c : s) { if (c=='+') { if(!cur.empty()) out.push_back(cur), cur.clear(); } else cur.push_back(c); }
-            if(!cur.empty()) out.push_back(cur);
-            return out;
-        };
-        for (auto tok : split(spec)) {
-            if (tok == "Default")     b.AddRanges(io.Fonts->GetGlyphRangesDefault());
-            else if (tok == "Cyrillic")    b.AddRanges(io.Fonts->GetGlyphRangesCyrillic());
-            else if (tok == "Vietnamese")  b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
-            else if (tok == "Japanese" || tok == "JapaneseFull") b.AddRanges(io.Fonts->GetGlyphRangesJapanese());
-            else if (tok == "Chinese"  || tok == "ChineseFull")  b.AddRanges(io.Fonts->GetGlyphRangesChineseFull());
-            else if (tok == "Korean") b.AddRanges(io.Fonts->GetGlyphRangesKorean());
-            else if (tok == "Punct")  b.AddText(u8"–—…•“”‘’");
-            // Latin, Greek, Thai, etc. — по мере необходимости
+      // Явные роли
+      bool merged_icons = !m_manual.merges_icons.empty();
+      bool merged_emoji = !m_manual.merges_emoji.empty();
+      do_merge_vec(m_manual.merges_icons);
+      do_merge_vec(m_manual.merges_emoji);
+
+      // Legacy: если использовали старый метод — включаем обе роли
+      if (!m_manual.merges_unknown.empty()) {
+        do_merge_vec(m_manual.merges_unknown);
+        merged_icons = true;
+        merged_emoji = true;
+      }
+
+      if (body) {
+        if (merged_icons)
+          m_fonts[FontRole::Icons] = body;
+        if (merged_emoji)
+          m_fonts[FontRole::Emoji] = body;
+      }
+
+      // Headlines
+      auto ensure_headline = [&](FontRole role, float px_default) {
+        auto it = m_manual.headlines.find(role);
+        if (it != m_manual.headlines.end()) {
+          add_single(role, it->second);
+        } else if (body) {
+          // reuse body path as a convenience
+          FontFile ff = m_manual.body;
+          ff.size_px = px_default;
+          add_single(role, ff);
         }
+      };
+      ensure_headline(FontRole::H1, m_px_h1);
+      ensure_headline(FontRole::H2, m_px_h2);
+      ensure_headline(FontRole::H3, m_px_h3);
+    } else {
+      br.message = "Manual mode: Body font not provided";
     }
+  }
 
-    /// \brief Build glyph ranges from LocalePack + extra glyphs from all FontFiles.
-    /// \details Combines named presets (ranges_preset), explicit pairs (ranges),
-    ///          locale-based defaults, and per-file extra_glyphs (UTF-8).
-    static inline void _build_ranges_from_pack(
-            std::vector<ImWchar>& out,
-            const LocalePack* pack,
-            const std::string& active_locale
-        ) {
-        ImGuiIO& io = ImGui::GetIO();
-        ImFontGlyphRangesBuilder b;
+  // Build atlas
+  if (!io.Fonts->Build()) {
+    br.success = false;
+    br.message = "ImFontAtlas::Build() failed";
+    return br;
+  }
 
-        if (pack) {
-            // 1) Named presets (e.g., "Default+Cyrillic+Vietnamese+Punct")
-            if (!pack->ranges_preset.empty())
-                _add_named_ranges(b, io, pack->ranges_preset);
+  // Update backend texture (SFML or stub true)
+  if (!updateBackendTextureSfml()) {
+    br.success = false;
+    br.message = "Backend font texture update failed";
+    return br;
+  }
 
-            // 2) Explicit [start,end] pairs (0-terminated). Ensure terminator.
-            if (!pack->ranges.empty()) {
-                if (pack->ranges.back() == 0) {
-                    b.AddRanges(pack->ranges.data());
-                } else {
-                    std::vector<ImWchar> tmp = pack->ranges;
-                    tmp.push_back(0);
-                    b.AddRanges(tmp.data());
-                }
+  // Default font
+  if (ImFont *f = getFont(FontRole::Body))
+    io.FontDefault = f;
+
+  // Done
+  br.success = true;
+  br.fonts = m_fonts;
+  m_dirty = false;
+  return br;
+}
+
+inline BuildResult FontManager::rebuildIfNeeded() {
+  if (!m_dirty) {
+    BuildResult ok{};
+    ok.success = true;
+    ok.fonts = m_fonts;
+    return ok;
+  }
+  return buildNow();
+}
+
+inline BuildResult FontManager::initFromJsonOrDefaults() {
+  using nlohmann::json;
+#ifdef IMGUIX_FONTS_ENABLE_JSON
+  BuildResult br{};
+
+  // Load JSON text (if exists)
+  std::string cfg_path;
+#ifdef __EMSCRIPTEN__
+  cfg_path = m_config_path; // как есть
+#else
+  cfg_path = ImGuiX::Utils::resolveExecPath(m_config_path);
+  // Fallback: если пусто или не найден — попробуем base_dir/fonts.json
+  if (readTextFile(cfg_path).empty()) {
+    const auto base_abs = ImGuiX::Utils::resolveExecPath(m_params.base_dir);
+    cfg_path = ImGuiX::Utils::joinPaths(base_abs, "fonts.json");
+  }
+#endif
+
+  const std::string json_text = readTextFile(cfg_path);
+
+  if (!json_text.empty()) {
+    json j;
+    try {
+      j = json::parse(json_text);
+
+      // base_dir (optional)
+      if (j.contains("base_dir") && j["base_dir"].is_string())
+        m_params.base_dir = j["base_dir"].get<std::string>();
+
+      // markdown_sizes (optional)
+      if (j.contains("markdown_sizes") && j["markdown_sizes"].is_object()) {
+        const auto &ms = j["markdown_sizes"];
+        if (ms.contains("body"))
+          m_px_body = ms["body"].get<float>();
+        if (ms.contains("h1"))
+          m_px_h1 = ms["h1"].get<float>();
+        if (ms.contains("h2"))
+          m_px_h2 = ms["h2"].get<float>();
+        if (ms.contains("h3"))
+          m_px_h3 = ms["h3"].get<float>();
+      }
+
+      // locales (packs)
+      if (j.contains("locales") && j["locales"].is_object()) {
+        for (auto it = j["locales"].begin(); it != j["locales"].end(); ++it) {
+          const std::string loc = it.key();
+          const json &L = it.value();
+
+          LocalePack pack{};
+          pack.locale = loc;
+
+          if (L.contains("inherits") && L["inherits"].is_string())
+            pack.inherits = L["inherits"].get<std::string>();
+
+          // ranges: массив пар ИЛИ строка-пресет (например
+          // "Default+Cyrillic+Punct")
+          if (L.contains("ranges")) {
+            if (L["ranges"].is_array()) {
+              for (const auto &v : L["ranges"])
+                pack.ranges.push_back(static_cast<ImWchar>(v.get<int>()));
+              // 0-терминатор добьём позже внутри buildRangesFromPack()
+            } else if (L["ranges"].is_string()) {
+              pack.ranges_preset =
+                  L["ranges"].get<std::string>(); // <-- ВАЖНО: сохраняем
             }
+          }
 
-            // 3) If neither presets nor explicit ranges given, fall back to locale defaults.
-            if (pack->ranges_preset.empty() && pack->ranges.empty())
-                _add_locale_ranges(b, io, active_locale);
+          // roles...
+          if (L.contains("roles") && L["roles"].is_object()) {
+            const auto &R = L["roles"];
+            auto parse_files = [&](const char *key, FontRole role) {
+              if (R.contains(key) && R[key].is_array()) {
+                for (const auto &item : R[key]) {
+                  FontFile ff{};
+                  if (item.contains("path"))
+                    ff.path = item["path"].get<std::string>();
+                  if (item.contains("size_px"))
+                    ff.size_px = item["size_px"].get<float>();
+                  if (item.contains("merge"))
+                    ff.merge = item["merge"].get<bool>();
+                  if (item.contains("freetype_flags"))
+                    ff.freetype_flags = item["freetype_flags"].get<unsigned>();
+                  if (item.contains("extra_glyphs"))
+                    ff.extra_glyphs = item["extra_glyphs"].get<std::string>();
+                  pack.roles[role].push_back(std::move(ff));
+                }
+              }
+            };
+            parse_files("Body", FontRole::Body);
+            parse_files("H1", FontRole::H1);
+            parse_files("H2", FontRole::H2);
+            parse_files("H3", FontRole::H3);
+            parse_files("Monospace", FontRole::Monospace);
+            parse_files("Bold", FontRole::Bold);
+            parse_files("Italic", FontRole::Italic);
+            parse_files("BoldItalic", FontRole::BoldItalic);
+            parse_files("Icons", FontRole::Icons);
+            parse_files("Emoji", FontRole::Emoji);
+          }
 
-            // 4) Common punctuation (harmless to add twice; builder deduplicates).
-            b.AddText(u8"–—…•“”‘’");
-
-            // 5) Per-file extra glyphs (UTF-8) — union across all roles/files.
-            for (const auto& kv : pack->roles)
-                for (const auto& ff : kv.second)
-                    if (!ff.extra_glyphs.empty())
-                        addExtraGlyphs(b, ff.extra_glyphs);
-        } else {
-            // No pack: locale-based defaults + punctuation.
-            _add_locale_ranges(b, io, active_locale);
-            b.AddText(u8"–—…•“”‘’");
+          m_packs[pack.locale] = std::move(pack);
         }
 
-        ImVector<ImWchar> built;
-        b.BuildRanges(&built);
-        out.assign(built.begin(), built.end());
-    }
+        // Второй проход: разворачиваем наследование после того, как ВСЕ пакеты
+        // прочитаны.
+        {
+          bool changed = true;
+          int guard = 0;
+          while (changed && guard++ < 16) {
+            changed = false;
+            for (auto &kv : m_packs) {
+              auto &child = kv.second;
+              if (child.inherits.empty())
+                continue;
+              auto pit = m_packs.find(child.inherits);
+              if (pit == m_packs.end())
+                continue;
+              const auto &parent = pit->second;
 
-
-    /// \brief Add a font file to ImGui atlas (respecting merge flag, size scaling and ranges).
-    static inline ImFont* _add_font_file(
-            const FontFile& ff,
-            const BuildParams& params,
-            const std::vector<ImWchar>& ranges,
-            const std::string& base_dir_abs,
-            const ImFontConfig& base_cfg
-        ) {
-        ImFontConfig cfg = base_cfg;
-        cfg.MergeMode = cfg.MergeMode || ff.merge;
-        
-#       ifdef IMGUI_ENABLE_FREETYPE
-        cfg.FontBuilderFlags = ff.freetype_flags; // ImGuiFreeTypeBuilderFlags
-#       endif
-
-        const float px = (ff.size_px > 0.0f ? ff.size_px : 16.0f);
-        const float eff_px = _scale_px(px, params);
-
-        fs::path p = fs::u8path(ff.path);
-        fs::path resolved_p = p.is_absolute() ? p : (fs::u8path(base_dir_abs) / p);
-        const std::string resolved = resolved_p.lexically_normal().u8string();
-
-        return ImGui::GetIO().Fonts->AddFontFromFileTTF(
-            resolved.c_str(), eff_px, &cfg, ranges.empty() ? nullptr : ranges.data()
-        );
-    }
-
-    /// \brief Switch FreeType builder for ImGui if requested and available.
-    static inline void _setup_freetype_if_needed(const BuildParams& params) {
-#   ifdef IMGUI_ENABLE_FREETYPE
-        if (!params.use_freetype) return;
-#       if IMGUI_VERSION_NUM >= 19200
-        ImGui::GetIO().Fonts->FontLoader = ImGuiFreeType::GetFontLoader();
-        ImGui::GetIO().Fonts->FontLoaderFlags = 0;
-#       else
-        ImGui::GetIO().Fonts->FontBuilderIO = ImGuiFreeType::GetBuilderForFreeType();
-        ImGui::GetIO().Fonts->FontBuilderFlags = 0;
-#       endif
-#   else
-        (void)params;
-#   endif
-    }
-
-    /// \brief After Fonts->Build(), update backend texture for SFML.
-    static inline bool _update_backend_texture_sfml() {
-#       if defined(IMGUI_SFML_VERSION_MAJOR) || defined(IMGUI_SFML_VERSION)
-        // ImGui-SFML provides UpdateFontTexture(); some versions return void.
-        ImGui::SFML::UpdateFontTexture();
-        return true;
-#       else
-        // If not using SFML backend, user should replace this with their backend call.
-        // We still return true to not fail builds on other backends.
-        return true;
-#       endif
-    }
-
-    /// ----------------------------
-    /// Public methods implementation
-    /// ----------------------------
-
-    inline bool FontManager::bootstrap(const BuildParams& params) {
-        m_params = params;
-        m_dirty = true;
-        return true;
-    }
-
-    inline BuildResult FontManager::buildNow() {
-        BuildResult br{};
-        
-        std::string base_dir_abs;
-#       ifdef __EMSCRIPTEN__
-        base_dir_abs = m_params.base_dir; // как есть
-#       else
-        base_dir_abs = ImGuiX::Utils::resolveExecPath(m_params.base_dir);
-#       endif
-
-        // We support either manual buffer (if active) or the active locale pack.
-        ImGuiIO& io = ImGui::GetIO();
-        io.Fonts->Clear();
-        io.FontDefault = nullptr;
-
-        _setup_freetype_if_needed(m_params);
-
-        // Build ranges
-        std::vector<ImWchar> ranges;
-        const LocalePack* pack_ptr = nullptr;
-
-        if (!m_manual.active) {
-            auto it = m_packs.find(m_active_locale);
-            if (it == m_packs.end()) {
-                // Try default
-                auto it2 = m_packs.find("default");
-                if (it2 != m_packs.end()) pack_ptr = &it2->second;
-            } else {
-                pack_ptr = &it->second;
-            }
-            _build_ranges_from_pack(ranges, pack_ptr, m_active_locale);
-        } else {
-            // Manual ranges: use default builder with extra glyphs from manual entries
-            ImFontGlyphRangesBuilder b;
-            _add_locale_ranges(b, io, m_active_locale);
-            if (m_manual.has_body) addExtraGlyphs(b, m_manual.body.extra_glyphs);
-            for (const auto& kv : m_manual.headlines) addExtraGlyphs(b, kv.second.extra_glyphs);
-            for (const auto& ff : m_manual.merges) addExtraGlyphs(b, ff.extra_glyphs);
-            ImVector<ImWchar> r; b.BuildRanges(&r);
-            ranges.assign(r.begin(), r.end());
-        }
-
-        // Base config for all fonts
-        ImFontConfig cfg{};
-        cfg.OversampleH = 3;
-        cfg.OversampleV = 1;
-        cfg.PixelSnapH  = false;
-
-        m_fonts.clear();
-
-        // Add Body first (either from pack or from manual)
-        ImFont* body = nullptr;
-
-        auto add_role_vec = [&](FontRole role, const std::vector<FontFile>& vec) -> ImFont* {
-            ImFont* last = nullptr;
-            for (size_t i = 0; i < vec.size(); ++i) {
-                ImFontConfig local = cfg;
-                // Merge mode depends on FontFile::merge; Body chain root usually merge=false.
-                local.MergeMode = (i > 0) ? (local.MergeMode || vec[i].merge) : vec[i].merge;
-                ImFont* f = _add_font_file(vec[i], m_params, ranges, base_dir_abs, local);
-                if (!f) { br.message = "Failed to load font: " + vec[i].path; }
-                last = f;
-            }
-            if (last) m_fonts[role] = last;
-            return last;
-        };
-
-        auto add_single = [&](FontRole role, const FontFile& ff)->ImFont* {
-            ImFont* f = _add_font_file(ff, m_params, ranges, base_dir_abs, cfg);
-            if (f) m_fonts[role] = f; else br.message = "Failed to load font: " + ff.path;
-            return f;
-        };
-
-        // Strategy per mode
-        if (!m_manual.active) {
-            // --- PACK MODE ---
-            // Body
-            if (pack_ptr) {
-                if (auto it = pack_ptr->roles.find(FontRole::Body); it != pack_ptr->roles.end() && !it->second.empty()) {
-                    body = add_role_vec(FontRole::Body, it->second);
-                }
-                // Merge Icons / Emoji into the last added (Body chain)
-                if (auto it = pack_ptr->roles.find(FontRole::Icons); it != pack_ptr->roles.end()) {
-                    for (const auto& ff : it->second) {
-                        FontFile mff = ff; mff.merge = true;
-                        ImFont* f = _add_font_file(mff, m_params, ranges, base_dir_abs, cfg);
-                        (void)f; // merged; no separate role pointer necessary
-                    }
-                    // record role as present (point to Body for retrieval semantics)
-                    if (body) m_fonts[FontRole::Icons] = body;
-                }
-                if (auto it = pack_ptr->roles.find(FontRole::Emoji); it != pack_ptr->roles.end()) {
-                    for (const auto& ff : it->second) {
-                        FontFile mff = ff; mff.merge = true;
-                        ImFont* f = _add_font_file(mff, m_params, ranges, base_dir_abs, cfg);
-                        (void)f;
-                    }
-                    if (body) m_fonts[FontRole::Emoji] = body;
+              // Роли: копировать недостающие (не перезаписывать имеющиеся)
+              for (const auto &rp : parent.roles)
+                if (!child.roles.count(rp.first)) {
+                  child.roles[rp.first] = rp.second;
+                  changed = true;
                 }
 
-                // Headings H1/H2/H3 (separate instances, may reuse Body TTF path with different size)
-                auto add_headline = [&](FontRole role, float px_default)->ImFont* {
-                    const FontFile* chosen = nullptr;
-                    if (auto it = pack_ptr->roles.find(role); it != pack_ptr->roles.end() && !it->second.empty())
-                        chosen = &it->second.front();
-                    FontFile ff{};
-                    if (chosen) {
-                        ff = *chosen;
-                        if (ff.size_px <= 0.0f) ff.size_px = px_default;
-                    } else if (body) {
-                        // reuse first Body file path
-                        const auto& bodyv = pack_ptr->roles.at(FontRole::Body);
-                        ff = bodyv.front();
-                        ff.size_px = px_default;
-                    } else {
-                        return nullptr;
-                    }
-                    return add_single(role, ff);
-                };
-
-                add_headline(FontRole::H1, m_px_h1);
-                add_headline(FontRole::H2, m_px_h2);
-                add_headline(FontRole::H3, m_px_h3);
-
-                // Bold/Italic/BoldItalic/Monospace
-                auto add_optional_role = [&](FontRole role)->ImFont* {
-                    if (auto it = pack_ptr->roles.find(role); it != pack_ptr->roles.end() && !it->second.empty())
-                        return add_single(role, it->second.front());
-                    return nullptr;
-                };
-                add_optional_role(FontRole::Bold);
-                add_optional_role(FontRole::Italic);
-                add_optional_role(FontRole::BoldItalic);
-                add_optional_role(FontRole::Monospace);
+              // Диапазоны: наследовать, если не заданы явно
+              if (child.ranges.empty() && !parent.ranges.empty()) {
+                child.ranges = parent.ranges;
+                changed = true;
+              }
+              // Пресет: наследовать, если не задан явно
+              if (child.ranges_preset.empty() &&
+                  !parent.ranges_preset.empty()) {
+                child.ranges_preset = parent.ranges_preset;
+                changed = true;
+              }
             }
-
-            // If still no Body, try a minimal fallback (Roboto + Icons) using base_dir
-            if (!body) {
-                FontFile fb{};
-                fb.path    = "Roboto-Medium.ttf";
-                fb.size_px = m_px_body;
-                body = add_single(FontRole::Body, fb);
-
-                FontFile ic{};
-                ic.path    = "forkawesome-webfont.ttf";
-                ic.size_px = m_px_body;
-                ic.merge   = true;
-                _add_font_file(ic, m_params, ranges, base_dir_abs, cfg);
-                if (body) m_fonts[FontRole::Icons] = body;
-
-                // Headings reuse Body path with different sizes
-                FontFile h{};
-                h.path = fb.path;
-                h.size_px = m_px_h1; add_single(FontRole::H1, h);
-                h.size_px = m_px_h2; add_single(FontRole::H2, h);
-                h.size_px = m_px_h3; add_single(FontRole::H3, h);
-            }
-        } else {
-            // --- MANUAL MODE ---
-            if (m_manual.has_body) {
-                // Body root
-                body = add_single(FontRole::Body, m_manual.body);
-                
-                auto do_merge_vec = [&](const std::vector<FontFile>& vec) {
-                    for (auto ff : vec) { ff.merge = true; (void)_add_font_file(ff, m_params, ranges, base_dir_abs, cfg); }
-                };
-
-                // Явные роли
-                bool merged_icons = !m_manual.merges_icons.empty();
-                bool merged_emoji = !m_manual.merges_emoji.empty();
-                do_merge_vec(m_manual.merges_icons);
-                do_merge_vec(m_manual.merges_emoji);
-
-                // Legacy: если использовали старый метод — включаем обе роли
-                if (!m_manual.merges_unknown.empty()) {
-                    do_merge_vec(m_manual.merges_unknown);
-                    merged_icons = true;
-                    merged_emoji = true;
-                }
-
-                if (body) {
-                    if (merged_icons) m_fonts[FontRole::Icons] = body;
-                    if (merged_emoji) m_fonts[FontRole::Emoji] = body;
-                }
-
-                // Headlines
-                auto ensure_headline = [&](FontRole role, float px_default) {
-                    auto it = m_manual.headlines.find(role);
-                    if (it != m_manual.headlines.end()) {
-                        add_single(role, it->second);
-                    } else if (body) {
-                        // reuse body path as a convenience
-                        FontFile ff = m_manual.body;
-                        ff.size_px = px_default;
-                        add_single(role, ff);
-                    }
-                };
-                ensure_headline(FontRole::H1, m_px_h1);
-                ensure_headline(FontRole::H2, m_px_h2);
-                ensure_headline(FontRole::H3, m_px_h3);
-            } else {
-                br.message = "Manual mode: Body font not provided";
-            }
+          }
         }
+      }
 
-        // Build atlas
-        if (!io.Fonts->Build()) {
-            br.success = false;
-            br.message = "ImFontAtlas::Build() failed";
-            return br;
-        }
-
-        // Update backend texture (SFML or stub true)
-        if (!_update_backend_texture_sfml()) {
-            br.success = false;
-            br.message = "Backend font texture update failed";
-            return br;
-        }
-
-        // Default font
-        if (ImFont* f = getFont(FontRole::Body))
-            io.FontDefault = f;
-
-        // Done
-        br.success = true;
-        br.fonts = m_fonts;
-        m_dirty = false;
-        return br;
+    } catch (const std::exception &e) {
+      br.success = false;
+      br.message = std::string("JSON parse error: ") + e.what();
+      // Fallback to defaults below
     }
+  }
 
-    inline BuildResult FontManager::rebuildIfNeeded() {
-        if (!m_dirty) {
-            BuildResult ok{};
-            ok.success = true;
-            ok.fonts = m_fonts;
-            return ok;
-        }
-        return buildNow();
+  // Choose active locale, or fallback to "default"
+  if (!m_packs.empty()) {
+    if (!m_packs.count(m_active_locale)) {
+      if (m_packs.count("default"))
+        m_active_locale = "default";
     }
+  }
 
-    inline BuildResult FontManager::initFromJsonOrDefaults() {
-        using nlohmann::json;
-#       ifdef IMGUIX_FONTS_ENABLE_JSON
-        BuildResult br{};
+  // Build now (either from packs or fallback)
+  return buildNow();
+#else
+  // JSON disabled: just build fallback (Roboto + Icons) using current
+  // BuildParams/base_dir.
+  return buildNow();
+#endif
+}
 
-        // Load JSON text (if exists)
-        std::string cfg_path;
-#       ifdef __EMSCRIPTEN__
-        cfg_path = m_config_path; // как есть
-#       else
-        cfg_path = ImGuiX::Utils::resolveExecPath(m_config_path);
-        // Fallback: если пусто или не найден — попробуем base_dir/fonts.json
-        if (readTextFile(cfg_path).empty()) {
-            const auto base_abs = ImGuiX::Utils::resolveExecPath(m_params.base_dir);
-            cfg_path = ImGuiX::Utils::joinPaths(base_abs, "fonts.json");
-        }
-#       endif
+inline std::string FontManager::readTextFile(const std::string &path) {
+  std::ifstream ifs(path, std::ios::in | std::ios::binary);
+  if (!ifs)
+    return {};
+  std::ostringstream oss;
+  oss << ifs.rdbuf();
+  return oss.str();
+}
 
-        const std::string json_text = readTextFile(cfg_path);
-        
-        if (!json_text.empty()) {
-            json j;
-            try {
-                j = json::parse(json_text);
-
-                // base_dir (optional)
-                if (j.contains("base_dir") && j["base_dir"].is_string())
-                    m_params.base_dir = j["base_dir"].get<std::string>();
-
-                // markdown_sizes (optional)
-                if (j.contains("markdown_sizes") && j["markdown_sizes"].is_object()) {
-                    const auto& ms = j["markdown_sizes"];
-                    if (ms.contains("body")) m_px_body = ms["body"].get<float>();
-                    if (ms.contains("h1"))   m_px_h1   = ms["h1"].get<float>();
-                    if (ms.contains("h2"))   m_px_h2   = ms["h2"].get<float>();
-                    if (ms.contains("h3"))   m_px_h3   = ms["h3"].get<float>();
-                }
-
-                // locales (packs)
-                if (j.contains("locales") && j["locales"].is_object()) {
-                    for (auto it = j["locales"].begin(); it != j["locales"].end(); ++it) {
-                        const std::string loc = it.key();
-                        const json& L = it.value();
-
-                        LocalePack pack{};
-                        pack.locale = loc;
-
-                        if (L.contains("inherits") && L["inherits"].is_string())
-                            pack.inherits = L["inherits"].get<std::string>();
-
-                        // ranges: массив пар ИЛИ строка-пресет (например "Default+Cyrillic+Punct")
-                        if (L.contains("ranges")) {
-                            if (L["ranges"].is_array()) {
-                                for (const auto& v : L["ranges"])
-                                    pack.ranges.push_back(static_cast<ImWchar>(v.get<int>()));
-                                // 0-терминатор добьём позже внутри _build_ranges_from_pack()
-                            } else if (L["ranges"].is_string()) {
-                                pack.ranges_preset = L["ranges"].get<std::string>(); // <-- ВАЖНО: сохраняем
-                            }
-                        }
-
-                        // roles...
-                        if (L.contains("roles") && L["roles"].is_object()) {
-                            const auto& R = L["roles"];
-                            auto parse_files = [&](const char* key, FontRole role) {
-                                if (R.contains(key) && R[key].is_array()) {
-                                    for (const auto& item : R[key]) {
-                                        FontFile ff{};
-                                        if (item.contains("path")) ff.path = item["path"].get<std::string>();
-                                        if (item.contains("size_px")) ff.size_px = item["size_px"].get<float>();
-                                        if (item.contains("merge")) ff.merge = item["merge"].get<bool>();
-                                        if (item.contains("freetype_flags")) ff.freetype_flags = item["freetype_flags"].get<unsigned>();
-                                        if (item.contains("extra_glyphs")) ff.extra_glyphs = item["extra_glyphs"].get<std::string>();
-                                        pack.roles[role].push_back(std::move(ff));
-                                    }
-                                }
-                            };
-                            parse_files("Body",       FontRole::Body);
-                            parse_files("H1",         FontRole::H1);
-                            parse_files("H2",         FontRole::H2);
-                            parse_files("H3",         FontRole::H3);
-                            parse_files("Monospace",  FontRole::Monospace);
-                            parse_files("Bold",       FontRole::Bold);
-                            parse_files("Italic",     FontRole::Italic);
-                            parse_files("BoldItalic", FontRole::BoldItalic);
-                            parse_files("Icons",      FontRole::Icons);
-                            parse_files("Emoji",      FontRole::Emoji);
-                        }
-
-                        m_packs[pack.locale] = std::move(pack);
-                    }
-
-                    // Второй проход: разворачиваем наследование после того, как ВСЕ пакеты прочитаны.
-                    {
-                        bool changed = true; int guard = 0;
-                        while (changed && guard++ < 16) {
-                            changed = false;
-                            for (auto &kv : m_packs) {
-                                auto &child = kv.second;
-                                if (child.inherits.empty()) continue;
-                                auto pit = m_packs.find(child.inherits);
-                                if (pit == m_packs.end()) continue;
-                                const auto &parent = pit->second;
-
-                                // Роли: копировать недостающие (не перезаписывать имеющиеся)
-                                for (const auto &rp : parent.roles)
-                                    if (!child.roles.count(rp.first)) { child.roles[rp.first] = rp.second; changed = true; }
-
-                                // Диапазоны: наследовать, если не заданы явно
-                                if (child.ranges.empty() && !parent.ranges.empty()) { child.ranges = parent.ranges; changed = true; }
-                                // Пресет: наследовать, если не задан явно
-                                if (child.ranges_preset.empty() && !parent.ranges_preset.empty()) { child.ranges_preset = parent.ranges_preset; changed = true; }
-                            }
-                        }
-                    }
-                }
-
-            } catch (const std::exception& e) {
-                br.success = false;
-                br.message = std::string("JSON parse error: ") + e.what();
-                // Fallback to defaults below
-            }
-        }
-
-        // Choose active locale, or fallback to "default"
-        if (!m_packs.empty()) {
-            if (!m_packs.count(m_active_locale)) {
-                if (m_packs.count("default")) m_active_locale = "default";
-            }
-        }
-
-        // Build now (either from packs or fallback)
-        return buildNow();
-#       else
-        // JSON disabled: just build fallback (Roboto + Icons) using current BuildParams/base_dir.
-        return buildNow();
-#       endif
-    }
-
-    inline std::string FontManager::readTextFile(const std::string& path) {
-        std::ifstream ifs(path, std::ios::in | std::ios::binary);
-        if (!ifs) return {};
-        std::ostringstream oss;
-        oss << ifs.rdbuf();
-        return oss.str();
-    }
-
-    inline void FontManager::addExtraGlyphs(ImFontGlyphRangesBuilder& b, const std::string& utf8) {
-        if (!utf8.empty())
-            b.AddText(utf8.c_str());
-    }
+inline void FontManager::addExtraGlyphs(ImFontGlyphRangesBuilder &b,
+                                        const std::string &utf8) {
+  if (!utf8.empty())
+    b.AddText(utf8.c_str());
+}
 
 } // namespace ImGuiX::Fonts
-


### PR DESCRIPTION
## Summary
- move FontManager helper functions into private static methods
- rename helpers to camelCase (e.g. scalePx, addLocaleRanges)

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a78060e314832c9532bf2b8520c12b