### PR TITLE
docs(readme): fix table of contents spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An object-oriented wrapper around [Dear ImGui](https://github.com/ocornut/imgui)
 > **Note:** ImGuiX uses an *MVC-like* architecture. See [Architecture](#architecture) for details.
 
 ## Table of Contents
+
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [SDK Installation](#sdk-installation)


### PR DESCRIPTION
## Summary
- add missing blank line after the Table of Contents heading to ensure proper rendering

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e2bd5284832c80374196256be408