### PR TITLE
docs(style): align multiline call closing parens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -544,9 +544,33 @@ namespace ImGuiX {
 ```
 
 ### Function Calls — Many Arguments & Ternary
-* When wrapping, break after `(` and put each argument on its own line with double indentation (8 spaces).
-* For ternary expressions inside arguments, break after `?` and before `:`; align both outcomes with the start of the ternary expression using the same double indentation.
-* Close with `)` aligned using a single indentation (4 spaces).
+* Break after `(` and put each argument on its own line with double indentation (8 spaces).
+* If an argument uses a ternary `?:`, break after `?` and before `:`; align both outcomes under the start of the ternary using the same double indentation.
+* Place the final `)` on its own line aligned with the call line, then `);`.
+
+**Good:**
+```cpp
+return ImGui::GetIO().Fonts->AddFontFromFileTTF(
+        resolved.c_str(),
+        eff_px,
+        &cfg,
+        ranges.empty() ?
+            nullptr :
+            ranges.data()
+);
+```
+
+**Bad (closing paren indented like arguments):**
+```cpp
+return ImGui::GetIO().Fonts->AddFontFromFileTTF(
+        resolved.c_str(),
+        eff_px,
+        &cfg,
+        ranges.empty() ?
+            nullptr :
+            ranges.data()
+    );
+```
 
 ### Pointer/Reference Style
 * Bind the symbol to the type: `ImFont*`, `const Foo&`.

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -155,20 +155,23 @@ namespace ImGuiX {
 ```
 
 ### Function Calls — Many Arguments & Ternary
-- When arguments need wrapping, break after `(` and place each argument on its own line with double indentation (8 spaces).
-- For arguments containing a ternary `?:`, break after `?` and before `:`; align both outcomes under the start of the ternary expression using the same double indentation.
-- Close with `)` aligned using a single indentation (4 spaces).
+- Break after `(` and put each argument on its own line with double indentation (8 spaces).
+- If an argument uses a ternary `?:`, break after `?` and before `:`; align both outcomes under the start of the ternary using the same double indentation.
+- Place the final `)` on its own line aligned with the call line, then `);`.
 
 **Good:**
 ```cpp
 return ImGui::GetIO().Fonts->AddFontFromFileTTF(
-        resolved.c_str(), eff_px, &cfg, ranges.empty() ?
+        resolved.c_str(),
+        eff_px,
+        &cfg,
+        ranges.empty() ?
             nullptr :
             ranges.data()
-    );
+);
 ```
 
-**Also acceptable:**
+**Bad (closing paren indented like arguments):**
 ```cpp
 return ImGui::GetIO().Fonts->AddFontFromFileTTF(
         resolved.c_str(),
@@ -178,15 +181,6 @@ return ImGui::GetIO().Fonts->AddFontFromFileTTF(
             nullptr :
             ranges.data()
     );
-```
-
-**Bad:**
-```cpp
-return ImGui::GetIO().Fonts->AddFontFromFileTTF(
-    resolved.c_str(), eff_px, &cfg, ranges.empty() ?
-        nullptr :
-        ranges.data()
-);
 ```
 
 ### Pointer/Reference Style


### PR DESCRIPTION
## Summary
- document that multiline calls close on an unindented line
- add good/bad examples for ternaries in argument lists

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_IMGUI_STDLIB=ON` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cff483f8832c8c85339cb9f026b6