### PR TITLE
refactor(core): rename ApplicationControl to ApplicationContext

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,9 +287,9 @@ Format: `type(scope): short description` where the scope is optional. Keep messa
 | Module         | Depends On                                        |
 | -------------- | ------------------------------------------------- |
 | Application    | WindowManager, EventBus, ResourceRegistry, Models |
-| WindowInstance | ApplicationControl, EventBus, Controllers         |
+| WindowInstance | ApplicationContext, EventBus, Controllers         |
 | Controller     | WindowInterface, EventBus, ResourceRegistry       |
-| Model          | ApplicationControl, EventBus, ResourceRegistry    |
+| Model          | ApplicationContext, EventBus, ResourceRegistry    |
 
 ### Glossary
 

--- a/include/imguix/controllers/ApplicationController.hpp
+++ b/include/imguix/controllers/ApplicationController.hpp
@@ -18,7 +18,7 @@ namespace ImGuiX::Controllers {
 
         /// \brief Get owning Application instance.
         /// \return Application reference.
-        /// \note Internally casts the window's `ApplicationControl` to `Application`.
+        /// \note Internally casts the window's `ApplicationContext` to `Application`.
         Application& application() {
             return static_cast<Application&>(window().application());
         }

--- a/include/imguix/core.hpp
+++ b/include/imguix/core.hpp
@@ -43,7 +43,7 @@
 #include "core/resource/ResourceRegistry.hpp"      ///< Global registry for shared resources
 
 // --- Controller and model interfaces ---
-#include "core/application/ApplicationControl.hpp" ///< Interface for application access
+#include "core/application/ApplicationContext.hpp" ///< Interface for application access
 #include "core/window/WindowInterface.hpp"         ///< Interface for window control
 #include "core/controller/Controller.hpp"          ///< Base interface for controllers
 #include "core/model/Model.hpp"                    ///< Base interface for models

--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -13,7 +13,7 @@ namespace ImGuiX {
     /// \brief Main application class.
     ///
     /// Controls window lifecycle, global event dispatching, and the main loop.
-    class Application : public ApplicationControl {
+    class Application : public ApplicationContext {
     public:
         /// \brief Constructs the application instance.
         Application();

--- a/include/imguix/core/application/Application.ipp
+++ b/include/imguix/core/application/Application.ipp
@@ -12,7 +12,7 @@ namespace ImGuiX {
 
     Application::Application()
         : m_event_bus(), m_registry(),
-          m_window_manager(*static_cast<ApplicationControl*>(this)) {
+          m_window_manager(*static_cast<ApplicationContext*>(this)) {
         m_registry.registerResource<OptionsStore>([] {
             return std::make_shared<OptionsStore>(
                     std::string(IMGUIX_CONFIG_DIR) + "/options.json",

--- a/include/imguix/core/application/ApplicationContext.hpp
+++ b/include/imguix/core/application/ApplicationContext.hpp
@@ -1,18 +1,18 @@
 #pragma once
-#ifndef _IMGUIX_CORE_APPLICATION_CONTROL_HPP_INCLUDED
-#define _IMGUIX_CORE_APPLICATION_CONTROL_HPP_INCLUDED
+#ifndef _IMGUIX_CORE_APPLICATION_CONTEXT_HPP_INCLUDED
+#define _IMGUIX_CORE_APPLICATION_CONTEXT_HPP_INCLUDED
 
-/// \file ApplicationControl.hpp
-/// \brief Interface for application-level control and global services.
+/// \file ApplicationContext.hpp
+/// \brief Interface for application-level context and global services.
 
 namespace ImGuiX {
 
-    /// \brief Interface for application-level control and global services.
+    /// \brief Interface for application-level context and global services.
     /// \note Allows components to interact with core application functionality without tight coupling.
     /// \note Provides access to closing application, application name, event bus, and resource registry.
-    class ApplicationControl {
+    class ApplicationContext {
     public:
-        virtual ~ApplicationControl() = default;
+        virtual ~ApplicationContext() = default;
 
         /// \brief Requests the application to close gracefully.
         virtual void close() = 0;
@@ -36,4 +36,4 @@ namespace ImGuiX {
 
 } // namespace ImGuiX
 
-#endif // _IMGUIX_CORE_APPLICATION_CONTROL_HPP_INCLUDED
+#endif // _IMGUIX_CORE_APPLICATION_CONTEXT_HPP_INCLUDED

--- a/include/imguix/core/model/Model.hpp
+++ b/include/imguix/core/model/Model.hpp
@@ -14,8 +14,8 @@ namespace ImGuiX {
     class Model : public Pubsub::EventMediator {
     public:
         /// \brief Constructs the model bound to the application.
-        /// \param app Reference to the ApplicationControl interface.
-        explicit Model(ApplicationControl& app)
+        /// \param app Reference to the ApplicationContext interface.
+        explicit Model(ApplicationContext& app)
             : EventMediator(app.eventBus()), m_app(app) {}
             
         Model(const Model&) = delete;
@@ -61,7 +61,7 @@ namespace ImGuiX {
         void notify(const Pubsub::Event&) const = delete;
 
     protected:
-        ApplicationControl& m_app; ///< Reference to the owning application.
+        ApplicationContext& m_app; ///< Reference to the owning application.
     };
 
 } // namespace ImGuiX

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -42,9 +42,9 @@ namespace ImGuiX {
     public:
         /// \brief Constructs the window with a unique ID and name.
         /// \param id Unique window identifier.
-        /// \param app Reference to application control interface.
+        /// \param app Reference to application context interface.
         /// \param name Window name (title).
-        explicit WindowInstance(int id, ApplicationControl& app, std::string name);
+        explicit WindowInstance(int id, ApplicationContext& app, std::string name);
         
         WindowInstance(const WindowInstance&) = delete;
         WindowInstance& operator=(WindowInstance) = delete;
@@ -156,7 +156,7 @@ namespace ImGuiX {
         const OptionsStore::View& options() const override;
 
         /// \brief Reference to the owning application.
-        ApplicationControl& application() override;
+        ApplicationContext& application() override;
 
 #       ifdef IMGUIX_USE_SFML_BACKEND
         sf::RenderWindow& getRenderTarget() override;
@@ -266,7 +266,7 @@ namespace ImGuiX {
         bool m_is_open = false;             ///< Whether the window is currently open.
         bool m_is_visible = true;           ///< Visibility flag.
 
-        ApplicationControl& m_application;  ///< Reference to the owning application.
+        ApplicationContext& m_application;  ///< Reference to the owning application.
         std::vector<std::unique_ptr<Controller>> m_controllers; ///< Attached controllers.
         std::string m_ini_path;             ///< Path to the window-specific ImGui ini file.
         bool m_is_ini_once = false;         ///< Ensures imgui ini is saved only once.

--- a/include/imguix/core/window/WindowInstance.ipp
+++ b/include/imguix/core/window/WindowInstance.ipp
@@ -3,7 +3,7 @@
 
 namespace ImGuiX {
 
-    WindowInstance::WindowInstance(int id, ApplicationControl& app, std::string name)
+    WindowInstance::WindowInstance(int id, ApplicationContext& app, std::string name)
         : EventMediator(app.eventBus()),
           m_window_id(id),
           m_window_name(std::move(name)),
@@ -71,7 +71,7 @@ namespace ImGuiX {
         return m_application.registry().getResource<OptionsStore>().view();
     }
     
-    ApplicationControl& WindowInstance::application() {
+    ApplicationContext& WindowInstance::application() {
         return m_application;
     }
     

--- a/include/imguix/core/window/WindowInterface.hpp
+++ b/include/imguix/core/window/WindowInterface.hpp
@@ -108,8 +108,8 @@ namespace ImGuiX {
         virtual const OptionsStore::View& options() const = 0;
         
         /// \brief Returns the owning application interface.
-        /// \return Reference to ApplicationControl.
-        virtual ApplicationControl& application() = 0;
+        /// \return Reference to ApplicationContext.
+        virtual ApplicationContext& application() = 0;
 
 #       ifdef IMGUIX_USE_SFML_BACKEND
         virtual sf::RenderWindow& getRenderTarget() = 0;

--- a/include/imguix/core/window/WindowManager.hpp
+++ b/include/imguix/core/window/WindowManager.hpp
@@ -13,8 +13,8 @@ namespace ImGuiX {
     class WindowManager : public Pubsub::EventMediator {
     public:
         /// \brief Construct window manager with access to the application.
-        /// \param app Reference to application control interface.
-        explicit WindowManager(ApplicationControl& app);
+        /// \param app Reference to application context interface.
+        explicit WindowManager(ApplicationContext& app);
 
         /// \brief Destructor. Unsubscribe from all events.
         virtual ~WindowManager() = default;
@@ -89,7 +89,7 @@ namespace ImGuiX {
         std::vector<std::unique_ptr<WindowInstance>> m_windows;      ///< Managed windows.
         std::vector<std::unique_ptr<WindowInstance>> m_pending_add;  ///< Newly created windows waiting to be added.
         std::vector<WindowInstance*> m_pending_init;                 ///< Windows pending initialization.
-        ApplicationControl&          m_application;                  ///< Reference to the owning application.
+        ApplicationContext&          m_application;                  ///< Reference to the owning application.
         std::deque<Events::LangChangeEvent> m_lang_events;           ///< Queued language change events.
         int                          m_ini_save_frame_counter{0};    ///< Frame counter for ini saving.
         static constexpr int         m_ini_save_interval{300};       ///< Frames between ini saves.

--- a/include/imguix/core/window/WindowManager.ipp
+++ b/include/imguix/core/window/WindowManager.ipp
@@ -2,7 +2,7 @@
 
 namespace ImGuiX {
 
-    WindowManager::WindowManager(ApplicationControl& app)
+    WindowManager::WindowManager(ApplicationContext& app)
         : EventMediator(app.eventBus()), m_application(app) {
         subscribe<Events::ApplicationExitEvent>();
         subscribe<Events::LangChangeEvent>();

--- a/include/imguix/windows/ImGuiFramedWindow.hpp
+++ b/include/imguix/windows/ImGuiFramedWindow.hpp
@@ -35,7 +35,7 @@ namespace ImGuiX::Windows {
         /// \param config    Configuration parameters.
         ImGuiFramedWindow(
             int id,
-            ApplicationControl& app,
+            ApplicationContext& app,
             std::string name,
             std::string title,
             WindowFlags flags =

--- a/include/imguix/windows/ImGuiFramedWindow.ipp
+++ b/include/imguix/windows/ImGuiFramedWindow.ipp
@@ -6,7 +6,7 @@ namespace ImGuiX::Windows {
     
     ImGuiFramedWindow::ImGuiFramedWindow(
             int id, 
-            ApplicationControl& app, 
+            ApplicationContext& app,
             std::string name,
             std::string title,
             WindowFlags flags, 

--- a/tests/imgui-i18n-test.cpp
+++ b/tests/imgui-i18n-test.cpp
@@ -167,7 +167,7 @@ private:
 class I18nWindow : public ImGuiX::WindowInstance {
 public:
     I18nWindow(int id, 
-               ImGuiX::ApplicationControl& app, 
+               ImGuiX::ApplicationContext& app,
                std::string name)
         : WindowInstance(id, app, std::move(name)) {}
 

--- a/tests/test-core-application.cpp
+++ b/tests/test-core-application.cpp
@@ -113,7 +113,7 @@ private:
 class DemoWindow : public ImGuiX::WindowInstance {
 public:
 
-    DemoWindow(int id, ImGuiX::ApplicationControl& app, std::string name)
+    DemoWindow(int id, ImGuiX::ApplicationContext& app, std::string name)
         : WindowInstance(id, app, std::move(name)) {
     }
 
@@ -156,7 +156,7 @@ public:
 
 class DemoWindow : public ImGuiX::WindowInstance {
 public:
-    DemoWindow(int id, ImGuiX::ApplicationControl& app, std::string name)
+    DemoWindow(int id, ImGuiX::ApplicationContext& app, std::string name)
         : WindowInstance(id, app, std::move(name)) {}
 
     void onInit() override {
@@ -194,7 +194,7 @@ public:
 
 class DemoWindow : public ImGuiX::WindowInstance {
 public:
-    DemoWindow(int id, ImGuiX::ApplicationControl& app, std::string name)
+    DemoWindow(int id, ImGuiX::ApplicationContext& app, std::string name)
         : WindowInstance(id, app, std::move(name)) {}
 
     void onInit() override {
@@ -230,7 +230,7 @@ public:
 /// \brief Simple window with ticking and rendering.
 class DummyWindow : public ImGuiX::WindowInstance {
 public:
-    DummyWindow(int id, std::string name, ImGuiX::ApplicationControl& app)
+    DummyWindow(int id, std::string name, ImGuiX::ApplicationContext& app)
         : WindowInstance(id, std::move(name), app) {}
 };
 

--- a/tests/test-framed-window.cpp
+++ b/tests/test-framed-window.cpp
@@ -45,7 +45,7 @@ class DemoFramedWindow : public ImGuiX::Windows::ImGuiFramedWindow {
 public:
     using WindowFlags = ImGuiX::Windows::WindowFlags;
 
-    DemoFramedWindow(int id, ImGuiX::ApplicationControl& app, std::string name, std::string title)
+    DemoFramedWindow(int id, ImGuiX::ApplicationContext& app, std::string name, std::string title)
         : ImGuiFramedWindow(id, app, std::move(name), std::move(title),
             WindowFlags::HasMenuBar |
             WindowFlags::DefaultControlButtons) {}


### PR DESCRIPTION
## Summary
- rename `ApplicationControl` interface to `ApplicationContext`
- update includes, documentation, and tests to use `ApplicationContext`

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f519e15c832c92d02d5529bf5340