### PR TITLE
refactor(core): centralize window/model creation

### DIFF
--- a/include/imguix/controllers/ApplicationController.hpp
+++ b/include/imguix/controllers/ApplicationController.hpp
@@ -3,33 +3,27 @@
 #define _IMGUIX_CONTROLLERS_APPLICATION_CONTROLLER_HPP_INCLUDED
 
 /// \file ApplicationController.hpp
-/// \brief Controller with direct access to the owning Application instance.
+/// \brief Controller with convenience helpers for accessing the application context.
 
 #include <imguix/core/controller/Controller.hpp>
-#include <imguix/core/application/Application.hpp>
+#include <imguix/core/application/ApplicationContext.hpp>
 
 namespace ImGuiX::Controllers {
 
-    /// \brief Controller that provides convenient access to the Application instance.
-    /// \note Offers helper methods to access the `Application` object and create windows.
+    /// \brief Controller that provides convenient access to the application context.
+    /// \note Offers helper method to create new windows.
     class ApplicationController : public Controller {
     public:
         using Controller::Controller;
-
-        /// \brief Get owning Application instance.
-        /// \return Application reference.
-        /// \note Internally casts the window's `ApplicationContext` to `Application`.
-        Application& application() {
-            return static_cast<Application&>(window().application());
-        }
 
         /// \brief Create and register a window of the specified type.
         /// \tparam WindowType Type derived from `WindowInstance`.
         /// \tparam Args Arguments forwarded to the constructor of the window.
         /// \return Reference to the created window.
-        template <typename WindowType, typename... Args>
+        template<class WindowType, class... Args>
         WindowType& createWindow(Args&&... args) {
-            return application().createWindow<WindowType>(std::forward<Args>(args)...);
+            return window().application().createWindow<WindowType>(
+                    std::forward<Args>(args)...);
         }
     };
 

--- a/include/imguix/controllers/ExtendedController.hpp
+++ b/include/imguix/controllers/ExtendedController.hpp
@@ -6,13 +6,10 @@
 /// \brief Extended controller that combines child and strategy controllers with access to the application context.
 
 #include "StrategicController.hpp"
-#include <imguix/core/application/Application.hpp>
-//#include <imguix/core/window/WindowInterface.hpp>
 
 namespace ImGuiX::Controllers {
 
-    /// \brief Extended controller with convenient access to the Application instance.
-    /// \note Provides utility methods such as `application()` and `createWindow()`.
+    /// \brief Extended controller with convenient access to window creation helpers.
     class ExtendedController : public StrategicController {
     public:
         using StrategicController::StrategicController;

--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -31,22 +31,6 @@ namespace ImGuiX {
         /// \param async If true, runs the main loop in a separate thread.
         void run(bool async = false);
 
-        /// \brief Creates a new window instance of the specified type.
-        /// \tparam T Type derived from WindowInstance.
-        /// \tparam Args Arguments forwarded to the window constructor.
-        /// \param args Constructor arguments.
-        /// \return Reference to the created window instance.
-        template<typename T, typename... Args>
-        T& createWindow(Args&&... args);
-        
-        /// \brief Creates and registers a model.
-        /// \tparam T Class derived from Model.
-        /// \tparam Args Arguments forwarded to the constructor.
-        /// \param args Constructor arguments.
-        /// \return Reference to the created model.
-        template<typename T, typename... Args>
-        T& createModel(Args&&... args);
-
         /// \brief Returns the global event bus.
         /// \return Reference to the event bus.
         Pubsub::EventBus& eventBus() override;
@@ -65,6 +49,10 @@ namespace ImGuiX {
         /// \brief Returns the application name.
         /// \return Reference to the name string.
         const std::string& name() const override;
+
+    protected:
+        WindowInstance& createWindowImpl(WindowFactory factory) override;
+        Model& createModelImpl(ModelFactory factory) override;
 
     private:
         Pubsub::EventBus m_event_bus;                 ///< Global event bus.

--- a/include/imguix/core/application/Application.ipp
+++ b/include/imguix/core/application/Application.ipp
@@ -49,28 +49,18 @@ namespace ImGuiX {
         }
 #endif
     }
-
-    template<typename T, typename... Args>
-    T& Application::createWindow(Args&&... args) {
-        static_assert(std::is_base_of<WindowInstance, T>::value,
-                      "T must derive from WindowInstance");
-
+    WindowInstance& Application::createWindowImpl(WindowFactory factory) {
         int id = m_next_window_id++;
-
-        auto window = std::make_unique<T>(id, *this,
-                                          std::forward<Args>(args)...);
-        T& ref = *window;
-
+        auto window = factory(id);
+        WindowInstance& ref = *window;
         m_window_manager.addWindow(std::move(window));
         return ref;
     }
-    
-    template<typename T, typename... Args>
-    T& Application::createModel(Args&&... args) {
-        static_assert(std::is_base_of<Model, T>::value, "T must be derived from Model");
-        auto model = std::make_unique<T>(*this, std::forward<Args>(args)...);
-        T& ref = *model;
-        m_pending_models.push_back(model.get());
+
+    Model& Application::createModelImpl(ModelFactory factory) {
+        auto model = factory();
+        Model& ref = *model;
+        m_pending_models.push_back(&ref);
         m_models.emplace_back(std::move(model));
         return ref;
     }

--- a/include/imguix/core/application/ApplicationContext.hpp
+++ b/include/imguix/core/application/ApplicationContext.hpp
@@ -5,7 +5,15 @@
 /// \file ApplicationContext.hpp
 /// \brief Interface for application-level context and global services.
 
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
 namespace ImGuiX {
+
+    class WindowInstance;
+    class Model;
 
     /// \brief Interface for application-level context and global services.
     /// \note Allows components to interact with core application functionality without tight coupling.
@@ -13,6 +21,41 @@ namespace ImGuiX {
     class ApplicationContext {
     public:
         virtual ~ApplicationContext() = default;
+
+        /// \brief Create and register a window of the specified type.
+        /// \tparam WindowType Type derived from WindowInstance.
+        /// \tparam Args Arguments forwarded to the constructor.
+        /// \param args Constructor arguments.
+        /// \return Reference to the created window.
+        template<class WindowType, class... Args>
+        WindowType& createWindow(Args&&... args) {
+            static_assert(std::is_base_of_v<WindowInstance, WindowType>,
+                    "WindowType must derive from WindowInstance");
+            auto factory = [&, this](int id) {
+                return std::make_unique<WindowType>(
+                        id,
+                        *this,
+                        std::forward<Args>(args)...);
+            };
+            return static_cast<WindowType&>(createWindowImpl(factory));
+        }
+
+        /// \brief Create and register a model of the specified type.
+        /// \tparam ModelType Type derived from Model.
+        /// \tparam Args Arguments forwarded to the constructor.
+        /// \param args Constructor arguments.
+        /// \return Reference to the created model.
+        template<class ModelType, class... Args>
+        ModelType& createModel(Args&&... args) {
+            static_assert(std::is_base_of_v<Model, ModelType>,
+                    "ModelType must derive from Model");
+            auto factory = [&, this]() {
+                return std::make_unique<ModelType>(
+                        *this,
+                        std::forward<Args>(args)...);
+            };
+            return static_cast<ModelType&>(createModelImpl(factory));
+        }
 
         /// \brief Requests the application to close gracefully.
         virtual void close() = 0;
@@ -32,8 +75,23 @@ namespace ImGuiX {
         /// \brief Provides access to the global resource registry.
         /// \return Reference to the resource registry.
         virtual ResourceRegistry& registry() = 0;
+
+    protected:
+        using WindowFactory = std::function<std::unique_ptr<WindowInstance>(int)>;
+        using ModelFactory  = std::function<std::unique_ptr<Model>()>;
+
+        /// \brief Implementation hook for window creation.
+        /// \param factory Factory functor constructing the window.
+        /// \return Reference to the created window.
+        virtual WindowInstance& createWindowImpl(WindowFactory factory) = 0;
+
+        /// \brief Implementation hook for model creation.
+        /// \param factory Factory functor constructing the model.
+        /// \return Reference to the created model.
+        virtual Model& createModelImpl(ModelFactory factory) = 0;
     };
 
 } // namespace ImGuiX
 
 #endif // _IMGUIX_CORE_APPLICATION_CONTEXT_HPP_INCLUDED
+


### PR DESCRIPTION
## Summary
- forward window/model creation through ApplicationContext templates
- override creation hooks in Application for registration logic
- drop Application downcasts in controllers when creating windows

## Testing
- `cmake -S . -B build` *(failed: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f787832c832cac941f7b80f1d46b