### PR TITLE
docs(core): refine comments in core and font headers

### DIFF
--- a/include/imguix/core.hpp
+++ b/include/imguix/core.hpp
@@ -21,7 +21,7 @@
 #include <imgui_impl_sdl2.h>
 #include <imgui_impl_opengl3.h>
 #else
-// Без бэкенда
+// No backend specified
 #endif
 
 #ifdef IMGUI_ENABLE_FREETYPE
@@ -35,8 +35,8 @@
 #include "core/events.hpp"                         ///< Common built-in events
 
 // --- Locale and Fonts ---
-#include "core/i18n.hpp"                           ///<
-#include "core/fonts/FontManager.hpp"              ///< FontManager: централизованная загрузка шрифтов (atlas ImGui + FreeType).
+#include "core/i18n.hpp"                           ///< Localization utilities
+#include "core/fonts/FontManager.hpp"              ///< FontManager: centralized font loading (ImGui atlas + FreeType)
 
 // --- Resource system ---
 #include "core/resource/ResourceRegistry.hpp"      ///< Global registry for shared resources

--- a/include/imguix/core/fonts/FontManager.hpp
+++ b/include/imguix/core/fonts/FontManager.hpp
@@ -27,15 +27,14 @@ namespace ImGuiX::Fonts {
 
     /// \brief Central manager for font atlas lifecycle.
     /// \details Guarantees a single valid atlas per frame. Rebuild happens only
-    /// between frames. FontManager: централизованная загрузка шрифтов (atlas ImGui
-    /// + FreeType).
-    /// - Header-only режим: определите IMGUIX_FONTS_HEADER_ONLY до подключения
-    /// этого заголовка,
-    ///   и реализация из FontManager.ipp подтянется автоматически.
-    /// - Иначе соберите отдельный TU, подключив FontManager.ipp в .cpp.
-    /// - Если определён IMGUI_ENABLE_FREETYPE — будет использован FreeType builder.
-    /// - Конфиг по умолчанию: data/resources/fonts/fonts.json (можно
-    /// переопределить).
+    /// between frames. Handles centralized font loading (ImGui atlas + FreeType).
+    /// - Header-only mode: define IMGUIX_FONTS_HEADER_ONLY before including this
+    ///   header and the implementation from FontManager.ipp is pulled
+    ///   automatically.
+    /// - Otherwise build a separate translation unit that includes
+    ///   FontManager.ipp in a .cpp.
+    /// - If IMGUI_ENABLE_FREETYPE is defined, the FreeType builder is used.
+    /// - Default config path: data/resources/fonts/fonts.json (can be overridden).
     class FontManager : 
         private FontManagerViewCRTP<FontManager>,
         private FontManagerControlCRTP<FontManager> {
@@ -64,16 +63,16 @@ namespace ImGuiX::Fonts {
         /// \brief Set active locale. May mark atlas dirty if ranges/fonts differ.
         void setLocale(std::string locale);
 		
-		/// \brief Задать диапазоны глифов пресетом (например "Default+Cyrillic+Punct").
-		/// \details Только для manual-режима. Сбрасывает явные ranges().
-		void setRanges(std::string preset);
+                /// \brief Set glyph ranges by preset (e.g., "Default+Cyrillic+Punct").
+                /// \details Manual mode only. Clears explicit ranges().
+                void setRanges(std::string preset);
 
-		/// \brief Задать диапазоны глифов явным массивом пар [start,end]. Можно без завершающего 0.
-		/// \details Только для manual-режима. Сбрасывает preset-строку.
-		void setRanges(const std::vector<ImWchar>& pairs);
+                /// \brief Set glyph ranges with explicit [start,end] pairs. Terminator 0 optional.
+                /// \details Manual mode only. Clears preset string.
+                void setRanges(const std::vector<ImWchar>& pairs);
 
-		/// \brief Очистить ручные диапазоны (preset/explicit). Будет использована locale-политика.
-		void clearRanges();
+                /// \brief Clear manual ranges (preset or explicit). Locale policy will be used.
+                void clearRanges();
 
         /// \brief Set Markdown headline sizes (px @ 96 DPI). Body is the base text
         /// size.
@@ -143,13 +142,13 @@ namespace ImGuiX::Fonts {
         /// \brief Returns current build parameters.
         const BuildParams &params() const;
         
-        /// \brief
+        /// \brief Access view interface.
         View& view() noexcept { return *this; }
-        
-        /// \brief
+
+        /// \brief Const access to view interface.
         const View& view() const noexcept { return *this; }
-        
-        /// \brief
+
+        /// \brief Access control interface.
         Control& control() noexcept { return *this; }
 
         FontManager() = default;
@@ -166,8 +165,8 @@ namespace ImGuiX::Fonts {
             std::vector<FontFile> merges_icons;   ///< explicit Icons
             std::vector<FontFile> merges_emoji;   ///< explicit Emoji
             std::vector<FontFile> merges_unknown; ///< legacy addFontMerge(ff)
-            std::vector<ImWchar> ranges;          ///< optional manual ranges
-			std::string          ranges_preset;   ///< "Default+Cyrillic+Vietnamese+Punct"
+            std::vector<ImWchar> ranges;          ///< Optional manual ranges
+            std::string ranges_preset;            ///< "Default+Cyrillic+Vietnamese+Punct"
         };
 
         BuildParams m_params{};

--- a/include/imguix/core/fonts/FontManagerControlCRTP.hpp
+++ b/include/imguix/core/fonts/FontManagerControlCRTP.hpp
@@ -3,58 +3,58 @@
 #define _IMGUIX_FONTS_FONT_MANAGER_CONTROL_CRTP_HPP_INCLUDED
 
 /// \file FontManagerControlCRTP.hpp
-/// \brief CRTP-фасад для безопасного управления шрифтами в рантайме.
-/// \note Все методы должны вызываться на GUI-потоке между кадрами.
+/// \brief CRTP facade for safe runtime font management.
+/// \note All methods must be called on the GUI thread between frames.
 
 namespace ImGuiX::Fonts {
 
-	template<class Impl>
-	struct FontManagerControlCRTP {
-		// --- Мутация, безопасная в рантайме ---
+        template<class Impl>
+        struct FontManagerControlCRTP {
+                // --- Mutation safe at runtime ---
 
-		/// Смена локали (пересоберёт атлас при следующем rebuildIfNeeded()).
-		void setLocale(std::string s) {
-			static_cast<Impl*>(this)->setLocale(std::move(s));
-		}
+                /// \brief Change active locale; rebuilds atlas on next rebuildIfNeeded().
+                void setLocale(std::string s) {
+                        static_cast<Impl*>(this)->setLocale(std::move(s));
+                }
 
-		/// Настройка размеров Markdown (px @ 96 DPI).
-		void setMarkdownSizes(float body, float h1, float h2, float h3) {
-			static_cast<Impl*>(this)->setMarkdownSizes(body, h1, h2, h3);
-		}
+                /// \brief Set Markdown sizes (px at 96 DPI).
+                void setMarkdownSizes(float body, float h1, float h2, float h3) {
+                        static_cast<Impl*>(this)->setMarkdownSizes(body, h1, h2, h3);
+                }
 
-		/// Логический DPI (масштабирование по дисплею).
-		void setDpi(float dpi) {
-			static_cast<Impl*>(this)->setDpi(dpi);
-		}
+                /// \brief Set logical DPI for display scaling.
+                void setDpi(float dpi) {
+                        static_cast<Impl*>(this)->setDpi(dpi);
+                }
 
-		/// Глобальный UI scale (доп. множитель).
-		void setUiScale(float ui_scale) {
-			static_cast<Impl*>(this)->setUiScale(ui_scale);
-		}
+                /// \brief Set global UI scale (additional multiplier).
+                void setUiScale(float ui_scale) {
+                        static_cast<Impl*>(this)->setUiScale(ui_scale);
+                }
 
-		/// Пересборка атласа, если помечен dirty.
-		/// \warning Вызывать между кадрами.
-		BuildResult rebuildIfNeeded() {
-			return static_cast<Impl*>(this)->rebuildIfNeeded();
-		}
+                /// \brief Rebuild atlas if marked dirty.
+                /// \warning Call between frames.
+                BuildResult rebuildIfNeeded() {
+                        return static_cast<Impl*>(this)->rebuildIfNeeded();
+                }
 
-		// --- Удобные геттеры (read-only) ---
+                // --- Convenient getters (read-only) ---
 
-		/// Получить шрифт по роли. Может вернуть nullptr.
-		[[nodiscard]] ImFont* getFont(FontRole role) const noexcept {
-			return static_cast<const Impl*>(this)->getFont(role);
-		}
+                /// \brief Get font by role; may return nullptr.
+                [[nodiscard]] ImFont* getFont(FontRole role) const noexcept {
+                        return static_cast<const Impl*>(this)->getFont(role);
+                }
 
-		/// Текущая активная локаль.
-		[[nodiscard]] const std::string& activeLocale() const noexcept {
-			return static_cast<const Impl*>(this)->activeLocale();
-		}
+                /// \brief Get currently active locale.
+                [[nodiscard]] const std::string& activeLocale() const noexcept {
+                        return static_cast<const Impl*>(this)->activeLocale();
+                }
 
-		/// Текущие параметры сборки (dpi/ui_scale/base_dir/use_freetype) — только чтение.
-		[[nodiscard]] const BuildParams& params() const noexcept {
-			return static_cast<const Impl*>(this)->params();
-		}
-	};
+                /// \brief Access current build parameters (dpi, ui_scale, base_dir, use_freetype).
+                [[nodiscard]] const BuildParams& params() const noexcept {
+                        return static_cast<const Impl*>(this)->params();
+                }
+        };
 
 } // namespace ImGuiX::Fonts
 

--- a/include/imguix/core/fonts/FontManagerViewCRTP.hpp
+++ b/include/imguix/core/fonts/FontManagerViewCRTP.hpp
@@ -2,24 +2,30 @@
 #ifndef _IMGUIX_FONTS_FONT_MANAGER_VIEW_CRTP_HPP_INCLUDED
 #define _IMGUIX_FONTS_FONT_MANAGER_VIEW_CRTP_HPP_INCLUDED
 
-namespace ImGuiX::Fonts {
-	
-	template<class Impl>
-	struct FontManagerViewCRTP {
-		
-		ImFont* getFont(FontRole r) const noexcept {
-			return static_cast<const Impl*>(this)->getFont(r);
-		}
-		
-		const std::string& activeLocale() const noexcept {
-			return static_cast<const Impl*>(this)->activeLocale();
-		}
-		
-		const BuildParams& params() const noexcept { 
-			return static_cast<const Impl*>(this)->params(); 
-		}
-	};
+/// \file FontManagerViewCRTP.hpp
+/// \brief CRTP view facade exposing read-only font access.
 
-};
+namespace ImGuiX::Fonts {
+
+        template<class Impl>
+        struct FontManagerViewCRTP {
+
+                /// \brief Get font by role; may return nullptr.
+                ImFont* getFont(FontRole r) const noexcept {
+                        return static_cast<const Impl*>(this)->getFont(r);
+                }
+
+                /// \brief Get currently active locale identifier.
+                const std::string& activeLocale() const noexcept {
+                        return static_cast<const Impl*>(this)->activeLocale();
+                }
+
+                /// \brief Access current build parameters.
+                const BuildParams& params() const noexcept {
+                        return static_cast<const Impl*>(this)->params();
+                }
+        };
+
+} // namespace ImGuiX::Fonts
 
 #endif // _IMGUIX_FONTS_FONT_MANAGER_VIEW_CRTP_HPP_INCLUDED

--- a/include/imguix/core/fonts/font_types.hpp
+++ b/include/imguix/core/fonts/font_types.hpp
@@ -31,11 +31,11 @@ namespace ImGuiX::Fonts {
 
 	/// \brief Per-locale font pack: files grouped by role + final glyph ranges.
 	struct LocalePack {
-		std::string locale; ///< e.g., "default", "en", "ru", "ja"
-		std::unordered_map<FontRole, std::vector<FontFile>> roles; ///<
-		std::vector<ImWchar> ranges;  ///< Final glyph ranges (0-terminated pairs). If empty, manager will build defaults.
-		std::string inherits;         ///< Optional inheritance tag (resolved by loader), empty if none.
-		std::string ranges_preset;    ///<
+                std::string locale; ///< e.g., "default", "en", "ru", "ja"
+                std::unordered_map<FontRole, std::vector<FontFile>> roles; ///< Font files grouped by logical role
+                std::vector<ImWchar> ranges;  ///< Final glyph ranges (0-terminated pairs). If empty, manager builds defaults.
+                std::string inherits;         ///< Optional inheritance tag (resolved by loader), empty if none.
+                std::string ranges_preset;    ///< Optional named range preset
 	};
 
 	/// \brief Parameters that affect atlas build and scaling.


### PR DESCRIPTION
## Summary
- translate and clarify comments in core.hpp
- polish Doxygen and inline comments in font manager headers and implementation
- document font type structures and CRTP helpers

## Testing
- `cmake ..` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d44bfa88832c87a8a0845bb3baf3