### PR TITLE
docs: clarify font configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,19 @@ After building, open `http://localhost:8081/index.html` in your browser.
 
 ## Fonts and Licensing
 
-For font usage instructions see [FONTS-GUIDE-RU.md](docs/FONTS-GUIDE-RU.md).
+ImGuiX ships with a `FontManager` that can auto-load fonts from a JSON config or
+be configured manually. By default, fonts are read from
+`data/resources/fonts/fonts.json`. For full details see
+[FONTS-GUIDE-RU.md](docs/FONTS-GUIDE-RU.md).
+
+An example manual setup in `WindowInstance::onInit()`:
+
+```cpp
+fontsBeginManual();
+fontsAddBody({ "Roboto-Medium.ttf", 16.0f });
+fontsAddMerge(FontRole::Icons, { "forkawesome-webfont.ttf", 16.0f, true });
+fontsBuildNow();
+```
 
 This repository bundles third-party fonts under their original licenses:
 


### PR DESCRIPTION
## Summary
- document FontManager's JSON auto-loading and manual setup in README

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_INCLUDE_DIR OpenGL))*
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: Could not find UDev library)*
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: windowsx.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e0a9a568832cae58ea55a0fa3b12