### PR TITLE
refactor(core): rename WindowControl to WindowInterface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,7 +288,7 @@ Format: `type(scope): short description` where the scope is optional. Keep messa
 | -------------- | ------------------------------------------------- |
 | Application    | WindowManager, EventBus, ResourceRegistry, Models |
 | WindowInstance | ApplicationControl, EventBus, Controllers         |
-| Controller     | WindowControl, EventBus, ResourceRegistry         |
+| Controller     | WindowInterface, EventBus, ResourceRegistry       |
 | Model          | ApplicationControl, EventBus, ResourceRegistry    |
 
 ### Glossary

--- a/include/imguix/controllers/ExtendedController.hpp
+++ b/include/imguix/controllers/ExtendedController.hpp
@@ -7,7 +7,7 @@
 
 #include "StrategicController.hpp"
 #include <imguix/core/application/Application.hpp>
-//#include <imguix/core/window/WindowControl.hpp>
+//#include <imguix/core/window/WindowInterface.hpp>
 
 namespace ImGuiX::Controllers {
 

--- a/include/imguix/core.hpp
+++ b/include/imguix/core.hpp
@@ -44,7 +44,7 @@
 
 // --- Controller and model interfaces ---
 #include "core/application/ApplicationControl.hpp" ///< Interface for application access
-#include "core/window/WindowControl.hpp"           ///< Interface for window control
+#include "core/window/WindowInterface.hpp"         ///< Interface for window control
 #include "core/controller/Controller.hpp"          ///< Base interface for controllers
 #include "core/model/Model.hpp"                    ///< Base interface for models
 

--- a/include/imguix/core/controller/Controller.hpp
+++ b/include/imguix/core/controller/Controller.hpp
@@ -9,6 +9,8 @@
 
 namespace ImGuiX {
 
+    class WindowInterface;
+
     /// \brief Base class for controllers that attach to a window.
     /// \note Provides access to window-level context, including event bus and resources.
     /// \note Override `drawContent()` and `drawUi()` to render content and interface.
@@ -16,7 +18,7 @@ namespace ImGuiX {
     public:
         /// \brief Constructs a controller bound to a window.
         /// \param window Reference to associated window control.
-        explicit Controller(WindowControl& window)
+        explicit Controller(WindowInterface& window)
             : EventMediator(window.eventBus()), m_window(window) {}
             
         Controller(const Controller&) = delete;
@@ -50,11 +52,11 @@ namespace ImGuiX {
 
         /// \brief Read-only access to the global options store.
         const OptionsStore::View& options() const {
-            return static_cast<const WindowControl&>(m_window).options();
+            return static_cast<const WindowInterface&>(m_window).options();
         }
-        
+
         /// \brief Returns reference to the associated window control.
-        WindowControl& window() {
+        WindowInterface& window() {
             return m_window;
         }
         
@@ -65,7 +67,7 @@ namespace ImGuiX {
         }
 
     protected:
-        WindowControl& m_window; ///< Controlled window instance.
+        WindowInterface& m_window; ///< Controlled window instance.
     };
 
 } // namespace ImGuiX

--- a/include/imguix/core/window/SfmlWindowInstance.ipp
+++ b/include/imguix/core/window/SfmlWindowInstance.ipp
@@ -69,7 +69,7 @@ namespace ImGuiX {
         m_window.display();
     }
     
-// --- WindowControl interface ---
+// --- WindowInterface interface ---
 
     void WindowInstance::setSize(int w, int h) {
         m_width = w;

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -24,6 +24,8 @@
 #    include "imgui_glsl_version.hpp"
 #endif
 
+#include "WindowInterface.hpp"
+
 #ifndef IMGUIX_CONFIG_DIR
 #    define IMGUIX_CONFIG_DIR "data/config"
 #endif
@@ -35,7 +37,7 @@ namespace ImGuiX {
     /// Combines event handling, rendering, and controller orchestration.
     /// Derive from this class to implement platform-specific windows.
     class WindowInstance :
-        public WindowControl,
+        private WindowInterface,
         public Pubsub::EventMediator {
     public:
         /// \brief Constructs the window with a unique ID and name.
@@ -82,7 +84,7 @@ namespace ImGuiX {
         template <typename ControllerType, typename... Args>
         ControllerType& createController(Args&&... args);
 
-        // --- WindowControl interface ---
+        // --- WindowInterface interface ---
 
         /// \brief Returns the unique ID of this window.
         int id() const override;

--- a/include/imguix/core/window/WindowInstance.ipp
+++ b/include/imguix/core/window/WindowInstance.ipp
@@ -29,13 +29,15 @@ namespace ImGuiX {
         static_assert(std::is_base_of<Controller, ControllerType>::value,
                       "ControllerType must derive from Controller");
 
-        auto ctrl = std::make_unique<ControllerType>(*this, std::forward<Args>(args)...);
+        auto ctrl = std::make_unique<ControllerType>(
+            static_cast<WindowInterface&>(*this),
+            std::forward<Args>(args)...);
         ControllerType& ref = *ctrl;
         m_controllers.push_back(std::move(ctrl));
         return ref;
     }
 
-// --- WindowControl interface ---
+// --- WindowInterface interface ---
 
     int WindowInstance::id() const {
         return m_window_id;

--- a/include/imguix/core/window/WindowInterface.hpp
+++ b/include/imguix/core/window/WindowInterface.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#ifndef _IMGUIX_CORE_WINDOW_CONTROL_HPP_INCLUDED
-#define _IMGUIX_CORE_WINDOW_CONTROL_HPP_INCLUDED
+#ifndef _IMGUIX_CORE_WINDOW_INTERFACE_HPP_INCLUDED
+#define _IMGUIX_CORE_WINDOW_INTERFACE_HPP_INCLUDED
 
-/// \file WindowControl.hpp
+/// \file WindowInterface.hpp
 /// \brief Interface for controlling and querying a single window instance.
 
 #ifdef IMGUIX_USE_SFML_BACKEND
@@ -20,9 +20,9 @@ namespace ImGuiX {
     /// - Geometry (size, visibility, active state)
     /// - Window state (open, minimized, maximized)
     /// - Global services (event bus, resource registry)
-    class WindowControl {
+    class WindowInterface {
     public:
-        virtual ~WindowControl() = default;
+        virtual ~WindowInterface() = default;
 
         /// \brief Returns unique window ID.
         /// \return Window identifier.
@@ -123,4 +123,4 @@ namespace ImGuiX {
 
 } // namespace ImGuiX
 
-#endif // _IMGUIX_CORE_WINDOW_CONTROL_HPP_INCLUDED
+#endif // _IMGUIX_CORE_WINDOW_INTERFACE_HPP_INCLUDED

--- a/tests/imgui-i18n-test.cpp
+++ b/tests/imgui-i18n-test.cpp
@@ -54,7 +54,7 @@ bool LoadFonts(float px) {
 
 class I18nController : public ImGuiX::Controller {
 public:
-    I18nController(ImGuiX::WindowControl& window)
+    I18nController(ImGuiX::WindowInterface& window)
         : Controller(window) {}
 
     void drawContent() override {

--- a/tests/test-core-application.cpp
+++ b/tests/test-core-application.cpp
@@ -63,7 +63,7 @@ private:
 /// \brief Controller that draws a button in ImGui and a circle using SFML.
 class DemoController : public ImGuiX::Controller {
 public:
-    DemoController(ImGuiX::WindowControl& window, ImGuiX::Application& app)
+    DemoController(ImGuiX::WindowInterface& window, ImGuiX::Application& app)
         : Controller(window), m_app(app) {
         subscribe<SecondsElapsedEvent>();
     }


### PR DESCRIPTION
## Summary
- rename WindowControl interface to WindowInterface
- update controllers and window implementation to use WindowInterface
- adjust WindowInstance to inherit privately and cast explicitly

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_BUILD_TESTS=OFF` *(fails: Cannot find source file libs/imgui/imgui.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68a7efb6f7ac832cb30c44f4784fefbf