### PR TITLE
refactor: apply header formatting

### DIFF
--- a/include/imguix/core/events/LogEvent.hpp
+++ b/include/imguix/core/events/LogEvent.hpp
@@ -19,46 +19,48 @@
 
 namespace ImGuiX::Events {
 
-	/// \enum LogLevel
-	/// \brief Logging severity levels.
-	enum class LogLevel {
-		Trace,
-		Debug,
-		Info,
-		Warn,
-		Error,
-		Fatal
-	};
+    /// \enum LogLevel
+    /// \brief Logging severity levels.
+    enum class LogLevel {
+        Trace,
+        Debug,
+        Info,
+        Warn,
+        Error,
+        Fatal
+    };
 
-	/// \brief Convert level to short string.
-	inline const char* level_to_cstr(LogLevel lv) noexcept {
-		switch (lv) {
-			case LogLevel::Trace: return "TRACE";
-			case LogLevel::Debug: return "DEBUG";
-			case LogLevel::Info:  return "INFO";
-			case LogLevel::Warn:  return "WARN";
-			case LogLevel::Error: return "ERROR";
-			case LogLevel::Fatal: return "FATAL";
-		}
-		return "UNKNOWN";
-	}
-	
-	/// \brief Event containing log message and source metadata.
-	class LogEvent : public Pubsub::Event {
-	public:
-		LogLevel level;       ///< Severity level
-		std::string message;  ///< Log text
-		const char* file;     ///< Source file
-		int line;             ///< Source line
-		const char* function; ///< Function signature
+    /// \brief Convert level to short string.
+    inline const char* level_to_cstr(LogLevel lv) noexcept {
+        switch (lv) {
+            case LogLevel::Trace: return "TRACE";
+            case LogLevel::Debug: return "DEBUG";
+            case LogLevel::Info:  return "INFO";
+            case LogLevel::Warn:  return "WARN";
+            case LogLevel::Error: return "ERROR";
+            case LogLevel::Fatal: return "FATAL";
+        }
+        return "UNKNOWN";
+    }
 
-		LogEvent(LogLevel lvl,
-				 std::string msg,
-				 const char* file,
-				 int line,
-				 const char* func)
-			: level(lvl), message(std::move(msg)),
-			  file(file), line(line), function(func) {}
+    /// \brief Event containing log message and source metadata.
+    class LogEvent : public Pubsub::Event {
+    public:
+        LogLevel level;       ///< Severity level
+        std::string message;  ///< Log text
+        const char* file;     ///< Source file
+        int line;             ///< Source line
+        const char* function; ///< Function signature
+
+        LogEvent(
+                LogLevel lvl,
+                std::string msg,
+                const char* file,
+                int line,
+                const char* func
+            )
+            : level(lvl), message(std::move(msg)),
+              file(file), line(line), function(func) {}
 
         std::type_index type() const override {
             return typeid(LogEvent);
@@ -67,7 +69,7 @@ namespace ImGuiX::Events {
         const char* name() const override {
             return "LogEvent";
         }
-	};
+    };
 
 } // namespace ImGuiX::Events
 

--- a/include/imguix/core/fonts/FontManager.hpp
+++ b/include/imguix/core/fonts/FontManager.hpp
@@ -41,7 +41,7 @@ namespace ImGuiX::Fonts {
     public:
         using View    = FontManagerViewCRTP<FontManager>;
         using Control = FontManagerControlCRTP<FontManager>;
-    
+
         /// \brief Set base directory for relative font paths (affects both JSON and
         /// manual mode).
         void setBaseDir(std::string base_dir);
@@ -55,24 +55,24 @@ namespace ImGuiX::Fonts {
         /// \brief Initialize manager with build parameters. Does not build
         /// immediately.
         /// \return true if parameters accepted.
-        bool bootstrap(const BuildParams &params);
+        bool bootstrap(const BuildParams& params);
 
         /// \brief Set JSON config path. Default: "data/resources/fonts/fonts.json";.
         void setConfigPath(std::string path);
 
         /// \brief Set active locale. May mark atlas dirty if ranges/fonts differ.
         void setLocale(std::string locale);
-		
-                /// \brief Set glyph ranges by preset (e.g., "Default+Cyrillic+Punct").
-                /// \details Manual mode only. Clears explicit ranges().
-                void setRanges(std::string preset);
 
-                /// \brief Set glyph ranges with explicit [start,end] pairs. Terminator 0 optional.
-                /// \details Manual mode only. Clears preset string.
-                void setRanges(const std::vector<ImWchar>& pairs);
+        /// \brief Set glyph ranges by preset (e.g., "Default+Cyrillic+Punct").
+        /// \details Manual mode only. Clears explicit ranges().
+        void setRanges(std::string preset);
 
-                /// \brief Clear manual ranges (preset or explicit). Locale policy will be used.
-                void clearRanges();
+        /// \brief Set glyph ranges with explicit [start,end] pairs. Terminator 0 optional.
+        /// \details Manual mode only. Clears preset string.
+        void setRanges(const std::vector<ImWchar>& pairs);
+
+        /// \brief Clear manual ranges (preset or explicit). Locale policy will be used.
+        void clearRanges();
 
         /// \brief Set Markdown headline sizes (px @ 96 DPI). Body is the base text
         /// size.
@@ -80,7 +80,7 @@ namespace ImGuiX::Fonts {
 
         /// \brief Provide/override a locale pack programmatically (used without JSON
         /// or to extend it).
-        void setLocalePack(const LocalePack &pack);
+        void setLocalePack(const LocalePack& pack);
 
         /// \brief Drop all registered packs.
         void clearPacks();
@@ -95,23 +95,23 @@ namespace ImGuiX::Fonts {
         /// build time.
         /// \note This only enqueues; actual AddFont happens inside
         /// buildNow()/rebuildIfNeeded().
-        void addFontBody(const FontFile &ff);
+        void addFontBody(const FontFile& ff);
 
         /// \brief Add headline font for H1/H2/H3. If path empty, Body TTF is reused
         /// at another size.
-        void addFontHeadline(FontRole role_h, const FontFile &ff);
+        void addFontHeadline(FontRole role_h, const FontFile& ff);
 
         /// \brief Add merged font explicitly as Icons or Emoji (MANUAL mode).
         /// \note Only FontRole::Icons or FontRole::Emoji are allowed; others are
         /// ignored.
-        void addFontMerge(FontRole role, const FontFile &ff);
+        void addFontMerge(FontRole role, const FontFile& ff);
 
         /// \brief Add merged font (icons/emoji) into Body chain.
         /// \details Manual mode: merges the file into Body. Role marking:
         /// if role is not specified, both Icons and Emoji are considered available
         /// and return Body (merged chain).
         /// \warning Prefer the role-specific overload above.
-        void addFontMerge(const FontFile &ff);
+        void addFontMerge(const FontFile& ff);
 
         /// \brief Build atlas immediately from the current manual configuration.
         /// \warning Must be called on the GUI thread between frames.
@@ -134,14 +134,14 @@ namespace ImGuiX::Fonts {
         // ----------------- Accessors -----------------
 
         /// \brief Get font by role. Returns nullptr if not available.
-        ImFont *getFont(FontRole role) const;
+        ImFont* getFont(FontRole role) const;
 
         /// \brief Returns currently active locale id.
-        const std::string &activeLocale() const;
+        const std::string& activeLocale() const;
 
         /// \brief Returns current build parameters.
-        const BuildParams &params() const;
-        
+        const BuildParams& params() const;
+
         /// \brief Access view interface.
         View& view() noexcept { return *this; }
 
@@ -183,7 +183,7 @@ namespace ImGuiX::Fonts {
         float m_px_h3 = 18.0f;
 
         // Resolved fonts after last successful build
-        std::unordered_map<FontRole, ImFont *> m_fonts;
+        std::unordered_map<FontRole, ImFont*> m_fonts;
 
         // Locale packs provided by JSON or programmatically
         std::unordered_map<std::string, LocalePack> m_packs;
@@ -192,49 +192,49 @@ namespace ImGuiX::Fonts {
         PendingManual m_manual{};
 
         // Internal static helpers
-        static float scalePx(float px_96, const BuildParams &p);
+        static float scalePx(float px_96, const BuildParams& p);
 
         static void addLocaleRanges(
-            ImFontGlyphRangesBuilder &b, 
-            ImGuiIO &io,
-            const std::string &locale);
-                                  
+            ImFontGlyphRangesBuilder& b,
+            ImGuiIO& io,
+            const std::string& locale);
+
         static void addNamedRanges(
-            ImFontGlyphRangesBuilder &b, 
-            ImGuiIO &io,
-            const std::string &spec
+            ImFontGlyphRangesBuilder& b,
+            ImGuiIO& io,
+            const std::string& spec
         );
-                                 
+
         static void buildRangesFromPack(
-            std::vector<ImWchar> &out,
-            const LocalePack *pack,
-            const std::string &active_locale
+            std::vector<ImWchar>& out,
+            const LocalePack* pack,
+            const std::string& active_locale
         );
-        
-        static ImFont *addFontFile(
-            const FontFile &ff, 
-            const BuildParams &params,
-            const std::vector<ImWchar> &ranges,
-            const std::string &base_dir_abs,
-            const ImFontConfig &base_cfg
+
+        static ImFont* addFontFile(
+            const FontFile& ff,
+            const BuildParams& params,
+            const std::vector<ImWchar>& ranges,
+            const std::string& base_dir_abs,
+            const ImFontConfig& base_cfg
         );
-        
-        static void setupFreetypeIfNeeded(const BuildParams &params);
+
+        static void setupFreetypeIfNeeded(const BuildParams& params);
 
         static bool updateBackendTexture();
 
         /// \brief Read all file to string. Returns empty string on error.
-        static inline std::string readTextFile(const std::string &path);
+        static inline std::string readTextFile(const std::string& path);
 
         /// \brief Add UTF-8 extra glyphs to builder.
         static inline void addExtraGlyphs(
-            ImFontGlyphRangesBuilder &b,
-            const std::string &utf8
+            ImFontGlyphRangesBuilder& b,
+            const std::string& utf8
         );
 
         // Non-copyable
-        FontManager(const FontManager &) = delete;
-        FontManager &operator=(const FontManager &) = delete;
+        FontManager(const FontManager&) = delete;
+        FontManager& operator=(const FontManager&) = delete;
     };
 
 } // namespace ImGuiX::Fonts

--- a/include/imguix/core/fonts/font_types.hpp
+++ b/include/imguix/core/fonts/font_types.hpp
@@ -4,54 +4,54 @@
 
 namespace ImGuiX::Fonts {
 
-	/// \brief Logical roles for fonts that UI code can request.
-	enum class FontRole {
-		Body,       ///< Primary text font
-		H1,         ///< Markdown level-1 header
-		H2,         ///< Markdown level-2 header
-		H3,         ///< Markdown level-3 header
-		Monospace,  ///< Code blocks / fixed-width
-		Bold,       ///< Bold style
-		Italic,     ///< Italic style
-		BoldItalic, ///< Bold + Italic
-		Icons,      ///< Icon set merged into Body (e.g., ForkAwesome)
-		Emoji       ///< Emoji set merged into Body (mono/bitmap, not color)
-	};
-	
-	/// \brief Single font file descriptor.
-	/// \details size_px is defined for 96 DPI; actual size will be scaled by
-	/// DPI*ui_scale.
-	struct FontFile {
-		std::string path;            ///< Absolute or relative to BuildParams::base_dir
-		float size_px = 16.0f;       ///< Base size at 96 DPI
-		bool merge = false;          ///< Merge glyphs into previous font (icons/emoji)
-		unsigned freetype_flags = 0; ///< ImGui FreeType builder flags (0 = default)
-		std::string extra_glyphs;    ///< Optional extra glyphs UTF-8 string with extra symbols
-	};
+    /// \brief Logical roles for fonts that UI code can request.
+    enum class FontRole {
+        Body,       ///< Primary text font
+        H1,         ///< Markdown level-1 header
+        H2,         ///< Markdown level-2 header
+        H3,         ///< Markdown level-3 header
+        Monospace,  ///< Code blocks / fixed-width
+        Bold,       ///< Bold style
+        Italic,     ///< Italic style
+        BoldItalic, ///< Bold + Italic
+        Icons,      ///< Icon set merged into Body (e.g., ForkAwesome)
+        Emoji       ///< Emoji set merged into Body (mono/bitmap, not color)
+    };
 
-	/// \brief Per-locale font pack: files grouped by role + final glyph ranges.
-	struct LocalePack {
-                std::string locale; ///< e.g., "default", "en", "ru", "ja"
-                std::unordered_map<FontRole, std::vector<FontFile>> roles; ///< Font files grouped by logical role
-                std::vector<ImWchar> ranges;  ///< Final glyph ranges (0-terminated pairs). If empty, manager builds defaults.
-                std::string inherits;         ///< Optional inheritance tag (resolved by loader), empty if none.
-                std::string ranges_preset;    ///< Optional named range preset
-	};
+    /// \brief Single font file descriptor.
+    /// \details size_px is defined for 96 DPI; actual size will be scaled by
+    /// DPI*ui_scale.
+    struct FontFile {
+        std::string path;            ///< Absolute or relative to BuildParams::base_dir
+        float size_px = 16.0f;       ///< Base size at 96 DPI
+        bool merge = false;          ///< Merge glyphs into previous font (icons/emoji)
+        unsigned freetype_flags = 0; ///< ImGui FreeType builder flags (0 = default)
+        std::string extra_glyphs;    ///< Optional extra glyphs UTF-8 string with extra symbols
+    };
 
-	/// \brief Parameters that affect atlas build and scaling.
-	struct BuildParams {
-		float dpi = 96.0f;     ///< Logical DPI (96 = 1.0 scale)
-		float ui_scale = 1.0f; ///< Global UI scaling factor
-		std::string base_dir = "data/resources/fonts"; ///< Base directory for relative paths
-		bool use_freetype = true;   ///< Use ImGui FreeType builder if available
-	};
+    /// \brief Per-locale font pack: files grouped by role + final glyph ranges.
+    struct LocalePack {
+        std::string locale; ///< e.g., "default", "en", "ru", "ja"
+        std::unordered_map<FontRole, std::vector<FontFile>> roles; ///< Font files grouped by logical role
+        std::vector<ImWchar> ranges;  ///< Final glyph ranges (0-terminated pairs). If empty, manager builds defaults.
+        std::string inherits;         ///< Optional inheritance tag (resolved by loader), empty if none.
+        std::string ranges_preset;    ///< Optional named range preset
+    };
 
-	/// \brief Result summary for a (re)build operation.
-	struct BuildResult {
-		bool success = false; ///< True if fonts were built and backend texture updated
-		std::unordered_map<FontRole, ImFont *> fonts; ///< Resolved fonts by role (subset may be present)
-		std::string message;  ///< Diagnostic info on failure
-	};
+    /// \brief Parameters that affect atlas build and scaling.
+    struct BuildParams {
+        float dpi = 96.0f;     ///< Logical DPI (96 = 1.0 scale)
+        float ui_scale = 1.0f; ///< Global UI scaling factor
+        std::string base_dir = "data/resources/fonts"; ///< Base directory for relative paths
+        bool use_freetype = true;   ///< Use ImGui FreeType builder if available
+    };
+
+    /// \brief Result summary for a (re)build operation.
+    struct BuildResult {
+        bool success = false; ///< True if fonts were built and backend texture updated
+        std::unordered_map<FontRole, ImFont*> fonts; ///< Resolved fonts by role (subset may be present)
+        std::string message;  ///< Diagnostic info on failure
+    };
 
 }; // namespace ImGuiX::Fonts
 

--- a/include/imguix/core/i18n/LangStore.hpp
+++ b/include/imguix/core/i18n/LangStore.hpp
@@ -35,7 +35,7 @@ namespace ImGuiX::I18N {
 
         LangStore()
             : LangStore(default_i18n_base_dir(), "en") {
-		}
+        }
 
         /// \brief Construct i18n store.
         /// \param base_dir Root folder with per-language subfolders (e.g., "<root>/en/", "<root>/ru/").
@@ -172,8 +172,8 @@ namespace ImGuiX::I18N {
         }
 
     private:
-		
-		// --- типы ключей и карты ---
+
+        // --- типы ключей и карты ---
         using KeyView = std::string_view;
     
         struct SvHash {
@@ -200,11 +200,11 @@ namespace ImGuiX::I18N {
         }
 
         static std::string default_i18n_base_dir() {
-#           if IMGUIX_RESOLVE_PATHS_REL_TO_EXE
+#if IMGUIX_RESOLVE_PATHS_REL_TO_EXE
             return ImGuiX::Utils::resolveExecPath(IMGUIX_I18N_DIR);
-#           else
+#else
             return std::string(IMGUIX_I18N_DIR);
-#           endif
+#endif
         }
         // ---------- JSON loading ----------
 

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -6,26 +6,26 @@
 /// \brief Abstract base class for a window instance in ImGuiX.
 
 #ifdef IMGUIX_USE_SFML_BACKEND
-#   include "DeltaClockSfml.hpp"
-#   include <imgui-SFML.h>
-#   include <SFML/Graphics.hpp>
+#    include "DeltaClockSfml.hpp"
+#    include <imgui-SFML.h>
+#    include <SFML/Graphics.hpp>
 #endif
 #ifdef IMGUIX_USE_GLFW_BACKEND
-#   include <imgui_impl_glfw.h>
-#   include <imgui_impl_opengl3.h>
-#   include <GLFW/glfw3.h>
-#   include "imgui_glsl_version.hpp"
+#    include <imgui_impl_glfw.h>
+#    include <imgui_impl_opengl3.h>
+#    include <GLFW/glfw3.h>
+#    include "imgui_glsl_version.hpp"
 #endif
 #ifdef IMGUIX_USE_SDL2_BACKEND
-#   include <imgui_impl_sdl2.h>
-#   include <imgui_impl_opengl3.h>
-#   include <SDL.h>
-#   include <SDL_opengles2.h>
-#   include "imgui_glsl_version.hpp"
+#    include <imgui_impl_sdl2.h>
+#    include <imgui_impl_opengl3.h>
+#    include <SDL.h>
+#    include <SDL_opengles2.h>
+#    include "imgui_glsl_version.hpp"
 #endif
 
 #ifndef IMGUIX_CONFIG_DIR
-#   define IMGUIX_CONFIG_DIR "data/config"
+#    define IMGUIX_CONFIG_DIR "data/config"
 #endif
 
 namespace ImGuiX {
@@ -34,7 +34,9 @@ namespace ImGuiX {
     ///
     /// Combines event handling, rendering, and controller orchestration.
     /// Derive from this class to implement platform-specific windows.
-    class WindowInstance : public WindowControl, public Pubsub::EventMediator {
+    class WindowInstance :
+        public WindowControl,
+        public Pubsub::EventMediator {
     public:
         /// \brief Constructs the window with a unique ID and name.
         /// \param id Unique window identifier.
@@ -208,14 +210,14 @@ namespace ImGuiX {
 
         /// \brief
         void fontsBeginManual();
-		
-		void fontsSetLocale(std::string locale);
-		
-		void fontsSetRangesPreset(std::string preset);                    // обёртка на setRanges(std::string)
 
-		void fontsSetRangesExplicit(const std::vector<ImWchar>& pairs);   // обёртка на setRanges(vector)
-		
-		void fontsClearRanges();                                          // обёртка на clearRanges()
+            void fontsSetLocale(std::string locale);
+
+            void fontsSetRangesPreset(std::string preset);                    // обёртка на setRanges(std::string)
+
+            void fontsSetRangesExplicit(const std::vector<ImWchar>& pairs);   // обёртка на setRanges(vector)
+
+            void fontsClearRanges();                                          // обёртка на clearRanges()
 
         /// \brief
         /// \param
@@ -239,19 +241,19 @@ namespace ImGuiX {
         bool fontsBuildNow();
 
     protected:
-#       ifdef IMGUIX_USE_SFML_BACKEND
+#ifdef IMGUIX_USE_SFML_BACKEND
         sf::RenderWindow m_window; ///< Underlying SFML render window.
-#       elif defined(IMGUIX_USE_GLFW_BACKEND)
+#elif defined(IMGUIX_USE_GLFW_BACKEND)
         GLFWwindow* m_window = nullptr; ///< Pointer to the GLFW window.
         ImGuiContext* m_imgui_ctx = nullptr;
         const char* selectGlslForGlfw(GLFWwindow* w) noexcept;
-#       elif defined(IMGUIX_USE_SDL2_BACKEND)
-        SDL_Window* m_window = nullptr;   ///< SDL window handle.
+#elif defined(IMGUIX_USE_SDL2_BACKEND)
+        SDL_Window* m_window = nullptr; ///< SDL window handle.
         SDL_GLContext m_gl_context = nullptr; ///< Associated GL context.
-        SDL_Window*   m_window = nullptr;
+        SDL_Window* m_window = nullptr;
         ImGuiContext* m_imgui_ctx = nullptr;
         const char* selectGlslForSdl(SDL_Window* w) noexcept;
-#       endif
+#endif
         int m_window_id;                    ///< Unique window identifier.
         std::string m_window_name;          ///< Internal window name.
         int m_width = 1280;                 ///< Current window width.
@@ -279,17 +281,17 @@ namespace ImGuiX {
         virtual void onBeforeLanguageApply(const std::string& /*lang*/) {};
     };
 
-} // namespace imguix
+} // namespace ImGuiX
 
 #ifdef IMGUIX_HEADER_ONLY
-#   include "WindowInstance.ipp"
-#   ifdef IMGUIX_USE_SFML_BACKEND
-#       include "SfmlWindowInstance.ipp"
-#   elif defined(IMGUIX_USE_GLFW_BACKEND)
-#       include "GlfwWindowInstance.ipp"
-#   elif defined(IMGUIX_USE_SDL2_BACKEND)
-#       include "Sdl2WindowInstance.ipp"
-#   endif
+#    include "WindowInstance.ipp"
+#    ifdef IMGUIX_USE_SFML_BACKEND
+#        include "SfmlWindowInstance.ipp"
+#    elif defined(IMGUIX_USE_GLFW_BACKEND)
+#        include "GlfwWindowInstance.ipp"
+#    elif defined(IMGUIX_USE_SDL2_BACKEND)
+#        include "Sdl2WindowInstance.ipp"
+#    endif
 #endif
 
 #endif // _IMGUIX_CORE_WINDOW_INSTANCE_IWINDOW_INSTANCE_HPP_INCLUDED

--- a/include/imguix/utils/path_utils.hpp
+++ b/include/imguix/utils/path_utils.hpp
@@ -11,16 +11,16 @@
 #include <filesystem>
 
 #if defined(_WIN32)
-#   include <Windows.h>
-#   include <codecvt>
-#   include <locale>
+#    include <Windows.h>
+#    include <codecvt>
+#    include <locale>
 #elif defined(__APPLE__)
-#   include <mach-o/dyld.h>
-#   include <limits.h>
-#   include <unistd.h>
+#    include <mach-o/dyld.h>
+#    include <limits.h>
+#    include <unistd.h>
 #else
-#   include <limits.h>
-#   include <unistd.h>
+#    include <limits.h>
+#    include <unistd.h>
 #endif
 
 namespace ImGuiX::Utils {
@@ -159,16 +159,16 @@ namespace ImGuiX::Utils {
 #endif
     }
 
-	/// \brief
+    /// \brief
     inline bool isAbsolutePath(const std::string& p) {
         return fs::u8path(p).is_absolute();
     }
 
-	/// \brief
+    /// \brief
     inline std::string joinPaths(const std::string& a, const std::string& b) {
         return (fs::u8path(a) / fs::u8path(b)).lexically_normal().u8string();
     }
 
-} // namespace ImGuiX::utils
+} // namespace ImGuiX::Utils
 
 #endif // _IMGUIX_UTILS_PATH_UTILS_HPP_INCLUDED

--- a/include/imguix/widgets/circle_button.hpp
+++ b/include/imguix/widgets/circle_button.hpp
@@ -15,7 +15,7 @@ namespace ImGuiX::Widgets {
     /// \param diameter Diameter of the button in pixels.
     /// \param color Base color of the button.
     /// \return True if the button was clicked.
-	bool CircleButton(const char* id, float diameter, const ImVec4& color) {
+    bool CircleButton(const char* id, float diameter, const ImVec4& color) {
         ImVec2 size = ImVec2(diameter, diameter);
         ImVec2 pos = ImGui::GetCursorScreenPos();
         ImGui::InvisibleButton(id, size);
@@ -25,12 +25,12 @@ namespace ImGuiX::Widgets {
 
         ImVec4 final_col = color;
         if (ImGui::IsItemHovered()) final_col = ImGui::GetStyleColorVec4(ImGuiCol_ButtonHovered);
-        if (ImGui::IsItemActive())  final_col = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
+        if (ImGui::IsItemActive()) final_col = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
 
         draw_list->AddCircleFilled(center, diameter * 0.5f, ImGui::ColorConvertFloat4ToU32(final_col), 16);
 
         return ImGui::IsItemClicked();
-	}
+    }
 
 } // namespace ImGuiX::Widgets
 

--- a/include/imguix/widgets/system_button.hpp
+++ b/include/imguix/widgets/system_button.hpp
@@ -74,7 +74,7 @@ namespace ImGuiX::Widgets {
             dl->AddLine(a2, b2, col, thickness);
         } else if (type == SystemButtonType::Minimize) {
             //float y = snap(pos.y + size.y - IMGUIX_SYSBTN_MARGIN - 1.0f);
-			ImVec2 a(snap(c.x - e), snap(c.y + e));
+            ImVec2 a(snap(c.x - e), snap(c.y + e));
             ImVec2 b(snap(c.x + e), snap(c.y + e));
             dl->AddLine(a, b, col, thickness);
         } else if (type == SystemButtonType::Maximize) {


### PR DESCRIPTION
## Summary
- normalize namespace indentation and pointer style across utility and widget headers
- align class inheritance, parameter references, and macros in core font and window headers
- format logging and localization headers for consistent style

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7daa56d2c832c9391245a1206259f