### PR TITLE
refactor: prefix UTF-8 string literals

### DIFF
--- a/include/imguix/controllers/ExtendedController.hpp
+++ b/include/imguix/controllers/ExtendedController.hpp
@@ -21,7 +21,7 @@ namespace ImGuiX::Controllers {
         template <typename ControllerType, typename... Args>
         ControllerType& createChildrenController(Args&&... args) {
             static_assert(std::is_base_of<Controller, ControllerType>::value,
-                          "ControllerType must derive from Controller");
+                          u8"ControllerType must derive from Controller");
 
             auto ctrl = std::make_unique<ControllerType>(window(), std::forward<Args>(args)...);
             ControllerType& ref = *ctrl;

--- a/include/imguix/controllers/StrategicController.hpp
+++ b/include/imguix/controllers/StrategicController.hpp
@@ -28,7 +28,7 @@ namespace ImGuiX::Controllers {
         template <typename Key, typename ControllerType, typename... Args>
         ControllerType& createStrategyController(Key key, Args&&... args) {
             static_assert(std::is_base_of<Controller, ControllerType>::value,
-                          "ControllerType must derive from Controller");
+                          u8"ControllerType must derive from Controller");
 
             auto ctrl = std::make_unique<ControllerType>(window(), std::forward<Args>(args)...);
             ControllerType& ref = *ctrl;

--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -63,7 +63,7 @@ namespace ImGuiX {
         std::atomic<bool> m_is_ini_once{false};        ///< Ensures imgui ini is saved only once.
 
         std::atomic<int> m_next_window_id{0};          ///< Incremental ID for new windows.
-        std::string m_app_name = "ImGuiX Application"; ///< Application name string.
+        std::string m_app_name = u8"ImGuiX Application"; ///< Application name string.
         std::vector<std::unique_ptr<Model>> m_models;  ///< Owned model objects.
         std::vector<Model*> m_pending_models;          ///< Models waiting for initialization.
 

--- a/include/imguix/core/application/Application.ipp
+++ b/include/imguix/core/application/Application.ipp
@@ -3,7 +3,7 @@
 #endif
 
 #ifndef IMGUIX_CONFIG_DIR
-#   define IMGUIX_CONFIG_DIR "data/config"
+#   define IMGUIX_CONFIG_DIR u8"data/config"
 #endif
 
 namespace ImGuiX {
@@ -13,7 +13,7 @@ namespace ImGuiX {
           m_window_manager(*static_cast<ApplicationContext*>(this)) {
         m_registry.registerResource<OptionsStore>([] {
             return std::make_shared<OptionsStore>(
-                    std::string(IMGUIX_CONFIG_DIR) + "/options.json",
+                    std::string(IMGUIX_CONFIG_DIR) + u8"/options.json",
                     0.5);
         });
     }
@@ -21,7 +21,7 @@ namespace ImGuiX {
     void Application::run(bool async) {
 #       ifdef IMGUIX_USE_SFML_BACKEND
         if (!registry().registerResource<DeltaClockSfml>()) {
-            throw std::runtime_error("Failed to register DeltaClockSfml resource");
+            throw std::runtime_error(u8"Failed to register DeltaClockSfml resource");
         }
 #       endif
 

--- a/include/imguix/core/application/ApplicationContext.hpp
+++ b/include/imguix/core/application/ApplicationContext.hpp
@@ -30,7 +30,7 @@ namespace ImGuiX {
         template<class WindowType, class... Args>
         WindowType& createWindow(Args&&... args) {
             static_assert(std::is_base_of_v<WindowInstance, WindowType>,
-                    "WindowType must derive from WindowInstance");
+                    u8"WindowType must derive from WindowInstance");
             auto factory = [&, this](int id) {
                 return std::make_unique<WindowType>(
                         id,
@@ -48,7 +48,7 @@ namespace ImGuiX {
         template<class ModelType, class... Args>
         ModelType& createModel(Args&&... args) {
             static_assert(std::is_base_of_v<Model, ModelType>,
-                    "ModelType must derive from Model");
+                    u8"ModelType must derive from Model");
             auto factory = [&, this]() {
                 return std::make_unique<ModelType>(
                         *this,

--- a/include/imguix/core/events/ApplicationExitEvent.hpp
+++ b/include/imguix/core/events/ApplicationExitEvent.hpp
@@ -17,7 +17,7 @@ namespace ImGuiX::Events {
         }
 
         const char* name() const override {
-            return "ApplicationExitEvent";
+            return u8"ApplicationExitEvent";
         }
     };
 

--- a/include/imguix/core/events/LangChangeEvent.hpp
+++ b/include/imguix/core/events/LangChangeEvent.hpp
@@ -42,7 +42,7 @@ namespace ImGuiX::Events {
         }
 
         const char* name() const override {
-            return "LangChangeEvent";
+            return u8"LangChangeEvent";
         }
     };
 

--- a/include/imguix/core/events/LogEvent.hpp
+++ b/include/imguix/core/events/LogEvent.hpp
@@ -27,19 +27,19 @@ namespace ImGuiX::Events {
     inline const char *levelToCStr(LogLevel level) noexcept {
       switch (level) {
       case LogLevel::Trace:
-        return "TRACE";
+        return u8"TRACE";
       case LogLevel::Debug:
-        return "DEBUG";
+        return u8"DEBUG";
       case LogLevel::Info:
-        return "INFO";
+        return u8"INFO";
       case LogLevel::Warn:
-        return "WARN";
+        return u8"WARN";
       case LogLevel::Error:
-        return "ERROR";
+        return u8"ERROR";
       case LogLevel::Fatal:
-        return "FATAL";
+        return u8"FATAL";
       }
-      return "UNKNOWN";
+      return u8"UNKNOWN";
     }
 
     /// \brief Event containing log message and source metadata.
@@ -58,7 +58,7 @@ namespace ImGuiX::Events {
 
       std::type_index type() const override { return typeid(LogEvent); }
 
-      const char *name() const override { return "LogEvent"; }
+      const char *name() const override { return u8"LogEvent"; }
     };
 
 } // namespace ImGuiX::Events

--- a/include/imguix/core/events/WindowClosedEvent.hpp
+++ b/include/imguix/core/events/WindowClosedEvent.hpp
@@ -21,7 +21,7 @@ namespace ImGuiX::Events {
         }
 
         const char* name() const override {
-            return "WindowClosedEvent";
+            return u8"WindowClosedEvent";
         }
     };
 

--- a/include/imguix/core/fonts/FontManager.hpp
+++ b/include/imguix/core/fonts/FontManager.hpp
@@ -173,8 +173,8 @@ namespace ImGuiX::Fonts {
         bool m_auto_init = true;
         bool m_dirty = true;
 
-        std::string m_config_path = "data/resources/fonts/fonts.json";
-        std::string m_active_locale = "default";
+        std::string m_config_path = u8"data/resources/fonts/fonts.json";
+        std::string m_active_locale = u8"default";
 
         // Markdown sizes (px @ 96 DPI)
         float m_px_body = 16.0f;

--- a/include/imguix/core/fonts/FontManager.ipp
+++ b/include/imguix/core/fonts/FontManager.ipp
@@ -151,29 +151,29 @@ namespace ImGuiX::Fonts {
 
         // Latin-based locales already covered by Default()
         // Add Cyrillic
-        if (locale == "ru" || 
-            locale == "uk" ||
-            locale == "bg" || 
-            locale == "kk" ||
-            locale == "sr") {
+        if (locale == u8"ru" || 
+            locale == u8"uk" ||
+            locale == u8"bg" || 
+            locale == u8"kk" ||
+            locale == u8"sr") {
             b.AddRanges(io.Fonts->GetGlyphRangesCyrillic());
         }
 
         // Vietnamese
-        if (locale == "vi") b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
+        if (locale == u8"vi") b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
 
         // CJK (careful: large)
-        if (locale == "ja")
+        if (locale == u8"ja")
             b.AddRanges(io.Fonts->GetGlyphRangesJapanese());
-        else if (locale == "zh" || locale == "zh-CN" || locale == "zh-TW")
+        else if (locale == u8"zh" || locale == u8"zh-CN" || locale == u8"zh-TW")
             b.AddRanges(io.Fonts->GetGlyphRangesChineseFull());
-        else if (locale == "ko")
+        else if (locale == u8"ko")
             b.AddRanges(io.Fonts->GetGlyphRangesKorean());
 
         // RTL (Arabic/Hebrew) – ImGui does not provide built-ins for all subsets;
         // user usually supplies proper ranges via JSON LocalePack::ranges or custom
         // font files.
-        if (locale == "ar" || locale == "fa" || locale == "he") {
+        if (locale == u8"ar" || locale == u8"fa" || locale == u8"he") {
             // Leave to JSON-provided ranges; if absent, fallback stays Latin-only.
             // You may add custom ranges here if you ship appropriate fonts.
         }
@@ -194,14 +194,14 @@ namespace ImGuiX::Fonts {
             if (!cur.empty()) out.push_back(cur); return out;
         };
         for (auto tok : split(spec)) {
-            if (tok == "Default")          b.AddRanges(io.Fonts->GetGlyphRangesDefault());
-            else if (tok == "Cyrillic")    b.AddRanges(io.Fonts->GetGlyphRangesCyrillic());
-            else if (tok == "Vietnamese")  b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
-            else if (tok == "Japanese" || tok == "JapaneseFull") b.AddRanges(io.Fonts->GetGlyphRangesJapanese());
-            else if (tok == "Chinese"  || tok == "ChineseFull")  b.AddRanges(io.Fonts->GetGlyphRangesChineseFull());
-            else if (tok == "Korean")      b.AddRanges(io.Fonts->GetGlyphRangesKorean());
-            else if (tok == "Punct")       b.AddText(u8"–—…•“”‘’");
-            else if (tok == "PUA" || tok == "Icons" || tok == "PrivateUse") {
+            if (tok == u8"Default")          b.AddRanges(io.Fonts->GetGlyphRangesDefault());
+            else if (tok == u8"Cyrillic")    b.AddRanges(io.Fonts->GetGlyphRangesCyrillic());
+            else if (tok == u8"Vietnamese")  b.AddRanges(io.Fonts->GetGlyphRangesVietnamese());
+            else if (tok == u8"Japanese" || tok == u8"JapaneseFull") b.AddRanges(io.Fonts->GetGlyphRangesJapanese());
+            else if (tok == u8"Chinese"  || tok == u8"ChineseFull")  b.AddRanges(io.Fonts->GetGlyphRangesChineseFull());
+            else if (tok == u8"Korean")      b.AddRanges(io.Fonts->GetGlyphRangesKorean());
+            else if (tok == u8"Punct")       b.AddText(u8"–—…•“”‘’");
+            else if (tok == u8"PUA" || tok == u8"Icons" || tok == u8"PrivateUse") {
                 static const ImWchar kPUA[] = { 0xE000, 0xF8FF, 0 };
                 b.AddRanges(kPUA);
             }
@@ -344,7 +344,7 @@ namespace ImGuiX::Fonts {
         if (!m_manual.active) {
             auto it = m_packs.find(m_active_locale);
             if (it == m_packs.end()) {
-                auto it2 = m_packs.find("default");
+                auto it2 = m_packs.find(u8"default");
                 if (it2 != m_packs.end()) pack_ptr = &it2->second;
             } else {
                 pack_ptr = &it->second;
@@ -442,7 +442,7 @@ namespace ImGuiX::Fonts {
                     vec[i].merge;
                 ImFont *f = addFontFile(vec[i], m_params, ranges, base_dir_abs, local);
                 if (!f) {
-                    br.message = "Failed to load font: " + vec[i].path;
+                    br.message = u8"Failed to load font: " + vec[i].path;
                 }
                 last = f;
             }
@@ -453,7 +453,7 @@ namespace ImGuiX::Fonts {
         auto add_single = [&](FontRole role, const FontFile &ff) -> ImFont * {
             ImFont *f = addFontFile(ff, m_params, ranges, base_dir_abs, cfg);
             if (f) m_fonts[role] = f;
-            else br.message = "Failed to load font: " + ff.path;
+            else br.message = u8"Failed to load font: " + ff.path;
             return f;
         };
 
@@ -534,12 +534,12 @@ namespace ImGuiX::Fonts {
         // If still no Body, try a minimal fallback (Roboto + Icons) using base_dir
         if (!body) {
           FontFile fb{};
-          fb.path = "Roboto-Medium.ttf";
+          fb.path = u8"Roboto-Medium.ttf";
           fb.size_px = m_px_body;
           body = add_single(FontRole::Body, fb);
 
           FontFile ic{};
-          ic.path = "forkawesome-webfont.ttf";
+          ic.path = u8"forkawesome-webfont.ttf";
           ic.size_px = m_px_body;
           ic.merge = true;
           addFontFile(ic, m_params, ranges, base_dir_abs, cfg);
@@ -605,14 +605,14 @@ namespace ImGuiX::Fonts {
           ensure_headline(FontRole::H2, m_px_h2);
           ensure_headline(FontRole::H3, m_px_h3);
         } else {
-          br.message = "Manual mode: Body font not provided";
+          br.message = u8"Manual mode: Body font not provided";
         }
       }
 
         // Update backend texture (SFML or stub true)
         if (!updateBackendTexture()) {
             br.success = false;
-            br.message = "Backend font texture update failed";
+            br.message = u8"Backend font texture update failed";
             return br;
         }
 
@@ -652,7 +652,7 @@ namespace ImGuiX::Fonts {
         // Fallback: if empty or not found, try base_dir/fonts.json
         if (readTextFile(cfg_path).empty()) {
             const auto base_abs = ImGuiX::Utils::resolveExecPath(m_params.base_dir);
-            cfg_path = ImGuiX::Utils::joinPaths(base_abs, "fonts.json");
+            cfg_path = ImGuiX::Utils::joinPaths(base_abs, u8"fonts.json");
         }
 #       endif
 
@@ -664,78 +664,78 @@ namespace ImGuiX::Fonts {
           j = json::parse(json_text);
 
           // base_dir (optional)
-          if (j.contains("base_dir") && j["base_dir"].is_string())
-            m_params.base_dir = j["base_dir"].get<std::string>();
+          if (j.contains(u8"base_dir") && j[u8"base_dir"].is_string())
+            m_params.base_dir = j[u8"base_dir"].get<std::string>();
 
           // markdown_sizes (optional)
-          if (j.contains("markdown_sizes") && j["markdown_sizes"].is_object()) {
-            const auto &ms = j["markdown_sizes"];
-            if (ms.contains("body"))
-              m_px_body = ms["body"].get<float>();
-            if (ms.contains("h1"))
-              m_px_h1 = ms["h1"].get<float>();
-            if (ms.contains("h2"))
-              m_px_h2 = ms["h2"].get<float>();
-            if (ms.contains("h3"))
-              m_px_h3 = ms["h3"].get<float>();
+          if (j.contains(u8"markdown_sizes") && j[u8"markdown_sizes"].is_object()) {
+            const auto &ms = j[u8"markdown_sizes"];
+            if (ms.contains(u8"body"))
+              m_px_body = ms[u8"body"].get<float>();
+            if (ms.contains(u8"h1"))
+              m_px_h1 = ms[u8"h1"].get<float>();
+            if (ms.contains(u8"h2"))
+              m_px_h2 = ms[u8"h2"].get<float>();
+            if (ms.contains(u8"h3"))
+              m_px_h3 = ms[u8"h3"].get<float>();
           }
 
           // locales (packs)
-          if (j.contains("locales") && j["locales"].is_object()) {
-            for (auto it = j["locales"].begin(); it != j["locales"].end(); ++it) {
+          if (j.contains(u8"locales") && j[u8"locales"].is_object()) {
+            for (auto it = j[u8"locales"].begin(); it != j[u8"locales"].end(); ++it) {
               const std::string loc = it.key();
               const json &L = it.value();
 
               LocalePack pack{};
               pack.locale = loc;
 
-              if (L.contains("inherits") && L["inherits"].is_string())
-                pack.inherits = L["inherits"].get<std::string>();
+              if (L.contains(u8"inherits") && L[u8"inherits"].is_string())
+                pack.inherits = L[u8"inherits"].get<std::string>();
 
               // ranges: array of pairs OR string preset (e.g.,
               // "Default+Cyrillic+Punct")
-              if (L.contains("ranges")) {
-                if (L["ranges"].is_array()) {
-                  for (const auto &v : L["ranges"])
+              if (L.contains(u8"ranges")) {
+                if (L[u8"ranges"].is_array()) {
+                  for (const auto &v : L[u8"ranges"])
                     pack.ranges.push_back(static_cast<ImWchar>(v.get<int>()));
                   // Append 0 terminator later inside buildRangesFromPack()
-                } else if (L["ranges"].is_string()) {
+                } else if (L[u8"ranges"].is_string()) {
                   pack.ranges_preset =
-                      L["ranges"].get<std::string>(); // <-- IMPORTANT: keep
+                      L[u8"ranges"].get<std::string>(); // <-- IMPORTANT: keep
                 }
               }
 
               // roles...
-              if (L.contains("roles") && L["roles"].is_object()) {
-                const auto &R = L["roles"];
+              if (L.contains(u8"roles") && L[u8"roles"].is_object()) {
+                const auto &R = L[u8"roles"];
                 auto parse_files = [&](const char *key, FontRole role) {
                   if (R.contains(key) && R[key].is_array()) {
                     for (const auto &item : R[key]) {
                       FontFile ff{};
-                      if (item.contains("path"))
-                        ff.path = item["path"].get<std::string>();
-                      if (item.contains("size_px"))
-                        ff.size_px = item["size_px"].get<float>();
-                      if (item.contains("merge"))
-                        ff.merge = item["merge"].get<bool>();
-                      if (item.contains("freetype_flags"))
-                        ff.freetype_flags = item["freetype_flags"].get<unsigned>();
-                      if (item.contains("extra_glyphs"))
-                        ff.extra_glyphs = item["extra_glyphs"].get<std::string>();
+                      if (item.contains(u8"path"))
+                        ff.path = item[u8"path"].get<std::string>();
+                      if (item.contains(u8"size_px"))
+                        ff.size_px = item[u8"size_px"].get<float>();
+                      if (item.contains(u8"merge"))
+                        ff.merge = item[u8"merge"].get<bool>();
+                      if (item.contains(u8"freetype_flags"))
+                        ff.freetype_flags = item[u8"freetype_flags"].get<unsigned>();
+                      if (item.contains(u8"extra_glyphs"))
+                        ff.extra_glyphs = item[u8"extra_glyphs"].get<std::string>();
                       pack.roles[role].push_back(std::move(ff));
                     }
                   }
                 };
-                parse_files("Body", FontRole::Body);
-                parse_files("H1", FontRole::H1);
-                parse_files("H2", FontRole::H2);
-                parse_files("H3", FontRole::H3);
-                parse_files("Monospace", FontRole::Monospace);
-                parse_files("Bold", FontRole::Bold);
-                parse_files("Italic", FontRole::Italic);
-                parse_files("BoldItalic", FontRole::BoldItalic);
-                parse_files("Icons", FontRole::Icons);
-                parse_files("Emoji", FontRole::Emoji);
+                parse_files(u8"Body", FontRole::Body);
+                parse_files(u8"H1", FontRole::H1);
+                parse_files(u8"H2", FontRole::H2);
+                parse_files(u8"H3", FontRole::H3);
+                parse_files(u8"Monospace", FontRole::Monospace);
+                parse_files(u8"Bold", FontRole::Bold);
+                parse_files(u8"Italic", FontRole::Italic);
+                parse_files(u8"BoldItalic", FontRole::BoldItalic);
+                parse_files(u8"Icons", FontRole::Icons);
+                parse_files(u8"Emoji", FontRole::Emoji);
               }
 
               m_packs[pack.locale] = std::move(pack);
@@ -781,7 +781,7 @@ namespace ImGuiX::Fonts {
 
         } catch (const std::exception &e) {
           br.success = false;
-          br.message = std::string("JSON parse error: ") + e.what();
+          br.message = std::string(u8"JSON parse error: ") + e.what();
           // Fallback to defaults below
         }
       }
@@ -789,8 +789,8 @@ namespace ImGuiX::Fonts {
         // Choose active locale, or fallback to "default"
         if (!m_packs.empty()) {
             if (!m_packs.count(m_active_locale)) {
-                if (m_packs.count("default"))
-                m_active_locale = "default";
+                if (m_packs.count(u8"default"))
+                m_active_locale = u8"default";
             }
         }
 

--- a/include/imguix/core/fonts/font_types.hpp
+++ b/include/imguix/core/fonts/font_types.hpp
@@ -42,7 +42,7 @@ namespace ImGuiX::Fonts {
     struct BuildParams {
         float dpi = 96.0f;     ///< Logical DPI (96 = 1.0 scale)
         float ui_scale = 1.0f; ///< Global UI scaling factor
-        std::string base_dir = "data/resources/fonts"; ///< Base directory for relative paths
+        std::string base_dir = u8"data/resources/fonts"; ///< Base directory for relative paths
         bool use_freetype = true;   ///< Use ImGui FreeType builder if available
     };
 

--- a/include/imguix/core/i18n.hpp
+++ b/include/imguix/core/i18n.hpp
@@ -29,15 +29,15 @@
 #include <imguix/utils/path_utils.hpp>
 
 #ifndef IMGUIX_I18N_DIR
-#   define IMGUIX_I18N_DIR "data/resources/i18n"   // default root for i18n assets
+#   define IMGUIX_I18N_DIR u8"data/resources/i18n"   // default root for i18n assets
 #endif
 
 #ifndef IMGUIX_I18N_JSON_BASENAME
-#   define IMGUIX_I18N_JSON_BASENAME "strings.json"
+#   define IMGUIX_I18N_JSON_BASENAME u8"strings.json"
 #endif
 
 #ifndef IMGUIX_I18N_PLURALS_FILENAME
-#   define IMGUIX_I18N_PLURALS_FILENAME "plurals.json"
+#   define IMGUIX_I18N_PLURALS_FILENAME u8"plurals.json"
 #endif
 
 // 1 = resolve IMGUIX_I18N_DIR relatively to the executable location.

--- a/include/imguix/core/i18n/LangStore.hpp
+++ b/include/imguix/core/i18n/LangStore.hpp
@@ -36,13 +36,13 @@ namespace ImGuiX::I18N {
     public:
 
         LangStore()
-            : LangStore(default_i18n_base_dir(), "en") {
+            : LangStore(default_i18n_base_dir(), u8"en") {
         }
 
         /// \brief Construct i18n store.
         /// \param base_dir Root folder with per-language subfolders (e.g., "<root>/en/", "<root>/ru/").
         /// \param default_lang Default language (fallback), typically "en".
-        explicit LangStore(std::string base_dir, std::string default_lang = "en")
+        explicit LangStore(std::string base_dir, std::string default_lang = u8"en")
             : m_base_dir(std::move(base_dir)),
               m_default_lang(std::move(default_lang)),
               m_current_lang(m_default_lang),
@@ -124,7 +124,7 @@ namespace ImGuiX::I18N {
             std::string combined;
             combined.reserve(base.size() + 2 + key.size());
             combined += base;
-            combined += "##";
+            combined += u8"##";
             combined.append(key.begin(), key.end());
 
             auto [ins, _] = m_label_cache.emplace(intern_key(std::string(key)), std::move(combined));
@@ -222,7 +222,7 @@ namespace ImGuiX::I18N {
                 if (ec) break;
                 if (!de.is_regular_file()) continue;
                 const auto& p = de.path();
-                if (p.extension() != ".json") continue;
+                if (p.extension() != u8".json") continue;
 
                 const std::string raw = read_file(p.string());
                 if (raw.empty()) continue;
@@ -270,7 +270,7 @@ namespace ImGuiX::I18N {
                         auto s = get_sv(*jt);
                         if (!s.empty()) { out.emplace(k, std::move(s)); continue; }
                     }
-                    if (auto jt = val.find("en"); jt != val.end()) {
+                    if (auto jt = val.find(u8"en"); jt != val.end()) {
                         auto s = get_sv(*jt);
                         if (!s.empty()) { out.emplace(k, std::move(s)); continue; }
                     }
@@ -307,7 +307,7 @@ namespace ImGuiX::I18N {
             if (auto it = by_key.find(doc_key); it != by_key.end())
                 return it->second;
 
-            const fs::path p = fs::path(m_base_dir) / lang / (std::string(doc_key) + ".md");
+            const fs::path p = fs::path(m_base_dir) / lang / (std::string(doc_key) + u8".md");
             auto s = read_file(p.string());
             if (!s.empty()) {
                 by_key.emplace(intern_key(std::string(doc_key)), s);
@@ -323,7 +323,7 @@ namespace ImGuiX::I18N {
         }
 
         static const std::string& missing_string() {
-            static const std::string k = "##null";
+            static const std::string k = u8"##null";
             return k;
         }
 
@@ -338,15 +338,15 @@ namespace ImGuiX::I18N {
 
         static std::string default_plural_suffix(const std::string& lang, long long n) {
             // Minimal fallback; PluralRules has richer built-ins.
-            if (lang == "ru") {
+            if (lang == u8"ru") {
                 long long n10 = n % 10;
                 long long n100 = n % 100;
-                if (n10 == 1 && n100 != 11) return "one";
-                if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return "few";
-                if (n10 == 0 || (n10 >= 5 && n10 <= 9) || (n100 >= 11 && n100 <= 14)) return "many";
-                return "other";
+                if (n10 == 1 && n100 != 11) return u8"one";
+                if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return u8"few";
+                if (n10 == 0 || (n10 >= 5 && n10 <= 9) || (n100 >= 11 && n100 <= 14)) return u8"many";
+                return u8"other";
             }
-            return (n == 1) ? "one" : "other";
+            return (n == 1) ? u8"one" : u8"other";
         }
 
         void try_load_plural_rules_from_default_location() {

--- a/include/imguix/core/i18n/PluralRules.hpp
+++ b/include/imguix/core/i18n/PluralRules.hpp
@@ -31,12 +31,12 @@ namespace ImGuiX::I18N {
             for (auto it = j.begin(); it != j.end(); ++it) {
                 const std::string lang = it.key();
                 const auto& node = it.value();
-                if (!node.contains("cardinal") || !node["cardinal"].is_array()) continue;
+                if (!node.contains(u8"cardinal") || !node[u8"cardinal"].is_array()) continue;
                 LangRules lr;
-                for (const auto& r : node["cardinal"]) {
-                    if (!r.contains("cat") || !r["cat"].is_string()) continue;
+                for (const auto& r : node[u8"cardinal"]) {
+                    if (!r.contains(u8"cat") || !r[u8"cat"].is_string()) continue;
                     Rule rule;
-                    rule.category = r["cat"].get<std::string>();
+                    rule.category = r[u8"cat"].get<std::string>();
                     rule.cond = r; // keep entire object; evaluator will inspect keys
                     lr.rules.emplace_back(std::move(rule));
                 }
@@ -58,16 +58,16 @@ namespace ImGuiX::I18N {
             }
 
             // Fallbacks
-            if (lang == "ru") {
+            if (lang == u8"ru") {
                 long long n10 = n % 10;
                 long long n100 = n % 100;
-                if (n10 == 1 && n100 != 11) return "one";
-                if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return "few";
-                if (n10 == 0 || (n10 >= 5 && n10 <= 9) || (n100 >= 11 && n100 <= 14)) return "many";
-                return "other";
+                if (n10 == 1 && n100 != 11) return u8"one";
+                if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return u8"few";
+                if (n10 == 0 || (n10 >= 5 && n10 <= 9) || (n100 >= 11 && n100 <= 14)) return u8"many";
+                return u8"other";
             }
             // default English-like
-            return (n == 1) ? "one" : "other";
+            return (n == 1) ? u8"one" : u8"other";
         }
 
     private:
@@ -91,65 +91,65 @@ namespace ImGuiX::I18N {
 
         static bool eval_rule(const nlohmann::json& r, long long n) {
             // order of precedence: structural keys (all/any/not/true), then simple predicates in this node
-            if (r.contains("true") && r["true"].is_boolean() && r["true"].get<bool>()) return true;
+            if (r.contains(u8"true") && r[u8"true"].is_boolean() && r[u8"true"].get<bool>()) return true;
 
-            if (r.contains("all") && r["all"].is_array()) {
-                for (const auto& sub : r["all"]) if (!eval_rule(sub, n)) return false;
+            if (r.contains(u8"all") && r[u8"all"].is_array()) {
+                for (const auto& sub : r[u8"all"]) if (!eval_rule(sub, n)) return false;
                 return true;
             }
-            if (r.contains("any") && r["any"].is_array()) {
-                for (const auto& sub : r["any"]) if (eval_rule(sub, n)) return true;
+            if (r.contains(u8"any") && r[u8"any"].is_array()) {
+                for (const auto& sub : r[u8"any"]) if (eval_rule(sub, n)) return true;
                 return false;
             }
-            if (r.contains("not")) {
-                return !eval_rule(r["not"], n);
+            if (r.contains(u8"not")) {
+                return !eval_rule(r[u8"not"], n);
             }
 
             // Simple numeric predicates at this node
-            if (r.contains("eq")) {
-                const auto& v = r["eq"];
+            if (r.contains(u8"eq")) {
+                const auto& v = r[u8"eq"];
                 if (v.is_number_integer()) return n == v.get<long long>();
             }
-            if (r.contains("in") && r["in"].is_array()) {
-                for (const auto& x : r["in"]) {
+            if (r.contains(u8"in") && r[u8"in"].is_array()) {
+                for (const auto& x : r[u8"in"]) {
                     if (x.is_number_integer() && n == x.get<long long>()) return true;
                 }
                 return false;
             }
-            if (r.contains("range") && r["range"].is_array() && r["range"].size() == 2) {
-                const auto a = r["range"][0].get<long long>();
-                const auto b = r["range"][1].get<long long>();
+            if (r.contains(u8"range") && r[u8"range"].is_array() && r[u8"range"].size() == 2) {
+                const auto a = r[u8"range"][0].get<long long>();
+                const auto b = r[u8"range"][1].get<long long>();
                 return (n >= a && n <= b);
             }
-            if (r.contains("mod_eq") && r["mod_eq"].is_object()) {
-                const auto& me = r["mod_eq"];
-                if (me.contains("mod") && me.contains("eq")) {
-                    const auto mod = me["mod"].get<long long>();
-                    const auto eq  = me["eq"].get<long long>();
+            if (r.contains(u8"mod_eq") && r[u8"mod_eq"].is_object()) {
+                const auto& me = r[u8"mod_eq"];
+                if (me.contains(u8"mod") && me.contains(u8"eq")) {
+                    const auto mod = me[u8"mod"].get<long long>();
+                    const auto eq  = me[u8"eq"].get<long long>();
                     if (mod != 0) return (n % mod) == eq;
                 }
             }
-            if (r.contains("mod_in_list") && r["mod_in_list"].is_object()) {
-                const auto& ml = r["mod_in_list"];
-                if (ml.contains("mod") && ml.contains("list") && ml["list"].is_array()) {
-                    const auto mod = ml["mod"].get<long long>();
+            if (r.contains(u8"mod_in_list") && r[u8"mod_in_list"].is_object()) {
+                const auto& ml = r[u8"mod_in_list"];
+                if (ml.contains(u8"mod") && ml.contains(u8"list") && ml[u8"list"].is_array()) {
+                    const auto mod = ml[u8"mod"].get<long long>();
                     if (mod == 0) return false;
                     const long long v = n % mod;
-                    for (const auto& x : ml["list"]) {
+                    for (const auto& x : ml[u8"list"]) {
                         if (x.is_number_integer() && v == x.get<long long>()) return true;
                     }
                     return false;
                 }
             }
-            if (r.contains("mod_in_range") && r["mod_in_range"].is_object()) {
-                const auto& mr = r["mod_in_range"];
-                if (mr.contains("mod") && mr.contains("range") &&
-                    mr["range"].is_array() && mr["range"].size() == 2) {
-                    const auto mod = mr["mod"].get<long long>();
+            if (r.contains(u8"mod_in_range") && r[u8"mod_in_range"].is_object()) {
+                const auto& mr = r[u8"mod_in_range"];
+                if (mr.contains(u8"mod") && mr.contains(u8"range") &&
+                    mr[u8"range"].is_array() && mr[u8"range"].size() == 2) {
+                    const auto mod = mr[u8"mod"].get<long long>();
                     if (mod == 0) return false;
                     const long long v = n % mod;
-                    const auto a = mr["range"][0].get<long long>();
-                    const auto b = mr["range"][1].get<long long>();
+                    const auto a = mr[u8"range"][0].get<long long>();
+                    const auto b = mr[u8"range"][1].get<long long>();
                     return (v >= a && v <= b);
                 }
             }

--- a/include/imguix/core/options/OptionsStore.ipp
+++ b/include/imguix/core/options/OptionsStore.ipp
@@ -27,16 +27,16 @@ namespace ImGuiX {
 
         static json& ensureMeta(json& root) {
             if (!root.is_object()) root = json::object();
-            auto it = root.find("__meta");
+            auto it = root.find(u8"__meta");
             if (it == root.end() || !it->is_object()) {
-                root["__meta"] = json::object();
+                root[u8"__meta"] = json::object();
             }
-            return root["__meta"];
+            return root[u8"__meta"];
         }
 
         static const json* meta(const json& root) {
             if (!root.is_object()) return nullptr;
-            auto it = root.find("__meta");
+            auto it = root.find(u8"__meta");
             if (it == root.end() || !it->is_object()) return nullptr;
             return &(*it);
         }
@@ -51,7 +51,7 @@ namespace ImGuiX {
                     std::ofstream tf(
                             m_tmp_path,
                             std::ios::binary | std::ios::trunc);
-                    if (!tf.good()) throw std::runtime_error("tmp open failed");
+                    if (!tf.good()) throw std::runtime_error(u8"tmp open failed");
                     tf << m_root.dump(2);
                     tf.flush();
                 }
@@ -71,8 +71,8 @@ namespace ImGuiX {
             if (v.is_number_integer()) return v.get<long long>() != 0;
             if (v.is_string()) {
                 auto s = v.get<std::string>();
-                if (s == "true" || s == "1") return true;
-                if (s == "false" || s == "0") return false;
+                if (s == u8"true" || s == u8"1") return true;
+                if (s == u8"false" || s == u8"0") return false;
             }
             return std::nullopt;
         }
@@ -81,7 +81,7 @@ namespace ImGuiX {
         static std::optional<Int> asInt(const json& v) {
             static_assert(std::is_same<Int, int32_t>::value ||
                           std::is_same<Int, int64_t>::value,
-                          "int type");
+                          u8"int type");
             if (v.is_number_integer()) {
                 long long x = v.get<long long>();
                 if constexpr (std::is_same<Int, int32_t>::value) {
@@ -120,7 +120,7 @@ namespace ImGuiX {
         static std::optional<F> asFloat(const json& v) {
             static_assert(std::is_same<F, float>::value ||
                           std::is_same<F, double>::value,
-                          "float type");
+                          u8"float type");
             if (v.is_number()) return static_cast<F>(v.get<double>());
             if (v.is_string()) {
                 try {
@@ -135,7 +135,7 @@ namespace ImGuiX {
             if (v.is_string()) return v.get<std::string>();
             if (v.is_number_integer()) return std::to_string(v.get<long long>());
             if (v.is_number_float()) return std::to_string(v.get<double>());
-            if (v.is_boolean()) return v.get<bool>() ? "true" : "false";
+            if (v.is_boolean()) return v.get<bool>() ? u8"true" : u8"false";
             return std::nullopt;
         }
 
@@ -154,7 +154,7 @@ namespace ImGuiX {
     inline OptionsStore::OptionsStore(std::string path, double save_delay_sec)
         : m_impl(std::make_unique<Impl>()) {
         m_impl->m_path = std::move(path);
-        m_impl->m_tmp_path = m_impl->m_path + ".tmp";
+        m_impl->m_tmp_path = m_impl->m_path + u8".tmp";
         m_impl->m_save_delay = save_delay_sec;
         load();
     }
@@ -209,7 +209,7 @@ namespace ImGuiX {
         std::vector<std::string> out;
         out.reserve(m_impl->m_root.size());
         for (auto it = m_impl->m_root.begin(); it != m_impl->m_root.end(); ++it) {
-            if (it.key() == "__meta") continue;
+            if (it.key() == u8"__meta") continue;
             out.push_back(it.key());
         }
         return out;
@@ -265,7 +265,7 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto it = m_impl->m_root.find(key);
         if (it == m_impl->m_root.end())
-            throw std::out_of_range("key not found: " + key);
+            throw std::out_of_range(u8"key not found: " + key);
         if (auto x = Impl::asBool(*it)) return *x;
         throw std::bad_cast();
     }
@@ -274,7 +274,7 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto it = m_impl->m_root.find(key);
         if (it == m_impl->m_root.end())
-            throw std::out_of_range("key not found: " + key);
+            throw std::out_of_range(u8"key not found: " + key);
         if (auto x = Impl::asInt<int32_t>(*it)) return *x;
         throw std::bad_cast();
     }
@@ -283,7 +283,7 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto it = m_impl->m_root.find(key);
         if (it == m_impl->m_root.end())
-            throw std::out_of_range("key not found: " + key);
+            throw std::out_of_range(u8"key not found: " + key);
         if (auto x = Impl::asInt<int64_t>(*it)) return *x;
         throw std::bad_cast();
     }
@@ -292,7 +292,7 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto it = m_impl->m_root.find(key);
         if (it == m_impl->m_root.end())
-            throw std::out_of_range("key not found: " + key);
+            throw std::out_of_range(u8"key not found: " + key);
         if (auto x = Impl::asFloat<float>(*it)) return *x;
         throw std::bad_cast();
     }
@@ -301,7 +301,7 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto it = m_impl->m_root.find(key);
         if (it == m_impl->m_root.end())
-            throw std::out_of_range("key not found: " + key);
+            throw std::out_of_range(u8"key not found: " + key);
         if (auto x = Impl::asFloat<double>(*it)) return *x;
         throw std::bad_cast();
     }
@@ -310,7 +310,7 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto it = m_impl->m_root.find(key);
         if (it == m_impl->m_root.end())
-            throw std::out_of_range("key not found: " + key);
+            throw std::out_of_range(u8"key not found: " + key);
         if (auto x = Impl::asString(*it)) return *x;
         throw std::bad_cast();
     }
@@ -320,7 +320,7 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto it = m_impl->m_root.find(key);
         if (it == m_impl->m_root.end())
-            throw std::out_of_range("key not found: " + key);
+            throw std::out_of_range(u8"key not found: " + key);
         if (auto x = Impl::asStrVec(*it)) return *x;
         throw std::bad_cast();
     }
@@ -398,7 +398,7 @@ namespace ImGuiX {
     inline void OptionsStore::setVersion(std::int32_t ver) noexcept {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto& m = Impl::ensureMeta(m_impl->m_root);
-        m["version"] = static_cast<long long>(ver);
+        m[u8"version"] = static_cast<long long>(ver);
         m_impl->touchLocked();
     }
 
@@ -406,8 +406,8 @@ namespace ImGuiX {
         std::lock_guard<std::mutex> lk(m_impl->m_mutex);
         auto* m = Impl::meta(m_impl->m_root);
         if (!m) return 0;
-        if (m->contains("version")) {
-            const json& v = (*m)["version"];
+        if (m->contains(u8"version")) {
+            const json& v = (*m)[u8"version"];
             if (v.is_number_integer()) {
                 long long x = v.get<long long>();
                 if (x < INT32_MIN || x > INT32_MAX) return 0;

--- a/include/imguix/core/pubsub/EventAwaiter.hpp
+++ b/include/imguix/core/pubsub/EventAwaiter.hpp
@@ -31,7 +31,7 @@ namespace ImGuiX::Pubsub {
                          public IAwaiterEx,
                          public std::enable_shared_from_this<EventAwaiter<EventType>> {
         static_assert(std::is_base_of<Event, EventType>::value,
-                      "EventType must derive from ImGuiX::Pubsub::Event");
+                      u8"EventType must derive from ImGuiX::Pubsub::Event");
     public:
         using Predicate = std::function<bool(const EventType&)>;
         using Callback  = std::function<void(const EventType&)>;

--- a/include/imguix/core/pubsub/EventBus.ipp
+++ b/include/imguix/core/pubsub/EventBus.ipp
@@ -4,7 +4,7 @@ namespace ImGuiX::Pubsub {
 
     template <typename EventType>
     void EventBus::subscribe(EventListener* owner, std::function<void(const EventType&)> callback) {
-        static_assert(std::is_base_of<Event, EventType>::value, "EventType must be derived from Event");
+        static_assert(std::is_base_of<Event, EventType>::value, u8"EventType must be derived from Event");
 
         auto type = std::type_index(typeid(EventType));
         std::lock_guard<std::mutex> lock(m_subscriptions_mutex);
@@ -18,7 +18,7 @@ namespace ImGuiX::Pubsub {
 
     template <typename EventType>
     void EventBus::subscribe(EventListener* owner, std::function<void(const Event* const)> callback) {
-        static_assert(std::is_base_of<Event, EventType>::value, "EventType must be derived from Event");
+        static_assert(std::is_base_of<Event, EventType>::value, u8"EventType must be derived from Event");
 
         auto type = std::type_index(typeid(EventType));
         std::lock_guard<std::mutex> lock(m_subscriptions_mutex);
@@ -30,7 +30,7 @@ namespace ImGuiX::Pubsub {
 
     template <typename EventType>
     void EventBus::subscribe(EventListener* listener) {
-        static_assert(std::is_base_of<Event, EventType>::value, "EventType must be derived from Event");
+        static_assert(std::is_base_of<Event, EventType>::value, u8"EventType must be derived from Event");
 
         auto type = std::type_index(typeid(EventType));
         std::lock_guard<std::mutex> lock(m_subscriptions_mutex);
@@ -43,7 +43,7 @@ namespace ImGuiX::Pubsub {
 
     template <typename EventType>
     void EventBus::unsubscribe(EventListener* owner) {
-        static_assert(std::is_base_of<Event, EventType>::value, "EventType must be derived from Event");
+        static_assert(std::is_base_of<Event, EventType>::value, u8"EventType must be derived from Event");
 
         auto type = std::type_index(typeid(EventType));
         std::lock_guard<std::mutex> lock(m_subscriptions_mutex);

--- a/include/imguix/core/resource/ResourceRegistry.ipp
+++ b/include/imguix/core/resource/ResourceRegistry.ipp
@@ -50,7 +50,7 @@ namespace ImGuiX {
         std::shared_lock<std::shared_mutex> progress_lock(m_progress_mutex);
         #endif
         if (m_in_progress.find(type) != m_in_progress.end()) {
-            throw std::runtime_error("Resource is being initialized");
+            throw std::runtime_error(u8"Resource is being initialized");
         }
         progress_lock.unlock();
         
@@ -61,7 +61,7 @@ namespace ImGuiX {
         #endif
         auto it = m_resources.find(type);
         if (it == m_resources.end()) {
-            throw std::runtime_error("Resource not registered");
+            throw std::runtime_error(u8"Resource not registered");
         }
 
         return *static_cast<T*>(it->second.get());

--- a/include/imguix/core/window/GlfwWindowInstance.ipp
+++ b/include/imguix/core/window/GlfwWindowInstance.ipp
@@ -60,20 +60,20 @@ namespace ImGuiX {
         // OpenGL ES?
         if (client == GLFW_OPENGL_ES_API) {
             int major = glfwGetWindowAttrib(w, GLFW_CONTEXT_VERSION_MAJOR);
-            return (major >= 3) ? "#version 300 es" : "#version 100";
+            return (major >= 3) ? u8"#version 300 es" : u8"#version 100";
         }
 
 #       if defined(__APPLE__)
         // macOS Core 3.2+
-        return "#version 150";
+        return u8"#version 150";
 #       else
         int major = glfwGetWindowAttrib(w, GLFW_CONTEXT_VERSION_MAJOR);
         int minor = glfwGetWindowAttrib(w, GLFW_CONTEXT_VERSION_MINOR);
         int profile = glfwGetWindowAttrib(w, GLFW_OPENGL_PROFILE);
 
         if (major > 3 || (major == 3 && minor >= 2) || profile == GLFW_OPENGL_CORE_PROFILE)
-            return "#version 150";
-        return "#version 130";
+            return u8"#version 150";
+        return u8"#version 130";
 #       endif
 #   endif
     }

--- a/include/imguix/core/window/Sdl2WindowInstance.ipp
+++ b/include/imguix/core/window/Sdl2WindowInstance.ipp
@@ -29,9 +29,9 @@ namespace ImGuiX {
         if (m_window || m_is_open) return true;
         if (SDL_Init(SDL_INIT_VIDEO) != 0) return false;
 #ifdef __EMSCRIPTEN__
-        SDL_SetHint(SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR, "#canvas");
-        SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, "0");
-        SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
+        SDL_SetHint(SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR, u8"#canvas");
+        SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, u8"0");
+        SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, u8"1");
 #endif
         m_window = SDL_CreateWindow(name().c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
                                    width(), height(), SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
@@ -82,14 +82,14 @@ namespace ImGuiX {
 		if (SDL_GL_GetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, &profile) != 0) return IMGUIX_GLSL_VERSION;
 
 		if (profile & SDL_GL_CONTEXT_PROFILE_ES)
-			return (major >= 3) ? "#version 300 es" : "#version 100";
+			return (major >= 3) ? u8"#version 300 es" : u8"#version 100";
 
 #   	if defined(__APPLE__)
-		return "#version 150";
+		return u8"#version 150";
 #   	else
 		if (major > 3 || (major == 3 && minor >= 2) || (profile & SDL_GL_CONTEXT_PROFILE_CORE))
-			return "#version 150";
-		return "#version 130";
+			return u8"#version 150";
+		return u8"#version 130";
 #   	endif
 #	endif
 	}

--- a/include/imguix/core/window/SfmlWindowInstance.ipp
+++ b/include/imguix/core/window/SfmlWindowInstance.ipp
@@ -127,9 +127,9 @@ namespace ImGuiX {
         if (!display || !handle)
             return;
 
-        Atom wmState = XInternAtom(display, "_NET_WM_STATE", False);
-        Atom maxHorz = XInternAtom(display, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
-        Atom maxVert = XInternAtom(display, "_NET_WM_STATE_MAXIMIZED_VERT", False);
+        Atom wmState = XInternAtom(display, u8"_NET_WM_STATE", False);
+        Atom maxHorz = XInternAtom(display, u8"_NET_WM_STATE_MAXIMIZED_HORZ", False);
+        Atom maxVert = XInternAtom(display, u8"_NET_WM_STATE_MAXIMIZED_VERT", False);
 
         XEvent xev{};
         xev.type = ClientMessage;
@@ -171,9 +171,9 @@ namespace ImGuiX {
         if (!display || !handle)
             return false;
 
-        Atom wmState = XInternAtom(display, "_NET_WM_STATE", False);
-        Atom maxHorz = XInternAtom(display, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
-        Atom maxVert = XInternAtom(display, "_NET_WM_STATE_MAXIMIZED_VERT", False);
+        Atom wmState = XInternAtom(display, u8"_NET_WM_STATE", False);
+        Atom maxHorz = XInternAtom(display, u8"_NET_WM_STATE_MAXIMIZED_HORZ", False);
+        Atom maxVert = XInternAtom(display, u8"_NET_WM_STATE_MAXIMIZED_VERT", False);
         Atom actualType;
         int actualFormat;
         unsigned long nitems, bytesAfter;
@@ -215,9 +215,9 @@ namespace ImGuiX {
         if (!display || !handle)
             return;
 
-        Atom wmState = XInternAtom(display, "_NET_WM_STATE", False);
-        Atom maxHorz = XInternAtom(display, "_NET_WM_STATE_MAXIMIZED_HORZ", False);
-        Atom maxVert = XInternAtom(display, "_NET_WM_STATE_MAXIMIZED_VERT", False);
+        Atom wmState = XInternAtom(display, u8"_NET_WM_STATE", False);
+        Atom maxHorz = XInternAtom(display, u8"_NET_WM_STATE_MAXIMIZED_HORZ", False);
+        Atom maxVert = XInternAtom(display, u8"_NET_WM_STATE_MAXIMIZED_VERT", False);
 
         XEvent xev{};
         xev.type = ClientMessage;

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -28,7 +28,7 @@
 #include "WindowInterface.hpp"
 
 #ifndef IMGUIX_CONFIG_DIR
-#    define IMGUIX_CONFIG_DIR "data/config"
+#    define IMGUIX_CONFIG_DIR u8"data/config"
 #endif
 
 namespace ImGuiX {

--- a/include/imguix/core/window/WindowInstance.ipp
+++ b/include/imguix/core/window/WindowInstance.ipp
@@ -27,7 +27,7 @@ namespace ImGuiX {
     template <typename ControllerType, typename... Args>
     ControllerType& WindowInstance::createController(Args&&... args) {
         static_assert(std::is_base_of<Controller, ControllerType>::value,
-                      "ControllerType must derive from Controller");
+                      u8"ControllerType must derive from Controller");
 
         auto ctrl = std::make_unique<ControllerType>(
             static_cast<WindowInterface&>(*this),
@@ -88,13 +88,13 @@ namespace ImGuiX {
     std::string WindowInstance::iniPath() const {
 #   ifdef __EMSCRIPTEN__
 #       ifdef IMGUIX_EMSCRIPTEN_IDBFS
-        return "/imguix_fs/imgui-" + std::to_string(m_window_id) + ".ini";
+        return u8"/imguix_fs/imgui-" + std::to_string(m_window_id) + u8".ini";
 #       else
         return {};
 #       endif
 #   else
         return ImGuiX::Utils::resolveExecPath(
-            std::string(IMGUIX_CONFIG_DIR) + "/imgui-" + std::to_string(m_window_id) + ".ini");
+            std::string(IMGUIX_CONFIG_DIR) + u8"/imgui-" + std::to_string(m_window_id) + u8".ini");
 #   endif
     }
 
@@ -167,7 +167,7 @@ namespace ImGuiX {
     }
 
     void WindowInstance::fontsBeginManual() {
-        assert(m_in_init_phase && !m_is_fonts_init && "fontsBeginManual() only allowed in onInit(), before initFonts()");
+        assert(m_in_init_phase && !m_is_fonts_init && u8"fontsBeginManual() only allowed in onInit(), before initFonts()");
         m_font_manager.beginManual();
         m_is_fonts_manual = true;
     }
@@ -180,46 +180,46 @@ namespace ImGuiX {
 	}
 	
 	void WindowInstance::fontsSetRangesPreset(std::string preset) {
-		assert(m_in_init_phase && "fontsSetRangesPreset() только в onInit()");
+		assert(m_in_init_phase && u8"fontsSetRangesPreset() только в onInit()");
 		m_font_manager.setRanges(std::move(preset));
 	}
 
 	void WindowInstance::fontsSetRangesExplicit(const std::vector<ImWchar>& pairs) {
-		assert(m_in_init_phase && "fontsSetRangesExplicit() только в onInit()");
+		assert(m_in_init_phase && u8"fontsSetRangesExplicit() только в onInit()");
 		m_font_manager.setRanges(pairs);
 	}
 
 	void WindowInstance::fontsClearRanges() {
-		assert(m_in_init_phase && "fontsClearRanges() только в onInit()");
+		assert(m_in_init_phase && u8"fontsClearRanges() только в onInit()");
 		m_font_manager.clearRanges();
 	}
 
     void WindowInstance::fontsAddBody(const ImGuiX::Fonts::FontFile& ff) {
-        assert(m_in_init_phase && "Only allowed in onInit()");
+        assert(m_in_init_phase && u8"Only allowed in onInit()");
         m_font_manager.addFontBody(ff);
     }
 
     void WindowInstance::fontsAddHeadline(ImGuiX::Fonts::FontRole role, const ImGuiX::Fonts::FontFile& ff) {
-        assert(m_in_init_phase && "Only allowed in onInit()");
+        assert(m_in_init_phase && u8"Only allowed in onInit()");
         m_font_manager.addFontHeadline(role, ff);
     }
 
     void WindowInstance::fontsAddMerge(ImGuiX::Fonts::FontRole role, const ImGuiX::Fonts::FontFile& ff) {
-        assert(m_in_init_phase && "Only allowed in onInit()");
+        assert(m_in_init_phase && u8"Only allowed in onInit()");
         m_font_manager.addFontMerge(role, ff);
     }
 
     void WindowInstance::fontsAddMerge(const ImGuiX::Fonts::FontFile& ff) {
-        assert(m_in_init_phase && "Only allowed in onInit()");
+        assert(m_in_init_phase && u8"Only allowed in onInit()");
         m_font_manager.addFontMerge(ff);
     }
 
     bool WindowInstance::fontsBuildNow() {
-        assert(m_in_init_phase && "Only allowed in onInit()");
+        assert(m_in_init_phase && u8"Only allowed in onInit()");
         auto br = m_font_manager.buildNow();
         if (br.success) m_is_fonts_init = true;
         if (!br.success) {
-            notify(IMGUIX_LOG_EVENT(ImGuiX::Events::LogLevel::Error, "Font init failed: {}"));
+            notify(IMGUIX_LOG_EVENT(ImGuiX::Events::LogLevel::Error, u8"Font init failed: {}"));
         }
         return br.success;
     }
@@ -232,7 +232,7 @@ namespace ImGuiX {
         auto br = m_font_manager.initFromJsonOrDefaults();
         m_is_fonts_init = br.success;
         if (!br.success) {
-            notify(IMGUIX_LOG_EVENT(ImGuiX::Events::LogLevel::Error, "Font init failed: {}"));
+            notify(IMGUIX_LOG_EVENT(ImGuiX::Events::LogLevel::Error, u8"Font init failed: {}"));
         }
     }
 }

--- a/include/imguix/core/window/imgui_glsl_version.hpp
+++ b/include/imguix/core/window/imgui_glsl_version.hpp
@@ -1,14 +1,14 @@
 // imgui_glsl_version.hpp
 #ifndef IMGUIX_GLSL_VERSION
 #  if defined(__EMSCRIPTEN__)
-#    define IMGUIX_GLSL_VERSION "#version 300 es"   // WebGL2
+#    define IMGUIX_GLSL_VERSION u8"#version 300 es"   // WebGL2
 #  elif defined(IMGUI_IMPL_OPENGL_ES3)
-#    define IMGUIX_GLSL_VERSION "#version 300 es"
+#    define IMGUIX_GLSL_VERSION u8"#version 300 es"
 #  elif defined(IMGUI_IMPL_OPENGL_ES2)
-#    define IMGUIX_GLSL_VERSION "#version 100"
+#    define IMGUIX_GLSL_VERSION u8"#version 100"
 #  elif defined(__APPLE__)
-#    define IMGUIX_GLSL_VERSION "#version 150"      // macOS Core 3.2
+#    define IMGUIX_GLSL_VERSION u8"#version 150"      // macOS Core 3.2
 #  else
-#    define IMGUIX_GLSL_VERSION "#version 130"      // Win/Linux Desktop GL
+#    define IMGUIX_GLSL_VERSION u8"#version 130"      // Win/Linux Desktop GL
 #  endif
 #endif

--- a/include/imguix/utils/encoding_utils.hpp
+++ b/include/imguix/utils/encoding_utils.hpp
@@ -135,43 +135,43 @@ namespace ImGuiX::Utils {
 
     template<typename Dummy = void>
     std::string Utf8ToAnsi(const std::string&) {
-        static_assert(detail::dependent_false_v<Dummy>, "Utf8ToAnsi is not supported on this platform");
+        static_assert(detail::dependent_false_v<Dummy>, u8"Utf8ToAnsi is not supported on this platform");
         return {};
     }
 
     template<typename Dummy = void>
     std::string AnsiToUtf8(const std::string&) {
-        static_assert(detail::dependent_false_v<Dummy>, "AnsiToUtf8 is not supported on this platform");
+        static_assert(detail::dependent_false_v<Dummy>, u8"AnsiToUtf8 is not supported on this platform");
         return {};
     }
 
     template<typename Dummy = void>
     std::string Utf8ToCp866(const std::string&) {
-        static_assert(detail::dependent_false_v<Dummy>, "Utf8ToCp866 is not supported on this platform");
+        static_assert(detail::dependent_false_v<Dummy>, u8"Utf8ToCp866 is not supported on this platform");
         return {};
     }
 
     template<typename Dummy = void>
     bool IsValidUtf8(const char*) {
-        static_assert(detail::dependent_false_v<Dummy>, "IsValidUtf8 is not supported on this platform");
+        static_assert(detail::dependent_false_v<Dummy>, u8"IsValidUtf8 is not supported on this platform");
         return false;
     }
 
     template<typename Dummy = void>
     std::string Cp1251ToUtf8(const std::string&) {
-        static_assert(detail::dependent_false_v<Dummy>, "Cp1251ToUtf8 is not supported on this platform");
+        static_assert(detail::dependent_false_v<Dummy>, u8"Cp1251ToUtf8 is not supported on this platform");
         return {};
     }
 
     template<typename Dummy = void>
     std::string Utf16ToUtf8(void*) {
-        static_assert(detail::dependent_false_v<Dummy>, "Utf16ToUtf8 is not supported on this platform");
+        static_assert(detail::dependent_false_v<Dummy>, u8"Utf16ToUtf8 is not supported on this platform");
         return {};
     }
 
     template<typename Dummy = void>
     std::wstring Utf8ToUtf16(const std::string&) {
-        static_assert(detail::dependent_false_v<Dummy>, "Utf8ToUtf16 is not supported on this platform");
+        static_assert(detail::dependent_false_v<Dummy>, u8"Utf8ToUtf16 is not supported on this platform");
         return {};
     }
 } // namespace ImGuiX::Utils

--- a/include/imguix/utils/path_utils.hpp
+++ b/include/imguix/utils/path_utils.hpp
@@ -37,7 +37,7 @@ namespace ImGuiX::Utils {
     template<typename Dummy = void>
     std::string getExecPath() {
 #ifdef __EMSCRIPTEN__
-        static_assert(detail::dependent_false_v<Dummy>, "getExecPath is not supported on Emscripten");
+        static_assert(detail::dependent_false_v<Dummy>, u8"getExecPath is not supported on Emscripten");
         return {};
 #elif defined(_WIN32)
         std::vector<wchar_t> buffer(MAX_PATH);
@@ -50,7 +50,7 @@ namespace ImGuiX::Utils {
         }
 
         if (size == 0)
-            throw std::runtime_error("Failed to get executable path.");
+            throw std::runtime_error(u8"Failed to get executable path.");
 
         std::wstring exe_path(buffer.begin(), buffer.begin() + size);
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
@@ -61,14 +61,14 @@ namespace ImGuiX::Utils {
         if (_NSGetExecutablePath(buffer.data(), &size) != 0) {
             buffer.resize(size);
             if (_NSGetExecutablePath(buffer.data(), &size) != 0)
-                throw std::runtime_error("Failed to get executable path.");
+                throw std::runtime_error(u8"Failed to get executable path.");
         }
         return std::string(buffer.data());
 #else
         char result[PATH_MAX];
-        ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
+        ssize_t count = readlink(u8"/proc/self/exe", result, PATH_MAX);
         if (count == -1)
-            throw std::runtime_error("Failed to get executable path.");
+            throw std::runtime_error(u8"Failed to get executable path.");
 
         return std::string(result, count);
 #endif
@@ -81,7 +81,7 @@ namespace ImGuiX::Utils {
     template<typename Dummy = void>
     std::string getExecDir() {
 #ifdef __EMSCRIPTEN__
-        static_assert(detail::dependent_false_v<Dummy>, "getExecDir is not supported on Emscripten");
+        static_assert(detail::dependent_false_v<Dummy>, u8"getExecDir is not supported on Emscripten");
         return {};
 #else
         fs::path path = fs::u8path(getExecPath());
@@ -96,7 +96,7 @@ namespace ImGuiX::Utils {
     template<typename Dummy = void>
     std::string resolveExecPath(const std::string& relative_path) {
 #ifdef __EMSCRIPTEN__
-        static_assert(detail::dependent_false_v<Dummy>, "resolveExecPath is not supported on Emscripten");
+        static_assert(detail::dependent_false_v<Dummy>, u8"resolveExecPath is not supported on Emscripten");
         return relative_path;
 #else
         return (fs::u8path(getExecDir()) / fs::u8path(relative_path)).u8string();
@@ -110,7 +110,7 @@ namespace ImGuiX::Utils {
     template<typename Dummy = void>
     std::string getFileName(const std::string& full_path) {
 #ifdef __EMSCRIPTEN__
-        static_assert(detail::dependent_false_v<Dummy>, "getFileName is not supported on Emscripten");
+        static_assert(detail::dependent_false_v<Dummy>, u8"getFileName is not supported on Emscripten");
         return full_path;
 #else
         return fs::u8path(full_path).filename().u8string();
@@ -125,7 +125,7 @@ namespace ImGuiX::Utils {
     template<typename Dummy = void>
     std::string makeRelative(const std::string& file_path, const std::string& base_path) {
 #ifdef __EMSCRIPTEN__
-        static_assert(detail::dependent_false_v<Dummy>, "makeRelative is not supported on Emscripten");
+        static_assert(detail::dependent_false_v<Dummy>, u8"makeRelative is not supported on Emscripten");
         return file_path;
 #else
         if (base_path.empty()) return file_path;
@@ -146,14 +146,14 @@ namespace ImGuiX::Utils {
     template<typename Dummy = void>
     void createDirectories(const std::string& path) {
 #ifdef __EMSCRIPTEN__
-        static_assert(detail::dependent_false_v<Dummy>, "createDirectories is not supported on Emscripten");
+        static_assert(detail::dependent_false_v<Dummy>, u8"createDirectories is not supported on Emscripten");
         (void)path;
 #else
         fs::path dir = fs::u8path(path);
         if (!fs::exists(dir)) {
             std::error_code ec;
             if (!fs::create_directories(dir, ec)) {
-                throw std::runtime_error("Failed to create directories: " + dir.u8string());
+                throw std::runtime_error(u8"Failed to create directories: " + dir.u8string());
             }
         }
 #endif

--- a/include/imguix/utils/strip_json_comments.hpp
+++ b/include/imguix/utils/strip_json_comments.hpp
@@ -70,7 +70,7 @@ namespace ImGuiX::Utils {
             const char next = (i + 1 < n) ? json_string[i + 1] : '\0';
 
             // Handle string boundaries only outside comments
-            if (comment == Comment::None && c == '"') {
+            if (comment == Comment::None && c == 'u8"') {
                 if (!detail::is_escaped_quote(json_string, i)) {
                     in_string = !in_string;
                 }
@@ -159,7 +159,7 @@ namespace ImGuiX::Utils {
             }
 
             if (comment == Comment::Block) {
-                // End of block comment "*/"
+                // End of block comment "*/u8"
                 if (c == '*' && next == '/') {
                     const std::size_t comment_end_inclusive = i + 1; // include '/'
                     if (with_whitespace) {

--- a/include/imguix/widgets/arrow_stepper.hpp
+++ b/include/imguix/widgets/arrow_stepper.hpp
@@ -19,8 +19,8 @@ namespace ImGuiX::Widgets {
         int   step        = 1;      ///< Increment/decrement step
         bool  wrap        = true;   ///< If exceed bounds, wrap to the other side
         float input_width = 48.0f;  ///< Width of InputInt
-        const char* fmt   = "%02d"; ///< Small preview text to the right
-        const char* input_id = "##val"; ///< ID for InputInt inside local PushID
+        const char* fmt   = u8"%02d"; ///< Small preview text to the right
+        const char* input_id = u8"##val"; ///< ID for InputInt inside local PushID
         float same_line_spacing = 2.0f; ///< Spacing between items on SameLine
         bool  disable_at_edges = true;
     };
@@ -56,7 +56,7 @@ namespace ImGuiX::Widgets {
         // Up
         bool at_up_edge = (!cfg.wrap && v >= maxv);
         if (cfg.disable_at_edges && at_up_edge) ImGui::BeginDisabled(true);
-        if (ImGui::ArrowButton("##up", ImGuiDir_Up)) {
+        if (ImGui::ArrowButton(u8"##up", ImGuiDir_Up)) {
             int nv = v + step;
             if (nv > maxv) {
                 if (cfg.wrap) nv = minv;
@@ -72,7 +72,7 @@ namespace ImGuiX::Widgets {
         ImGui::SameLine(0.0f, cfg.same_line_spacing);
         bool at_dn_edge = (!cfg.wrap && v <= minv);
         if (cfg.disable_at_edges && at_dn_edge) ImGui::BeginDisabled(true);
-        if (ImGui::ArrowButton("##dn", ImGuiDir_Down)) {
+        if (ImGui::ArrowButton(u8"##dn", ImGuiDir_Down)) {
             int nv = v - step;
             if (nv < minv) {
                 if (cfg.wrap) nv = maxv;

--- a/include/imguix/widgets/auth_panel.hpp
+++ b/include/imguix/widgets/auth_panel.hpp
@@ -38,9 +38,9 @@ namespace ImGuiX::Widgets {
         const char* icon_hide     = u8"\ue8f5";  ///< «глаз перечёркнутый»
         ImVec2      button_size   = ImVec2(0,0); ///< (0,0) — авто (по высоте текущего фрейма)
         float       same_line_w   = 0.0f;        ///< Отступ перед кнопкой (SameLine(offset))
-        const char* tooltip_show  = "Show password";
-        const char* tooltip_hide  = "Hide password";
-        const char* text_label    = "Show";      ///< Текст для чекбокса, если use_icon == false
+        const char* tooltip_show  = u8"Show password";
+        const char* tooltip_hide  = u8"Hide password";
+        const char* text_label    = u8"Show";      ///< Текст для чекбокса, если use_icon == false
         
         ImFont*     icon_font     = nullptr;     ///< шрифт с иконками (если null — текущий)
         float       icon_baseline = 5.0f;        ///< сдвиг по Y в пикселях (подгонка базлайна)
@@ -54,14 +54,14 @@ namespace ImGuiX::Widgets {
 
 		bool        use_icon          = true;      ///< icon or text
 		const char* icon_text         = u8"\uE312";///< default Material PUA 'keyboard' (alt: u8"\uE23E")
-		const char* text              = "[KB]";    ///< text label if use_icon==false
+		const char* text              = u8"[KB]";    ///< text label if use_icon==false
 		ImFont*     icon_font         = nullptr;   ///< icon font (merged or dedicated)
 		ImVec2      button_size       = ImVec2(0,0);
 		float       same_line_w       = 0.0f;      ///< SameLine(offset) before button
 		float       icon_baseline     = 4.0f;      ///< Y offset to fit baseline
 		float       icon_rounding     = -1.0f;     ///< bg rounding, -1 => default
-		const char* tooltip_toggle_on = "Show keyboard";
-		const char* tooltip_toggle_off= "Hide keyboard";
+		const char* tooltip_toggle_on = u8"Show keyboard";
+		const char* tooltip_toggle_off= u8"Hide keyboard";
 
 		// VK render mode
 		bool        vk_as_overlay     = true;      ///< true: floating overlay window; false: embed under form
@@ -71,12 +71,12 @@ namespace ImGuiX::Widgets {
     /// \brief Configuration for AuthPanel.
     struct AuthPanelConfig {
         // Labels
-        std::string header          = "Authorization";
-        std::string hint_email      = "email";
-        std::string hint_password   = "password";
-        std::string hint_host       = "host";
-        std::string connected_label = "connected";
-        std::string connect_label   = "connect";
+        std::string header          = u8"Authorization";
+        std::string hint_email      = u8"email";
+        std::string hint_password   = u8"password";
+        std::string hint_host       = u8"host";
+        std::string connected_label = u8"connected";
+        std::string connect_label   = u8"connect";
 
         // Options
         bool show_host              = false;
@@ -105,7 +105,7 @@ namespace ImGuiX::Widgets {
         std::function<void()> on_connect;
 
         // Email regex (basic)
-        const char* email_regex = R"(.+@.+\.\w+)";
+        const char* email_regex = u8R"(.+@.+\.\w+)";
     };
 
     /// \brief Renders login form. Optionally includes host input.
@@ -125,14 +125,14 @@ namespace ImGuiX::Widgets {
 		AuthPanelResult res = AuthPanelResult::None;
         ImGui::PushID(id);
         
-        const ImGuiID key_show_pwd = ImGui::GetID("show_password");
+        const ImGuiID key_show_pwd = ImGui::GetID(u8"show_password");
         ImGuiStorage* st = ImGui::GetStateStorage();
 
 		//--
 		enum class VKTarget : int { None=0, Host=1, Email=2, Password=3 };
 
-		const ImGuiID key_vk_visible = ImGui::GetID("vk_visible");
-		const ImGuiID key_vk_target  = ImGui::GetID("vk_target");
+		const ImGuiID key_vk_visible = ImGui::GetID(u8"vk_visible");
+		const ImGuiID key_vk_target  = ImGui::GetID(u8"vk_target");
 
 		auto get_vk_visible = [&](){ return st->GetInt(key_vk_visible, 0) != 0; };
 		auto set_vk_visible = [&](bool v){ st->SetInt(key_vk_visible, v ? 1 : 0); };
@@ -165,9 +165,9 @@ namespace ImGuiX::Widgets {
 			}
 			// tooltip reflects next state
 			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("%s", get_vk_visible() ? 
-					(cfg.vk.tooltip_toggle_off?cfg.vk.tooltip_toggle_off:"Hide keyboard"):
-					(cfg.vk.tooltip_toggle_on? cfg.vk.tooltip_toggle_on :"Show keyboard"));
+				ImGui::SetTooltip(u8"%s", get_vk_visible() ? 
+					(cfg.vk.tooltip_toggle_off?cfg.vk.tooltip_toggle_off:u8"Hide keyboard"):
+					(cfg.vk.tooltip_toggle_on? cfg.vk.tooltip_toggle_on :u8"Show keyboard"));
 			return pressed;
 		};
 
@@ -200,22 +200,22 @@ namespace ImGuiX::Widgets {
             height += ImGui::GetFrameHeightWithSpacing();
         }
         height += ImGui::GetFrameHeightWithSpacing(); // кнопка Connect
-        ImGui::BeginChild("##AuthPanel", ImVec2(ImGui::GetWindowWidth() * 0.65f, height), true);
+        ImGui::BeginChild(u8"##AuthPanel", ImVec2(ImGui::GetWindowWidth() * 0.65f, height), true);
 
-        ImGui::Text("%s", cfg.header.c_str());
+        ImGui::Text(u8"%s", cfg.header.c_str());
         ImGui::Separator();
 
         // Host
         if (cfg.show_host) {
             char buf[512];
-            std::strncpy(buf, (host ? host->c_str() : ""), sizeof(buf));
+            std::strncpy(buf, (host ? host->c_str() : u8""), sizeof(buf));
             buf[sizeof(buf)-1] = '\0';
-            if (ImGui::InputTextWithHint("##host", cfg.hint_host.c_str(), buf, sizeof(buf)-1)) {
+            if (ImGui::InputTextWithHint(u8"##host", cfg.hint_host.c_str(), buf, sizeof(buf)-1)) {
                 if (host) { *host = buf; res |= AuthPanelResult::HostChanged; }
             }
 			
 			if (cfg.vk.enabled_host) {
-				if (draw_kb_button("##vk_host")) {
+				if (draw_kb_button(u8"##vk_host")) {
 					toggle_vk_for(VKTarget::Host);
 				}
 			}
@@ -240,7 +240,7 @@ namespace ImGuiX::Widgets {
             char buf[512];
             std::strncpy(buf, email.c_str(), sizeof(buf));
             buf[sizeof(buf)-1] = '\0';
-            if (ImGui::InputTextWithHint("##email", cfg.hint_email.c_str(), buf, sizeof(buf)-1)) {
+            if (ImGui::InputTextWithHint(u8"##email", cfg.hint_email.c_str(), buf, sizeof(buf)-1)) {
                 email = buf;
                 res |= AuthPanelResult::EmailChanged;
                 // revalidate quickly
@@ -252,7 +252,7 @@ namespace ImGuiX::Widgets {
                 }
             }
 			if (cfg.vk.enabled_email) {
-				if (draw_kb_button("##vk_email")) {
+				if (draw_kb_button(u8"##vk_email")) {
 					toggle_vk_for(VKTarget::Email);
 				}
 			}
@@ -264,7 +264,7 @@ namespace ImGuiX::Widgets {
         if (cfg.use_email_state) {
             ImGui::SameLine();
             ImGui::PushStyleColor(ImGuiCol_CheckMark, cfg.email_state_color);
-            ImGui::RadioButton(cfg.email_state_label.empty() ? "state" : cfg.email_state_label.c_str(),
+            ImGui::RadioButton(cfg.email_state_label.empty() ? u8"state" : cfg.email_state_label.c_str(),
                                cfg.email_state);
             ImGui::PopStyleColor();
         }
@@ -276,12 +276,12 @@ namespace ImGuiX::Widgets {
             char buf[512];
             std::strncpy(buf, password.c_str(), sizeof(buf));
             buf[sizeof(buf)-1] = '\0';
-            if (ImGui::InputTextWithHint("##password", cfg.hint_password.c_str(), buf, sizeof(buf)-1, flags)) {
+            if (ImGui::InputTextWithHint(u8"##password", cfg.hint_password.c_str(), buf, sizeof(buf)-1, flags)) {
                 password = buf;
                 res |= AuthPanelResult::PasswordChanged;
             }
 			if (cfg.vk.enabled_password) {
-				if (draw_kb_button("##vk_password")) {
+				if (draw_kb_button(u8"##vk_password")) {
 					toggle_vk_for(VKTarget::Password);
 				}
 			}
@@ -305,15 +305,15 @@ namespace ImGuiX::Widgets {
 				eye.rounding    = cfg.password_toggle.icon_rounding;
 			
                 const char* icon = show_password ? 
-                    (cfg.password_toggle.icon_hide ? cfg.password_toggle.icon_hide : "X") : 
-                    (cfg.password_toggle.icon_show ? cfg.password_toggle.icon_show : "V");
-                if (IconButtonCentered("##pwd_eye", icon, eye)) {
+                    (cfg.password_toggle.icon_hide ? cfg.password_toggle.icon_hide : u8"X") : 
+                    (cfg.password_toggle.icon_show ? cfg.password_toggle.icon_show : u8"V");
+                if (IconButtonCentered(u8"##pwd_eye", icon, eye)) {
                     show_password = !show_password;
                     set_show(show_password);
                 }
                 if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip("%s", show_password ? (cfg.password_toggle.tooltip_hide ? cfg.password_toggle.tooltip_hide : "Hide")
-                                                          : (cfg.password_toggle.tooltip_show ? cfg.password_toggle.tooltip_show : "Show"));
+                    ImGui::SetTooltip(u8"%s", show_password ? (cfg.password_toggle.tooltip_hide ? cfg.password_toggle.tooltip_hide : u8"Hide")
+                                                          : (cfg.password_toggle.tooltip_show ? cfg.password_toggle.tooltip_show : u8"Show"));
                 }
             } else {
                 if (ImGui::Checkbox(cfg.password_toggle.text_label, &show_password)) {
@@ -371,11 +371,11 @@ namespace ImGuiX::Widgets {
 				std::string& ref = *vk_text_ptr;
 				ImGui::Dummy(ImVec2(0.0f, ImGui::GetStyle().ItemSpacing.y));
 				ImGui::Separator();
-				ImGui::TextUnformatted("Virtual keyboard:");
-				ImGuiX::Widgets::VirtualKeyboard("##vk_embed", ref, vkcfg);
+				ImGui::TextUnformatted(u8"Virtual keyboard:");
+				ImGuiX::Widgets::VirtualKeyboard(u8"##vk_embed", ref, vkcfg);
 			} else {
 				// ОВЕРЛЕЙ: поверх всех окон. Рендерим как отдельное окно ближе к концу кадра.
-				const ImGuiID key_vk_was_visible = ImGui::GetID("vk_was_visible");
+				const ImGuiID key_vk_was_visible = ImGui::GetID(u8"vk_was_visible");
 				bool vk_visible_now  = get_vk_visible();
 				bool vk_visible_prev = (st->GetInt(key_vk_was_visible, 0) != 0);
 				bool vk_just_opened  = vk_visible_now && !vk_visible_prev;
@@ -398,7 +398,7 @@ namespace ImGuiX::Widgets {
 				
 				ImGui::SetNextWindowBgAlpha(0.98f);
 				ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 6.0f);
-				if (ImGui::Begin("##vk_overlay_window",
+				if (ImGui::Begin(u8"##vk_overlay_window",
 								 nullptr,
 								 ImGuiWindowFlags_NoTitleBar |
 								 ImGuiWindowFlags_NoResize |
@@ -409,7 +409,7 @@ namespace ImGuiX::Widgets {
 				{
 					// Render VK as usual
 					std::string& ref = *vk_text_ptr;
-					bool mod = ImGuiX::Widgets::VirtualKeyboard("##vk_overlay", ref, vkcfg);
+					bool mod = ImGuiX::Widgets::VirtualKeyboard(u8"##vk_overlay", ref, vkcfg);
 					
 					// Close on ESC
 					if (ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {

--- a/include/imguix/widgets/domain_selector.hpp
+++ b/include/imguix/widgets/domain_selector.hpp
@@ -13,9 +13,9 @@ namespace ImGuiX::Widgets {
 
     /// \brief Configuration for DomainSelector.
     struct DomainSelectorConfig {
-        std::string header      = "Domain";
-        std::string hint_domain = "domain";
-        std::string custom_text = "Custom";
+        std::string header      = u8"Domain";
+        std::string hint_domain = u8"domain";
+        std::string custom_text = u8"Custom";
         std::string default_domain;
         std::string help_text;
         bool        show_help   = false;
@@ -33,8 +33,8 @@ namespace ImGuiX::Widgets {
         bool updated = false;
         ImGui::PushID(id);
 
-        ImGui::BeginChild("##DomainSelector", ImVec2(ImGui::GetWindowWidth() * 0.65f, 100.0f), true);
-        ImGui::Text("%s", cfg.header.c_str());
+        ImGui::BeginChild(u8"##DomainSelector", ImVec2(ImGui::GetWindowWidth() * 0.65f, 100.0f), true);
+        ImGui::Text(u8"%s", cfg.header.c_str());
         ImGui::Separator();
 
         bool use_input = cfg.domains.empty();
@@ -51,7 +51,7 @@ namespace ImGuiX::Widgets {
             items.push_back(cfg.custom_text.c_str());
             if (combo_index < 0) { combo_index = static_cast<int>(items.size()) - 1; use_input = true; }
 
-            if (ImGui::Combo("##domain.combo", &combo_index, items.data(), static_cast<int>(items.size()))) {
+            if (ImGui::Combo(u8"##domain.combo", &combo_index, items.data(), static_cast<int>(items.size()))) {
                 if (combo_index == static_cast<int>(cfg.domains.size())) {
                     host = cfg.default_domain;
                     use_input = true;
@@ -62,14 +62,14 @@ namespace ImGuiX::Widgets {
                 updated = true;
             }
 
-            if (cfg.show_help) { ImGui::SameLine(); ImGui::TextDisabled("(?)"); if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", cfg.help_text.c_str()); }
+            if (cfg.show_help) { ImGui::SameLine(); ImGui::TextDisabled(u8"(?)"); if (ImGui::IsItemHovered()) ImGui::SetTooltip(u8"%s", cfg.help_text.c_str()); }
         }
 
         if (use_input) {
             char buf[512];
             std::strncpy(buf, host.c_str(), sizeof(buf));
             buf[sizeof(buf)-1] = '\0';
-            if (ImGui::InputTextWithHint("##domain.input", cfg.hint_domain.c_str(), buf, sizeof(buf)-1)) {
+            if (ImGui::InputTextWithHint(u8"##domain.input", cfg.hint_domain.c_str(), buf, sizeof(buf)-1)) {
                 host = buf;
                 updated = true;
             }
@@ -77,7 +77,7 @@ namespace ImGuiX::Widgets {
 
         if (cfg.domains.empty() && cfg.show_help) {
             ImGui::SameLine();
-            ImGui::TextDisabled("(?)"); if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", cfg.help_text.c_str());
+            ImGui::TextDisabled(u8"(?)"); if (ImGui::IsItemHovered()) ImGui::SetTooltip(u8"%s", cfg.help_text.c_str());
         }
 
         ImGui::EndChild();

--- a/include/imguix/widgets/hours_selector.hpp
+++ b/include/imguix/widgets/hours_selector.hpp
@@ -15,8 +15,8 @@ namespace ImGuiX::Widgets {
 
     /// \brief Configuration for HoursSelector.
     struct HoursSelectorConfig {
-        const char* label        = "Hours";     ///< Combo label (left of preview)
-        const char* empty_hint   = "none";      ///< Preview text when no hours selected
+        const char* label        = u8"Hours";     ///< Combo label (left of preview)
+        const char* empty_hint   = u8"none";      ///< Preview text when no hours selected
         ImVec2      child_size   = ImVec2(260, 110); ///< Scrolling area size inside combo
         ImVec2      cell_size    = ImVec2(18, 18);   ///< Clickable cell size for each hour
         int         rows         = 3;           ///< Grid rows (rows*cols should cover 24)
@@ -43,12 +43,12 @@ namespace ImGuiX::Widgets {
 
         // Build compact preview string that fits into cfg.combo_width
         auto build_preview = [&](float max_w)->std::string {
-            if (selected_hours.empty()) return std::string(cfg.empty_hint ? cfg.empty_hint : "none");
+            if (selected_hours.empty()) return std::string(cfg.empty_hint ? cfg.empty_hint : u8"none");
             std::string acc;
             acc.reserve(64);
             for (size_t i = 0; i < selected_hours.size(); ++i) {
                 char tmp[8];
-                std::snprintf(tmp, sizeof(tmp), "%s%d", (i ? "," : ""), selected_hours[i]);
+                std::snprintf(tmp, sizeof(tmp), u8"%s%d", (i ? u8"," : u8""), selected_hours[i]);
                 std::string candidate = acc;
                 candidate += tmp;
                 float w = ImGui::CalcTextSize(candidate.c_str()).x;
@@ -56,10 +56,10 @@ namespace ImGuiX::Widgets {
                     acc.swap(candidate);
                 } else {
                     // Add ellipsis if anything was added before; otherwise show first with ellipsis
-                    if (!acc.empty()) acc += "...";
+                    if (!acc.empty()) acc += u8"...";
                     else {
                         // Show first number and ellipsis anyway
-                        std::snprintf(tmp, sizeof(tmp), "%d...", selected_hours[i]);
+                        std::snprintf(tmp, sizeof(tmp), u8"%d...", selected_hours[i]);
                         acc = tmp;
                     }
                     break;
@@ -79,8 +79,8 @@ namespace ImGuiX::Widgets {
 
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(cfg.combo_width);
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : "Hours", preview.c_str())) {
-            ImGui::BeginChild("##hours_grid", cfg.child_size, true);
+        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Hours", preview.c_str())) {
+            ImGui::BeginChild(u8"##hours_grid", cfg.child_size, true);
 
             // Grid layout
             const int rows = std::max(1, cfg.rows);
@@ -91,12 +91,12 @@ namespace ImGuiX::Widgets {
             const int total = std::max(rows * cols, 24);
 
             // Small toolbar (optional): Select All / Clear
-            if (ImGui::SmallButton("All")) {
+            if (ImGui::SmallButton(u8"All")) {
                 for (int i = 0; i < 24; ++i) mark[i] = true;
                 changed = true;
             }
             ImGui::SameLine();
-            if (ImGui::SmallButton("None")) {
+            if (ImGui::SmallButton(u8"None")) {
                 for (int i = 0; i < 24; ++i) mark[i] = false;
                 changed = true;
             }
@@ -113,7 +113,7 @@ namespace ImGuiX::Widgets {
                     }
                     ImGui::PushID(idx);
                     char label_txt[4];
-                    std::snprintf(label_txt, sizeof(label_txt), "%d", idx);
+                    std::snprintf(label_txt, sizeof(label_txt), u8"%d", idx);
 
                     bool selected = mark[idx];
                     if (selected && cfg.use_header_color_for_selected) {

--- a/include/imguix/widgets/proxy_panel.hpp
+++ b/include/imguix/widgets/proxy_panel.hpp
@@ -30,14 +30,14 @@ namespace ImGuiX::Widgets {
     /// \brief UI configuration for ProxyPanel.
     struct ProxyPanelConfig {
         // Labels
-        const char* header            = "Proxy settings";
-        const char* hint_ip           = "ip";
-        const char* hint_port         = "port";
-        const char* hint_user         = "user";
-        const char* hint_pass         = "password";
-        const char* label_use_proxy   = "use proxy";
-        const char* button_check      = "check proxy";
-        const char* label_checked     = "checked";
+        const char* header            = u8"Proxy settings";
+        const char* hint_ip           = u8"ip";
+        const char* hint_port         = u8"port";
+        const char* hint_user         = u8"user";
+        const char* hint_pass         = u8"password";
+        const char* label_use_proxy   = u8"use proxy";
+        const char* button_check      = u8"check proxy";
+        const char* label_checked     = u8"checked";
 
         // Options
         bool show_type                = true;   ///< show type combo (HTTP/SOCKS)
@@ -69,8 +69,8 @@ namespace ImGuiX::Widgets {
                           ? ImVec2(ImGui::GetWindowWidth() * 0.65f, 148.0f)
                           : cfg.panel_size;
 
-        ImGui::BeginChild("##proxy_panel", size, cfg.border);
-        ImGui::Text("%s", cfg.header ? cfg.header : "Proxy");
+        ImGui::BeginChild(u8"##proxy_panel", size, cfg.border);
+        ImGui::Text(u8"%s", cfg.header ? cfg.header : u8"Proxy");
         ImGui::Separator();
 
         // Collapse inputs when proxy disabled (but still visible)
@@ -80,7 +80,7 @@ namespace ImGuiX::Widgets {
         bool bad_ip = false;
         if (!st.ip.empty()) {
             // Minimal IPv4 check. For hostnames, расширь по необходимости.
-            static const std::regex re_ip(R"(^\d{1,3}(\.\d{1,3}){3}$)");
+            static const std::regex re_ip(u8R"(^\d{1,3}(\.\d{1,3}){3}$)");
             bad_ip = !std::regex_match(st.ip, re_ip);
         }
 
@@ -91,7 +91,7 @@ namespace ImGuiX::Widgets {
             char buf[256];
             std::strncpy(buf, st.ip.c_str(), sizeof(buf));
             buf[sizeof(buf)-1] = '\0';
-            if (ImGui::InputTextWithHint("##proxy.ip", cfg.hint_ip, buf, sizeof(buf)-1,
+            if (ImGui::InputTextWithHint(u8"##proxy.ip", cfg.hint_ip, buf, sizeof(buf)-1,
                                          ImGuiInputTextFlags_AutoSelectAll)) {
                 st.ip = buf;
                 changed = true;
@@ -101,15 +101,15 @@ namespace ImGuiX::Widgets {
         if (bad_ip) ImGui::PopStyleColor();
 
         ImGui::SameLine();
-        ImGui::TextUnformatted(":");
+        ImGui::TextUnformatted(u8":");
 
         // --- Port ---
         ImGui::SameLine();
         ImGui::PushItemWidth(cfg.field_width_port);
         {
             char pbuf[32];
-            std::snprintf(pbuf, sizeof(pbuf), "%d", std::max(0, st.port));
-            if (ImGui::InputTextWithHint("##proxy.port", cfg.hint_port, pbuf, sizeof(pbuf)-1,
+            std::snprintf(pbuf, sizeof(pbuf), u8"%d", std::max(0, st.port));
+            if (ImGui::InputTextWithHint(u8"##proxy.port", cfg.hint_port, pbuf, sizeof(pbuf)-1,
                                          ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_CharsDecimal)) {
                 int v = 0;
                 if (*pbuf) v = std::clamp(std::atoi(pbuf), 0, 65535);
@@ -123,8 +123,8 @@ namespace ImGuiX::Widgets {
             ImGui::SameLine();
             ImGui::PushItemWidth(cfg.field_width_type);
             int t = static_cast<int>(st.type);
-            const char* items[] = { "HTTP", "SOCKS 4", "SOCKS 5" };
-            if (ImGui::Combo("##proxy.type", &t, items, IM_ARRAYSIZE(items))) {
+            const char* items[] = { u8"HTTP", u8"SOCKS 4", u8"SOCKS 5" };
+            if (ImGui::Combo(u8"##proxy.type", &t, items, IM_ARRAYSIZE(items))) {
                 st.type = static_cast<ProxyType>(t);
                 changed = true;
             }
@@ -137,7 +137,7 @@ namespace ImGuiX::Widgets {
             char ubuf[256];
             std::strncpy(ubuf, st.username.c_str(), sizeof(ubuf));
             ubuf[sizeof(ubuf)-1] = '\0';
-            if (ImGui::InputTextWithHint("##proxy.user", cfg.hint_user, ubuf, sizeof(ubuf)-1,
+            if (ImGui::InputTextWithHint(u8"##proxy.user", cfg.hint_user, ubuf, sizeof(ubuf)-1,
                                          ImGuiInputTextFlags_AutoSelectAll)) {
                 st.username = ubuf;
                 changed = true;
@@ -146,7 +146,7 @@ namespace ImGuiX::Widgets {
         ImGui::PopItemWidth();
 
         ImGui::SameLine();
-        ImGui::TextUnformatted(":");
+        ImGui::TextUnformatted(u8":");
 
         // --- Pass ---
         ImGui::SameLine();
@@ -155,7 +155,7 @@ namespace ImGuiX::Widgets {
             char pbuf2[256];
             std::strncpy(pbuf2, st.password.c_str(), sizeof(pbuf2));
             pbuf2[sizeof(pbuf2)-1] = '\0';
-            if (ImGui::InputTextWithHint("##proxy.pass", cfg.hint_pass, pbuf2, sizeof(pbuf2)-1,
+            if (ImGui::InputTextWithHint(u8"##proxy.pass", cfg.hint_pass, pbuf2, sizeof(pbuf2)-1,
                                          ImGuiInputTextFlags_Password)) {
                 st.password = pbuf2;
                 changed = true;

--- a/include/imguix/widgets/text_center.hpp
+++ b/include/imguix/widgets/text_center.hpp
@@ -60,10 +60,10 @@ namespace ImGuiX::Widgets {
         const float x  = x0 + (avail_w - block_w) * 0.5f;
         ImGui::SetCursorPosX(x);
 
-        ImGui::BeginChild("##TextWrappedCentered", ImVec2(block_w, 0.0f),
+        ImGui::BeginChild(u8"##TextWrappedCentered", ImVec2(block_w, 0.0f),
                           false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBackground);
         ImGui::PushTextWrapPos(0.0f);
-        ImGui::TextWrapped("%s", text);
+        ImGui::TextWrapped(u8"%s", text);
         ImGui::PopTextWrapPos();
         ImGui::EndChild();
     }

--- a/include/imguix/widgets/time_picker.hpp
+++ b/include/imguix/widgets/time_picker.hpp
@@ -41,7 +41,7 @@ namespace ImGuiX::Widgets {
 
     inline std::string format_hms(uint32_t sec) {
         int h, m, s; seconds_to_hms(static_cast<int>(sec), h, m, s);
-        char buf[16]; std::snprintf(buf, sizeof(buf), "%02d:%02d:%02d", h, m, s);
+        char buf[16]; std::snprintf(buf, sizeof(buf), u8"%02d:%02d:%02d", h, m, s);
         return std::string(buf);
     }
 
@@ -50,7 +50,7 @@ namespace ImGuiX::Widgets {
         uint32_t a = static_cast<uint32_t>(pos ? off_sec : -off_sec);
         char buf[20];
         int h, m, s; seconds_to_hms(static_cast<int>(a), h, m, s);
-        std::snprintf(buf, sizeof(buf), "%c%02d:%02d:%02d", pos ? '+' : '-', h, m, s);
+        std::snprintf(buf, sizeof(buf), u8"%c%02d:%02d:%02d", pos ? '+' : '-', h, m, s);
         return std::string(buf);
     }
     
@@ -67,14 +67,14 @@ namespace ImGuiX::Widgets {
         int n = 0;
 
         // Try HH:MM:SS
-        if (std::sscanf(txt, "%d:%d:%d%n", &h, &m, &s, &n) >= 2 && n > 0) {
+        if (std::sscanf(txt, u8"%d:%d:%d%n", &h, &m, &s, &n) >= 2 && n > 0) {
             // ok
-        } else if (std::sscanf(txt, "%d:%d%n", &h, &m, &n) == 2) {
+        } else if (std::sscanf(txt, u8"%d:%d%n", &h, &m, &n) == 2) {
             s = 0;
         } else {
             // Try compact HHMM or HMM
             int packed = 0;
-            if (std::sscanf(txt, "%d%n", &packed, &n) == 1) {
+            if (std::sscanf(txt, u8"%d%n", &packed, &n) == 1) {
                 if (packed < 0) packed = -packed;
                 if (packed >= 0 && packed <= 235959) {
                     if (packed <= 959) { // HMM
@@ -106,8 +106,8 @@ namespace ImGuiX::Widgets {
     // ---------- configs & data ---------------------------------------------------
 
     struct TimePickerConfig {
-        const char* label       = "Time";
-        const char* desc        = "HH:MM:SS";
+        const char* label       = u8"Time";
+        const char* desc        = u8"HH:MM:SS";
         float       combo_width = 160.0f;
         bool        show_desc   = true;
         float       field_width = 48.0f;
@@ -122,37 +122,37 @@ namespace ImGuiX::Widgets {
 
     inline const std::vector<TimeZoneInfo>& DefaultTimeZones() {
         static const std::vector<TimeZoneInfo> tz = {
-            {"_custom",           "Custom (manual)",             0,     false},
-            {"Europe/London",     "London (UTC+0)",              0,     true },
-            {"Europe/Berlin",     "Frankfurt/Berlin (UTC+1)",    3600,  true },
-            {"Europe/Zurich",     "Zurich (UTC+1)",              3600,  true },
-            {"Europe/Moscow",     "Moscow (UTC+3)",              10800, false},
+            {u8"_custom",           u8"Custom (manual)",             0,     false},
+            {u8"Europe/London",     u8"London (UTC+0)",              0,     true },
+            {u8"Europe/Berlin",     u8"Frankfurt/Berlin (UTC+1)",    3600,  true },
+            {u8"Europe/Zurich",     u8"Zurich (UTC+1)",              3600,  true },
+            {u8"Europe/Moscow",     u8"Moscow (UTC+3)",              10800, false},
 
-            {"America/New_York",  "New York (UTC-5)",           -18000, true },
-            {"America/Chicago",   "Chicago (UTC-6)",            -21600, true },
-            {"America/Denver",    "Denver (UTC-7)",             -25200, true },
-            {"America/Los_Angeles","Los Angeles (UTC-8)",       -28800, true },
+            {u8"America/New_York",  u8"New York (UTC-5)",           -18000, true },
+            {u8"America/Chicago",   u8"Chicago (UTC-6)",            -21600, true },
+            {u8"America/Denver",    u8"Denver (UTC-7)",             -25200, true },
+            {u8"America/Los_Angeles",u8"Los Angeles (UTC-8)",       -28800, true },
 
-            {"Asia/Shanghai",     "Shanghai (UTC+8)",            28800, false},
-            {"Asia/Hong_Kong",    "Hong Kong (UTC+8)",           28800, false},
-            {"Asia/Singapore",    "Singapore (UTC+8)",           28800, false},
-            {"Asia/Tokyo",        "Tokyo (UTC+9)",               32400, false},
-            {"Asia/Seoul",        "Seoul (UTC+9)",               32400, false},
+            {u8"Asia/Shanghai",     u8"Shanghai (UTC+8)",            28800, false},
+            {u8"Asia/Hong_Kong",    u8"Hong Kong (UTC+8)",           28800, false},
+            {u8"Asia/Singapore",    u8"Singapore (UTC+8)",           28800, false},
+            {u8"Asia/Tokyo",        u8"Tokyo (UTC+9)",               32400, false},
+            {u8"Asia/Seoul",        u8"Seoul (UTC+9)",               32400, false},
 
-            {"Australia/Sydney",  "Sydney (UTC+10)",             36000, true },
+            {u8"Australia/Sydney",  u8"Sydney (UTC+10)",             36000, true },
 
-            {"America/Sao_Paulo", "Sao Paulo (UTC-3)",          -10800, true },
-            {"America/Mexico_City","Mexico City (UTC-6)",       -21600, true },
+            {u8"America/Sao_Paulo", u8"Sao Paulo (UTC-3)",          -10800, true },
+            {u8"America/Mexico_City",u8"Mexico City (UTC-6)",       -21600, true },
 
-            {"Asia/Dubai",        "Dubai (UTC+4)",               14400, false},
-            {"Asia/Jerusalem",    "Tel Aviv (UTC+2)",            7200,  true }
+            {u8"Asia/Dubai",        u8"Dubai (UTC+4)",               14400, false},
+            {u8"Asia/Jerusalem",    u8"Tel Aviv (UTC+2)",            7200,  true }
         };
         return tz;
     }
 
     struct TimeOffsetPickerConfig {
-        const char* label        = "Offset";
-        const char* desc         = "±HH:MM:SS";
+        const char* label        = u8"Offset";
+        const char* desc         = u8"±HH:MM:SS";
         float       combo_width  = 210.0f;
         bool        show_desc    = true;
         bool        show_gmt     = true;
@@ -170,19 +170,19 @@ namespace ImGuiX::Widgets {
 
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(cfg.combo_width);
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : "Time", preview.c_str())) {
+        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Time", preview.c_str())) {
             if (cfg.show_desc && cfg.desc) ImGui::TextUnformatted(cfg.desc);
 
             int h, m, s; seconds_to_hms(seconds, h, m, s);
 
-            ArrowStepperConfig sc_h{0,23,1,true,cfg.field_width,"%02d h"};
-            ArrowStepperConfig sc_m{0,59,1,true,cfg.field_width,"%02d m"};
-            ArrowStepperConfig sc_s{0,59,1,true,cfg.field_width,"%02d s"};
+            ArrowStepperConfig sc_h{0,23,1,true,cfg.field_width,u8"%02d h"};
+            ArrowStepperConfig sc_m{0,59,1,true,cfg.field_width,u8"%02d m"};
+            ArrowStepperConfig sc_s{0,59,1,true,cfg.field_width,u8"%02d s"};
 
             bool any = false;
-            any |= ArrowStepper("h", h, sc_h);
-            any |= ArrowStepper("m", m, sc_m);
-            any |= ArrowStepper("s", s, sc_s);
+            any |= ArrowStepper(u8"h", h, sc_h);
+            any |= ArrowStepper(u8"m", m, sc_m);
+            any |= ArrowStepper(u8"s", s, sc_s);
 
             int prev = seconds;
             seconds = hms_to_seconds(h, m, s);
@@ -214,13 +214,13 @@ namespace ImGuiX::Widgets {
 
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(cfg.combo_width);
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : "Offset", preview.c_str())) {
+        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Offset", preview.c_str())) {
             if (cfg.show_desc && cfg.desc) ImGui::TextUnformatted(cfg.desc);
 
             // Timezone combo
             if (cfg.show_tz_list && !tzlist.empty()) {
                 const char* cur = tzlist[tz_index_io].label;
-                if (ImGui::BeginCombo("Timezone", cur)) {
+                if (ImGui::BeginCombo(u8"Timezone", cur)) {
                     for (int i = 0; i < (int)tzlist.size(); ++i) {
                         bool sel = (i == tz_index_io);
                         if (ImGui::Selectable(tzlist[i].label, sel)) { tz_index_io = i; changed = true; }
@@ -245,16 +245,16 @@ namespace ImGuiX::Widgets {
             // 1) Direct string edit with sign parsing
             {
                 char buf[32];
-                std::snprintf(buf, sizeof(buf), "%s", format_signed_hms(offset_sec).c_str());
+                std::snprintf(buf, sizeof(buf), u8"%s", format_signed_hms(offset_sec).c_str());
                 ImGui::SetNextItemWidth(140.0f);
-                if (ImGui::InputText("##offset_str", buf, sizeof(buf))) {
+                if (ImGui::InputText(u8"##offset_str", buf, sizeof(buf))) {
                     int64_t v = 0;
                     if (parse_signed_hms(buf, v)) {
                         if (v != offset_sec) { offset_sec = v; changed = true; }
                     }
                 }
                 ImGui::SameLine();
-                ImGui::TextUnformatted("±HH:MM[:SS]");
+                ImGui::TextUnformatted(u8"±HH:MM[:SS]");
             }
 
             // 2) H/M/S steppers edit magnitude + allow crossing zero to change sign
@@ -268,9 +268,9 @@ namespace ImGuiX::Widgets {
                 const bool was_positive = positive;
 
                 // steppers: NO wrap here (we control borders ourselves)
-                ArrowStepperConfig sc_h{0,23,1,false,cfg.field_width,"%02d h"};
-                ArrowStepperConfig sc_m{0,59,1,false,cfg.field_width,"%02d m"};
-                ArrowStepperConfig sc_s{0,59,1,false,cfg.field_width,"%02d s"};
+                ArrowStepperConfig sc_h{0,23,1,false,cfg.field_width,u8"%02d h"};
+                ArrowStepperConfig sc_m{0,59,1,false,cfg.field_width,u8"%02d m"};
+                ArrowStepperConfig sc_s{0,59,1,false,cfg.field_width,u8"%02d s"};
 				
 				sc_h.disable_at_edges = false;
 				sc_m.disable_at_edges = false;
@@ -278,9 +278,9 @@ namespace ImGuiX::Widgets {
 
                 int dh = 0, dm = 0, ds = 0; // last deltas from arrows/wheel; 0 if edited via text
                 bool any = false;
-                any |= ArrowStepper("oh", h, sc_h, &dh);
-                any |= ArrowStepper("om", m, sc_m, &dm);
-                any |= ArrowStepper("os", s, sc_s, &ds);
+                any |= ArrowStepper(u8"oh", h, sc_h, &dh);
+                any |= ArrowStepper(u8"om", m, sc_m, &dm);
+                any |= ArrowStepper(u8"os", s, sc_s, &ds);
 
                 int new_abs = hms_to_seconds(h, m, s);
 
@@ -311,8 +311,8 @@ namespace ImGuiX::Widgets {
 
             if (cfg.show_gmt) {
                 std::string g = format_signed_hms(offset_sec);
-                ImGui::Text("GMT %s%s", g.c_str(),
-                            (!custom && has_dst_out) ? " (DST observed)" : "");
+                ImGui::Text(u8"GMT %s%s", g.c_str(),
+                            (!custom && has_dst_out) ? u8" (DST observed)" : u8"");
             }
 
             ImGui::EndCombo();

--- a/include/imguix/widgets/virtual_keyboard.hpp
+++ b/include/imguix/widgets/virtual_keyboard.hpp
@@ -8,7 +8,7 @@
 /// ImGui 1.92.* compatible (public API only).
 
 #if defined(_MSC_VER)
-#pragma execution_character_set("utf-8")
+#pragma execution_character_set(u8"utf-8")
 #endif
 
 #include <imgui.h>
@@ -77,12 +77,12 @@ namespace ImGuiX::Widgets {
         
         // Locale/Layouts
         std::vector<const char*> locales = {
-            "en",
-            "es","pt-BR","pt","fr","de","it",
-            "ru","uk","be",
-            "tr","pl",
-            "id","vi","th",
-            "ar","hi","ur"
+            u8"en",
+            u8"es",u8"pt-BR",u8"pt",u8"fr",u8"de",u8"it",
+            u8"ru",u8"uk",u8"be",
+            u8"tr",u8"pl",
+            u8"id",u8"vi",u8"th",
+            u8"ar",u8"hi",u8"ur"
         };
         int     start_locale_index = 0;        ///< index inside locales
 
@@ -121,31 +121,31 @@ namespace ImGuiX::Widgets {
             u8"ñ", u8"Ñ", u8"á", u8"é", u8"í", u8"ó", u8"ú", u8"ü", u8"¡", u8"¿"
         };
         // PT (+BR)
-        static const char* ACC_PT[] = { "ç","Ç","ã","Ã","õ","Õ","á","é","í","ó","ú" };
+        static const char* ACC_PT[] = { u8"ç",u8"Ç",u8"ã",u8"Ã",u8"õ",u8"Õ",u8"á",u8"é",u8"í",u8"ó",u8"ú" };
         // DE
-        static const char* ACC_DE[] = { "ä","Ä","ö","Ö","ü","Ü","ß","ẞ" };
+        static const char* ACC_DE[] = { u8"ä",u8"Ä",u8"ö",u8"Ö",u8"ü",u8"Ü",u8"ß",u8"ẞ" };
         // FR
-        static const char* ACC_FR[] = { "ç","Ç","œ","Œ","æ","Æ","é","è","ê","ë","â","î","ô","û","ï","ü","à","ù","ç" };
+        static const char* ACC_FR[] = { u8"ç",u8"Ç",u8"œ",u8"Œ",u8"æ",u8"Æ",u8"é",u8"è",u8"ê",u8"ë",u8"â",u8"î",u8"ô",u8"û",u8"ï",u8"ü",u8"à",u8"ù",u8"ç" };
         // IT
-        static const char* ACC_IT[] = { "à","è","é","ì","ò","ù","À","È","É","Ì","Ò","Ù" };
+        static const char* ACC_IT[] = { u8"à",u8"è",u8"é",u8"ì",u8"ò",u8"ù",u8"À",u8"È",u8"É",u8"Ì",u8"Ò",u8"Ù" };
         // PL
-        static const char* ACC_PL[] = { "ą","Ą","ć","Ć","ę","Ę","ł","Ł","ń","Ń","ó","Ó","ś","Ś","ź","Ź","ż","Ż" };
+        static const char* ACC_PL[] = { u8"ą",u8"Ą",u8"ć",u8"Ć",u8"ę",u8"Ę",u8"ł",u8"Ł",u8"ń",u8"Ń",u8"ó",u8"Ó",u8"ś",u8"Ś",u8"ź",u8"Ź",u8"ż",u8"Ż" };
         // TR
-        static const char* ACC_TR[] = { "ç","Ç","ğ","Ğ","ı","İ","ö","Ö","ş","Ş","ü","Ü" };
+        static const char* ACC_TR[] = { u8"ç",u8"Ç",u8"ğ",u8"Ğ",u8"ı",u8"İ",u8"ö",u8"Ö",u8"ş",u8"Ş",u8"ü",u8"Ü" };
 
         // Fallback (id/en/ru/uk/be/…)
         static const AccentsSet ACC_EMPTY{ nullptr, 0 };
         
         if (!lc) return ACC_EMPTY;
         auto eq = [](const char* a, const char* b){ return a && std::strcmp(a,b)==0; };
-        if (eq(lc,"es"))   return AccentsSet{ ACC_ES, (int)(sizeof(ACC_ES)/sizeof(*ACC_ES)) };
-        if (eq(lc,"pt") || eq(lc,"pt-BR"))
+        if (eq(lc,u8"es"))   return AccentsSet{ ACC_ES, (int)(sizeof(ACC_ES)/sizeof(*ACC_ES)) };
+        if (eq(lc,u8"pt") || eq(lc,u8"pt-BR"))
                            return AccentsSet{ ACC_PT, (int)(sizeof(ACC_PT)/sizeof(*ACC_PT)) };
-        if (eq(lc,"de"))   return AccentsSet{ ACC_DE, (int)(sizeof(ACC_DE)/sizeof(*ACC_DE)) };
-        if (eq(lc,"fr"))   return AccentsSet{ ACC_FR, (int)(sizeof(ACC_FR)/sizeof(*ACC_FR)) };
-        if (eq(lc,"it"))   return AccentsSet{ ACC_IT, (int)(sizeof(ACC_IT)/sizeof(*ACC_IT)) };
-        if (eq(lc,"pl"))   return AccentsSet{ ACC_PL, (int)(sizeof(ACC_PL)/sizeof(*ACC_PL)) };
-        if (eq(lc,"tr"))   return AccentsSet{ ACC_TR, (int)(sizeof(ACC_TR)/sizeof(*ACC_TR)) };
+        if (eq(lc,u8"de"))   return AccentsSet{ ACC_DE, (int)(sizeof(ACC_DE)/sizeof(*ACC_DE)) };
+        if (eq(lc,u8"fr"))   return AccentsSet{ ACC_FR, (int)(sizeof(ACC_FR)/sizeof(*ACC_FR)) };
+        if (eq(lc,u8"it"))   return AccentsSet{ ACC_IT, (int)(sizeof(ACC_IT)/sizeof(*ACC_IT)) };
+        if (eq(lc,u8"pl"))   return AccentsSet{ ACC_PL, (int)(sizeof(ACC_PL)/sizeof(*ACC_PL)) };
+        if (eq(lc,u8"tr"))   return AccentsSet{ ACC_TR, (int)(sizeof(ACC_TR)/sizeof(*ACC_TR)) };
         return ACC_EMPTY;
     }
 
@@ -168,19 +168,19 @@ namespace ImGuiX::Widgets {
     inline const KBLayout& get_layout(const char* name) {
         // English (ASCII): uppercase computed at press-time for ASCII
         static const KBLayout EN {
-            "en",
-            {"q","w","e","r","t","y","u","i","o","p"}, 10,
-            {"a","s","d","f","g","h","j","k","l"},     9,
-            {"z","x","c","v","b","n","m"},             7,
+            u8"en",
+            {u8"q",u8"w",u8"e",u8"r",u8"t",u8"y",u8"u",u8"i",u8"o",u8"p"}, 10,
+            {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l"},     9,
+            {u8"z",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m"},             7,
             // uppercase placeholders (not used; will be toupper for ASCII)
-            {"Q","W","E","R","T","Y","U","I","O","P"}, 10,
-            {"A","S","D","F","G","H","J","K","L"},      9,
-            {"Z","X","C","V","B","N","M"},              7
+            {u8"Q",u8"W",u8"E",u8"R",u8"T",u8"Y",u8"U",u8"I",u8"O",u8"P"}, 10,
+            {u8"A",u8"S",u8"D",u8"F",u8"G",u8"H",u8"J",u8"K",u8"L"},      9,
+            {u8"Z",u8"X",u8"C",u8"V",u8"B",u8"N",u8"M"},              7
         };
         
         // ES (Spanish): add ñ / Ñ
         static const KBLayout ES {
-            "es",
+            u8"es",
             {u8"q",u8"w",u8"e",u8"r",u8"t",u8"y",u8"u",u8"i",u8"o",u8"p"}, 10,
             {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l",u8"ñ"}, 10,
             {u8"z",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m"},                    7,
@@ -191,118 +191,118 @@ namespace ImGuiX::Widgets {
         
         // PT (Portuguese, incl. pt-BR): add ç / Ç and ã / Ã, õ / Õ
         static const KBLayout PT {
-            "pt",
-            {"q","w","e","r","t","y","u","i","o","p"},      10,
-            {"a","s","d","f","g","h","j","k","l","ç"},      10,
-            {"z","x","c","v","b","n","m","ã","õ"},          9,
-            {"Q","W","E","R","T","Y","U","I","O","P"},      10,
-            {"A","S","D","F","G","H","J","K","L","Ç"},      10,
-            {"Z","X","C","V","B","N","M","Ã","Õ"},          9
+            u8"pt",
+            {u8"q",u8"w",u8"e",u8"r",u8"t",u8"y",u8"u",u8"i",u8"o",u8"p"},      10,
+            {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l",u8"ç"},      10,
+            {u8"z",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m",u8"ã",u8"õ"},          9,
+            {u8"Q",u8"W",u8"E",u8"R",u8"T",u8"Y",u8"U",u8"I",u8"O",u8"P"},      10,
+            {u8"A",u8"S",u8"D",u8"F",u8"G",u8"H",u8"J",u8"K",u8"L",u8"Ç"},      10,
+            {u8"Z",u8"X",u8"C",u8"V",u8"B",u8"N",u8"M",u8"Ã",u8"Õ"},          9
         };
         
         // DE (German): add ä ö ü ß (ẞ uppercase)
         static const KBLayout DE {
-            "de",
-            {"q","w","e","r","t","z","u","i","o","p"},         10, // 'z' position per DE habit
-            {"a","s","d","f","g","h","j","k","l","ä","ö"},     11,
-            {"y","x","c","v","b","n","m","ü","ß"},             9,
-            {"Q","W","E","R","T","Z","U","I","O","P"},         10,
-            {"A","S","D","F","G","H","J","K","L","Ä","Ö"},     11,
-            {"Y","X","C","V","B","N","M","Ü","ẞ"},             9
+            u8"de",
+            {u8"q",u8"w",u8"e",u8"r",u8"t",u8"z",u8"u",u8"i",u8"o",u8"p"},         10, // 'z' position per DE habit
+            {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l",u8"ä",u8"ö"},     11,
+            {u8"y",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m",u8"ü",u8"ß"},             9,
+            {u8"Q",u8"W",u8"E",u8"R",u8"T",u8"Z",u8"U",u8"I",u8"O",u8"P"},         10,
+            {u8"A",u8"S",u8"D",u8"F",u8"G",u8"H",u8"J",u8"K",u8"L",u8"Ä",u8"Ö"},     11,
+            {u8"Y",u8"X",u8"C",u8"V",u8"B",u8"N",u8"M",u8"Ü",u8"ẞ"},             9
         };
         
         // FR (French): add ç / Ç, œ / Œ, æ / Æ (acute etc. via accent panel later)
         static const KBLayout FR {
-            "fr",
-            {"q","w","e","r","t","y","u","i","o","p"},         10,
-            {"a","s","d","f","g","h","j","k","l","ç","œ"},     11,
-            {"z","x","c","v","b","n","m","æ"},                  8,
-            {"Q","W","E","R","T","Y","U","I","O","P"},         10,
-            {"A","S","D","F","G","H","J","K","L","Ç","Œ"},     11,
-            {"Z","X","C","V","B","N","M","Æ"},                  8
+            u8"fr",
+            {u8"q",u8"w",u8"e",u8"r",u8"t",u8"y",u8"u",u8"i",u8"o",u8"p"},         10,
+            {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l",u8"ç",u8"œ"},     11,
+            {u8"z",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m",u8"æ"},                  8,
+            {u8"Q",u8"W",u8"E",u8"R",u8"T",u8"Y",u8"U",u8"I",u8"O",u8"P"},         10,
+            {u8"A",u8"S",u8"D",u8"F",u8"G",u8"H",u8"J",u8"K",u8"L",u8"Ç",u8"Œ"},     11,
+            {u8"Z",u8"X",u8"C",u8"V",u8"B",u8"N",u8"M",u8"Æ"},                  8
         };
         
         // IT (Italian): common accented vowels (minimal set)
         static const KBLayout IT {
-            "it",
-            {"q","w","e","r","t","y","u","i","o","p"},               10,
-            {"a","s","d","f","g","h","j","k","l","à","è","é"},       12,
-            {"z","x","c","v","b","n","m","ì","ò","ù"},               10,
-            {"Q","W","E","R","T","Y","U","I","O","P"},               10,
-            {"A","S","D","F","G","H","J","K","L","À","È","É"},       12,
-            {"Z","X","C","V","B","N","M","Ì","Ò","Ù"},               10
+            u8"it",
+            {u8"q",u8"w",u8"e",u8"r",u8"t",u8"y",u8"u",u8"i",u8"o",u8"p"},               10,
+            {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l",u8"à",u8"è",u8"é"},       12,
+            {u8"z",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m",u8"ì",u8"ò",u8"ù"},               10,
+            {u8"Q",u8"W",u8"E",u8"R",u8"T",u8"Y",u8"U",u8"I",u8"O",u8"P"},               10,
+            {u8"A",u8"S",u8"D",u8"F",u8"G",u8"H",u8"J",u8"K",u8"L",u8"À",u8"È",u8"É"},       12,
+            {u8"Z",u8"X",u8"C",u8"V",u8"B",u8"N",u8"M",u8"Ì",u8"Ò",u8"Ù"},               10
         };
         
         // PL (Polish): ą ć ę ł ń ó ś ź ż
         static const KBLayout PL {
-            "pl",
-            {"q","w","e","r","t","y","u","i","o","p"},                10,
-            {"a","s","d","f","g","h","j","k","l","ł","ó"},            11,
-            {"z","x","c","v","b","n","m","ą","ć","ę","ń","ś","ź","ż"},14,
-            {"Q","W","E","R","T","Y","U","I","O","P"},                10,
-            {"A","S","D","F","G","H","J","K","L","Ł","Ó"},            11,
-            {"Z","X","C","V","B","N","M","Ą","Ć","Ę","Ń","Ś","Ź","Ż"},14
+            u8"pl",
+            {u8"q",u8"w",u8"e",u8"r",u8"t",u8"y",u8"u",u8"i",u8"o",u8"p"},                10,
+            {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l",u8"ł",u8"ó"},            11,
+            {u8"z",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m",u8"ą",u8"ć",u8"ę",u8"ń",u8"ś",u8"ź",u8"ż"},14,
+            {u8"Q",u8"W",u8"E",u8"R",u8"T",u8"Y",u8"U",u8"I",u8"O",u8"P"},                10,
+            {u8"A",u8"S",u8"D",u8"F",u8"G",u8"H",u8"J",u8"K",u8"L",u8"Ł",u8"Ó"},            11,
+            {u8"Z",u8"X",u8"C",u8"V",u8"B",u8"N",u8"M",u8"Ą",u8"Ć",u8"Ę",u8"Ń",u8"Ś",u8"Ź",u8"Ż"},14
         };
         
         // TR (Turkish): ç ğ ı İ ö ş ü
         static const KBLayout TR {
-            "tr",
-            {"q","w","e","r","t","y","u","ı","o","p"},            10, // dotless ı
-            {"a","s","d","f","g","h","j","k","l","ş","ç"},        11,
-            {"z","x","c","v","b","n","m","ö","ü","ğ"},            10,
-            {"Q","W","E","R","T","Y","U","İ","O","P"},            10, // dotted İ
-            {"A","S","D","F","G","H","J","K","L","Ş","Ç"},        11,
-            {"Z","X","C","V","B","N","M","Ö","Ü","Ğ"},            10
+            u8"tr",
+            {u8"q",u8"w",u8"e",u8"r",u8"t",u8"y",u8"u",u8"ı",u8"o",u8"p"},            10, // dotless ı
+            {u8"a",u8"s",u8"d",u8"f",u8"g",u8"h",u8"j",u8"k",u8"l",u8"ş",u8"ç"},        11,
+            {u8"z",u8"x",u8"c",u8"v",u8"b",u8"n",u8"m",u8"ö",u8"ü",u8"ğ"},            10,
+            {u8"Q",u8"W",u8"E",u8"R",u8"T",u8"Y",u8"U",u8"İ",u8"O",u8"P"},            10, // dotted İ
+            {u8"A",u8"S",u8"D",u8"F",u8"G",u8"H",u8"J",u8"K",u8"L",u8"Ş",u8"Ç"},        11,
+            {u8"Z",u8"X",u8"C",u8"V",u8"B",u8"N",u8"M",u8"Ö",u8"Ü",u8"Ğ"},            10
         };
 
         // Russian (полный набор с Ё)
         static const KBLayout CYR_RU {
-            "cyr-ru",
-            {"й","ц","у","к","е","н","г","ш","щ","з","х","ъ"}, 12,
-            {"ф","ы","в","а","п","р","о","л","д","ж","э"},     11,
-            {"я","ч","с","м","и","т","ь","б","ю","ё"},         10,
-            {"Й","Ц","У","К","Е","Н","Г","Ш","Щ","З","Х","Ъ"}, 12,
-            {"Ф","Ы","В","А","П","Р","О","Л","Д","Ж","Э"},     11,
-            {"Я","Ч","С","М","И","Т","Ь","Б","Ю","Ё"},         10
+            u8"cyr-ru",
+            {u8"й",u8"ц",u8"у",u8"к",u8"е",u8"н",u8"г",u8"ш",u8"щ",u8"з",u8"х",u8"ъ"}, 12,
+            {u8"ф",u8"ы",u8"в",u8"а",u8"п",u8"р",u8"о",u8"л",u8"д",u8"ж",u8"э"},     11,
+            {u8"я",u8"ч",u8"с",u8"м",u8"и",u8"т",u8"ь",u8"б",u8"ю",u8"ё"},         10,
+            {u8"Й",u8"Ц",u8"У",u8"К",u8"Е",u8"Н",u8"Г",u8"Ш",u8"Щ",u8"З",u8"Х",u8"Ъ"}, 12,
+            {u8"Ф",u8"Ы",u8"В",u8"А",u8"П",u8"Р",u8"О",u8"Л",u8"Д",u8"Ж",u8"Э"},     11,
+            {u8"Я",u8"Ч",u8"С",u8"М",u8"И",u8"Т",u8"Ь",u8"Б",u8"Ю",u8"Ё"},         10
         };
         
         // Ukrainian (добавлены І, Ї, Є, Ґ)
         static const KBLayout CYR_UK {
-            "cyr-uk",
-            {"й","ц","у","к","е","н","г","ш","щ","з","х","ї"}, 12,
-            {"ф","і","в","а","п","р","о","л","д","ж","є"},     11,
-            {"я","ч","с","м","и","т","ь","б","ю","ґ"},         10,
-            {"Й","Ц","У","К","Е","Н","Г","Ш","Щ","З","Х","Ї"}, 12,
-            {"Ф","І","В","А","П","Р","О","Л","Д","Ж","Є"},     11,
-            {"Я","Ч","С","М","И","Т","Ь","Б","Ю","Ґ"},         10
+            u8"cyr-uk",
+            {u8"й",u8"ц",u8"у",u8"к",u8"е",u8"н",u8"г",u8"ш",u8"щ",u8"з",u8"х",u8"ї"}, 12,
+            {u8"ф",u8"і",u8"в",u8"а",u8"п",u8"р",u8"о",u8"л",u8"д",u8"ж",u8"є"},     11,
+            {u8"я",u8"ч",u8"с",u8"м",u8"и",u8"т",u8"ь",u8"б",u8"ю",u8"ґ"},         10,
+            {u8"Й",u8"Ц",u8"У",u8"К",u8"Е",u8"Н",u8"Г",u8"Ш",u8"Щ",u8"З",u8"Х",u8"Ї"}, 12,
+            {u8"Ф",u8"І",u8"В",u8"А",u8"П",u8"Р",u8"О",u8"Л",u8"Д",u8"Ж",u8"Є"},     11,
+            {u8"Я",u8"Ч",u8"С",u8"М",u8"И",u8"Т",u8"Ь",u8"Б",u8"Ю",u8"Ґ"},         10
         };
 
         // Belarusian (добавлены Ў, І, Ё)
         static const KBLayout CYR_BE {
-            "cyr-be",
-            {"й","ц","у","к","е","н","г","ш","ў","з","х","'",}, 12, // заменяем щ → ў
-            {"ф","і","в","а","п","р","о","л","д","ж","э"},      11,
-            {"я","ч","с","м","і","т","ь","б","ю","ё"},          10,
-            {"Й","Ц","У","К","Е","Н","Г","Ш","Ў","З","Х","\"",},12,
-            {"Ф","І","В","А","П","Р","О","Л","Д","Ж","Э"},      11,
-            {"Я","Ч","С","М","І","Т","Ь","Б","Ю","Ё"},          10
+            u8"cyr-be",
+            {u8"й",u8"ц",u8"у",u8"к",u8"е",u8"н",u8"г",u8"ш",u8"ў",u8"з",u8"х",u8"'",}, 12, // заменяем щ → ў
+            {u8"ф",u8"і",u8"в",u8"а",u8"п",u8"р",u8"о",u8"л",u8"д",u8"ж",u8"э"},      11,
+            {u8"я",u8"ч",u8"с",u8"м",u8"і",u8"т",u8"ь",u8"б",u8"ю",u8"ё"},          10,
+            {u8"Й",u8"Ц",u8"У",u8"К",u8"Е",u8"Н",u8"Г",u8"Ш",u8"Ў",u8"З",u8"Х",u8"\"",},12,
+            {u8"Ф",u8"І",u8"В",u8"А",u8"П",u8"Р",u8"О",u8"Л",u8"Д",u8"Ж",u8"Э"},      11,
+            {u8"Я",u8"Ч",u8"С",u8"М",u8"І",u8"Т",u8"Ь",u8"Б",u8"Ю",u8"Ё"},          10
         };
 
         if (!name) return EN;
         auto eq = [](const char* a, const char* b){ return a && std::strcmp(a,b)==0; };
 
-        if (eq(name,"ru")) return CYR_RU;
-        if (eq(name,"uk")) return CYR_UK;
-        if (eq(name,"be")) return CYR_BE;
+        if (eq(name,u8"ru")) return CYR_RU;
+        if (eq(name,u8"uk")) return CYR_UK;
+        if (eq(name,u8"be")) return CYR_BE;
         
          // Latin with dedicated layouts
-        if (eq(name,"es"))     return ES;
-        if (eq(name,"pt") || eq(name,"pt-BR")) return PT;
-        if (eq(name,"de"))     return DE;
-        if (eq(name,"fr"))     return FR;
-        if (eq(name,"it"))     return IT;
-        if (eq(name,"pl"))     return PL;
-        if (eq(name,"tr"))     return TR;
+        if (eq(name,u8"es"))     return ES;
+        if (eq(name,u8"pt") || eq(name,u8"pt-BR")) return PT;
+        if (eq(name,u8"de"))     return DE;
+        if (eq(name,u8"fr"))     return FR;
+        if (eq(name,u8"it"))     return IT;
+        if (eq(name,u8"pl"))     return PL;
+        if (eq(name,u8"tr"))     return TR;
         // es, pt, pt-BR, de, fr, it, pl, tr, id, vi, th, ar, hi, ur и т.д. → EN (временный fallback)
         
         // Fallbacks
@@ -397,9 +397,9 @@ namespace ImGuiX::Widgets {
                                       : ImGui::GetStyle().ItemSpacing; // keep style
 		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, spacing);
 
-        const ImGuiID key_vk_locale = ImGui::GetID("vk_locale");
-        const ImGuiID key_vk_shift_state = ImGui::GetID("vk_shift_state");
-        const ImGuiID key_vk_pane_mode   = ImGui::GetID("vk_pane_mode");
+        const ImGuiID key_vk_locale = ImGui::GetID(u8"vk_locale");
+        const ImGuiID key_vk_shift_state = ImGui::GetID(u8"vk_shift_state");
+        const ImGuiID key_vk_pane_mode   = ImGui::GetID(u8"vk_pane_mode");
         ImGuiStorage* st = ImGui::GetStateStorage();
 
         if (state) state->submitted = false;
@@ -449,7 +449,7 @@ namespace ImGuiX::Widgets {
 
         // --- раскладка / shift состояние ---
         int locale_index = get_locale();
-        const char* locale_name = cfg.locales.empty() ? "en" : cfg.locales[locale_index];
+        const char* locale_name = cfg.locales.empty() ? u8"en" : cfg.locales[locale_index];
         const KBLayout& L = get_layout(locale_name);
         bool shift = get_shift();
 
@@ -486,7 +486,7 @@ namespace ImGuiX::Widgets {
         child_h += cfg.height_bias_px;
         child_h += 2.0f * pad_y;
 
-        ImGui::BeginChild("##VirtualKeyboard", ImVec2(child_w, child_h), cfg.border, ImGuiWindowFlags_NoScrollbar);
+        ImGui::BeginChild(u8"##VirtualKeyboard", ImVec2(child_w, child_h), cfg.border, ImGuiWindowFlags_NoScrollbar);
         const float base_x = ImGui::GetCursorPosX();
 
         // 
@@ -503,7 +503,7 @@ namespace ImGuiX::Widgets {
         if (cfg.show_top_preview) {
             // background (Child) + colored text inside
             ImGui::PushStyleColor(ImGuiCol_ChildBg, cfg.preview_bg_col);
-            ImGui::BeginChild("##vk_preview",
+            ImGui::BeginChild(u8"##vk_preview",
                 ImVec2(inner_w, preview_h),
                 cfg.preview_border,
                 ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
@@ -521,24 +521,24 @@ namespace ImGuiX::Widgets {
         }
 
         auto press = [&](const char* label, bool ascii_single = false) {
-            if (std::strcmp(label, "Bksp") == 0) {
+            if (std::strcmp(label, u8"Bksp") == 0) {
                 if (!text.empty()) { 
                     text.pop_back(); 
                     modified = true; 
                 }
                 return;
             }
-            if (std::strcmp(label, "Shift") == 0) {
+            if (std::strcmp(label, u8"Shift") == 0) {
                 shift = !shift; 
                 set_shift(shift);
                 return;
             }
-            if (std::strcmp(label, "Space") == 0) { 
+            if (std::strcmp(label, u8"Space") == 0) { 
                 text.push_back(' '); 
                 modified = true; 
                 return; 
             }
-            if (std::strcmp(label, "Enter") == 0) { 
+            if (std::strcmp(label, u8"Enter") == 0) { 
                 if (cfg.submit_on_enter) {
                     // если нужно — поддержать Shift+Enter = перенос строки
                     if (cfg.shift_enter_newline && 
@@ -588,10 +588,10 @@ namespace ImGuiX::Widgets {
         const float right_anchor_offset = left_w_outer + (cfg.show_special ? cfg.pane_gap : 0.0f);
 
         // Панель слева
-        ImGui::BeginChild("##vk_left", ImVec2(left_w_outer, top_h), true, ImGuiWindowFlags_NoScrollbar);
+        ImGui::BeginChild(u8"##vk_left", ImVec2(left_w_outer, top_h), true, ImGuiWindowFlags_NoScrollbar);
         {
 			if (cfg.show_digits) {
-                const char* row1[] = {"1","2","3","4","5","6","7","8","9","0"};
+                const char* row1[] = {u8"1",u8"2",u8"3",u8"4",u8"5",u8"6",u8"7",u8"8",u8"9",u8"0"};
                 for (int i = 0; i < 10; ++i) {
                     if (ImGui::Button(row1[i], key_size)) press(row1[i], /*ascii=*/true);
                     if (i < 9) ImGui::SameLine();
@@ -614,7 +614,7 @@ namespace ImGuiX::Widgets {
                 }
             };
 
-            bool ascii_letters = (std::strcmp(L.name, "en") == 0);
+            bool ascii_letters = (std::strcmp(L.name, u8"en") == 0);
 
             draw_row(shift && !ascii_letters ? L.row2U : L.row2, L.row2_n, ascii_letters);
 			draw_row(shift && !ascii_letters ? L.row3U : L.row3, L.row3_n, ascii_letters);
@@ -625,7 +625,7 @@ namespace ImGuiX::Widgets {
         // Панель справа
         if (cfg.show_special) {
             ImGui::SameLine(0.0f, cfg.pane_gap);
-            ImGui::BeginChild("##vk_right", ImVec2(right_w_outer, top_h), true, ImGuiWindowFlags_NoScrollbar);
+            ImGui::BeginChild(u8"##vk_right", ImVec2(right_w_outer, top_h), true, ImGuiWindowFlags_NoScrollbar);
             {
 				// --- small mode switch (top)
                 VKSpecialPane pane = get_pane();
@@ -646,11 +646,11 @@ namespace ImGuiX::Widgets {
                 } else {
 					// --- SYMBOLS GRID (as before) ---
                     const char* spec[] = {
-                        "!","@","#","$","%","^",
-                        "&","*","(",")","-","_",
-                        "+","=","{","}","[","]",
-                        "|","\\",":",";","'","\"",
-                        "<",">",",",".","?","/"
+                        u8"!",u8"@",u8"#",u8"$",u8"%",u8"^",
+                        u8"&",u8"*",u8"(",u8")",u8"-",u8"_",
+                        u8"+",u8"=",u8"{",u8"}",u8"[",u8"]",
+                        u8"|",u8"\\",u8":",u8";",u8"'",u8"\"",
+                        u8"<",u8">",u8",",u8".",u8"?",u8"/"
                     };
                     constexpr int cols = 6, rows = 5;
                     int idx = 0;
@@ -710,15 +710,15 @@ namespace ImGuiX::Widgets {
             if (cfg.show_bottom) {
                 const ImVec2 wide(key_size.x * 1.5f, key_size.y);
                 const ImVec2 space_size(key_size.x * 4,   key_size.y);
-                if (ButtonOrIcon("Shift", wide)) press("Shift");
+                if (ButtonOrIcon(u8"Shift", wide)) press(u8"Shift");
                 ImGui::SameLine();
-                if (ButtonOrIcon("Space", space_size)) press("Space");
+                if (ButtonOrIcon(u8"Space", space_size)) press(u8"Space");
                 ImGui::SameLine();
-                if (ButtonOrIcon("Bksp", wide)) press("Bksp");
+                if (ButtonOrIcon(u8"Bksp", wide)) press(u8"Bksp");
                 if (cfg.allow_enter) { 
                     ImGui::SameLine(); 
-                    if (ButtonOrIcon("Enter", wide)) { 
-                        press("Enter"); 
+                    if (ButtonOrIcon(u8"Enter", wide)) { 
+                        press(u8"Enter"); 
                     }
                 }
             }
@@ -734,9 +734,9 @@ namespace ImGuiX::Widgets {
 
                 //VKSpecialPane pane = get_pane();
                 const float btn_w = 64.0f; // компактно и стабильно
-                if (ButtonOrIcon("Symbols", ImVec2(btn_w, 0))) set_pane(VKSpecialPane::Symbols);
+                if (ButtonOrIcon(u8"Symbols", ImVec2(btn_w, 0))) set_pane(VKSpecialPane::Symbols);
                 ImGui::SameLine(0.0f, style.ItemSpacing.x);
-                if (ButtonOrIcon("Accents", ImVec2(btn_w, 0))) set_pane(VKSpecialPane::Accents);
+                if (ButtonOrIcon(u8"Accents", ImVec2(btn_w, 0))) set_pane(VKSpecialPane::Accents);
 
                 // вернуть X, чтобы правое выравнивание локали считалось от текущей строки целиком
                 //ImGui::SetCursorPosX(saved_x);
@@ -751,7 +751,7 @@ namespace ImGuiX::Widgets {
                 ImGui::SetCursorPosX(x);
                 ImGui::SetNextItemWidth(w);
                 const char* cur = cfg.locales[locale_index];
-                if (ImGui::BeginCombo("##vk_locale_br", cur, ImGuiComboFlags_HeightSmall)) {
+                if (ImGui::BeginCombo(u8"##vk_locale_br", cur, ImGuiComboFlags_HeightSmall)) {
                     for (int i = 0; i < (int)cfg.locales.size(); ++i) {
                         bool sel = (i == locale_index);
                         if (ImGui::Selectable(cfg.locales[i], sel)) {
@@ -769,7 +769,7 @@ namespace ImGuiX::Widgets {
             ImGui::SetCursorPosY(ImGui::GetCursorPosY() - (cfg.spacing + key_size.y)); // поднять к верху
             ImGui::SetNextItemWidth(std::max(44.0f, cfg.locale_width));
             const char* cur = cfg.locales[locale_index];
-            if (ImGui::BeginCombo("##vk_locale_top", cur, ImGuiComboFlags_HeightSmall)) {
+            if (ImGui::BeginCombo(u8"##vk_locale_top", cur, ImGuiComboFlags_HeightSmall)) {
                 for (int i = 0; i < (int)cfg.locales.size(); ++i) {
                     bool sel = (i == locale_index);
                     if (ImGui::Selectable(cfg.locales[i], sel)) {

--- a/include/imguix/windows/GlfwImGuiFramedWindow.ipp
+++ b/include/imguix/windows/GlfwImGuiFramedWindow.ipp
@@ -44,7 +44,7 @@ namespace ImGuiX::Windows {
         ImGui::SetNextWindowPos(ImVec2(0, 0));
         ImGui::SetNextWindowSize(ImVec2((float)fb_w, (float)fb_h));
 
-        ImVec2 char_size = ImGui::CalcTextSize("W");
+        ImVec2 char_size = ImGui::CalcTextSize(u8"W");
         ImVec2 padding = ImGui::GetStyle().WindowPadding;
         float title_padding_x = padding.x + char_size.x * 2.0f;
 
@@ -65,14 +65,14 @@ namespace ImGuiX::Windows {
         }
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::Begin("##imguix_framed_window", nullptr, flags);
+        ImGui::Begin(u8"##imguix_framed_window", nullptr, flags);
         ImGui::PopStyleVar();
 
         if (hasFlag(m_flags, WindowFlags::DisableBackground) || m_disable_background) {
             ImGui::PopStyleColor(2);
         }
 
-        ImGui::BeginChild("##imguix_title_bar", ImVec2(0, m_config.title_bar_height), false,
+        ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(0, m_config.title_bar_height), false,
                           ImGuiWindowFlags_NoScrollbar |
                           ImGuiWindowFlags_NoDecoration);
 
@@ -99,7 +99,7 @@ namespace ImGuiX::Windows {
 
         if (hasFlag(m_flags, WindowFlags::HasMenuBar)) {
             ImGui::SetCursorPosY(m_config.title_bar_height);
-            ImGui::BeginChild("##imguix_menu_bar", ImVec2(0, 0), false,
+            ImGui::BeginChild(u8"##imguix_menu_bar", ImVec2(0, 0), false,
                               ImGuiWindowFlags_MenuBar |
                               ImGuiWindowFlags_NoScrollbar |
                               ImGuiWindowFlags_NoDecoration |

--- a/include/imguix/windows/ImGuiFramedWindow.hpp
+++ b/include/imguix/windows/ImGuiFramedWindow.hpp
@@ -17,9 +17,9 @@ namespace ImGuiX::Windows {
         int frame_corner_radius = 8; ///< Radius of the outer window corners.
         int resize_border = 8;       ///< Thickness of the manual resize border.
         int title_bar_height = 32;   ///< Height of the custom title bar.
-        const char* close_button_text = "X##imguix_btn_close"; ///< Label for the close button.
-        const char* minimize_button_text = "_##imguix_btn_minimize"; ///< Label for the minimize button.
-        const char* maximize_button_text = "[]##imguix_btn_maximize"; ///< Label for the maximize button.
+        const char* close_button_text = u8"X##imguix_btn_close"; ///< Label for the close button.
+        const char* minimize_button_text = u8"_##imguix_btn_minimize"; ///< Label for the minimize button.
+        const char* maximize_button_text = u8"[]##imguix_btn_maximize"; ///< Label for the maximize button.
         ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); ///< Background clear color.
     };
 

--- a/include/imguix/windows/ImGuiFramedWindow.ipp
+++ b/include/imguix/windows/ImGuiFramedWindow.ipp
@@ -29,13 +29,13 @@ namespace ImGuiX::Windows {
     void ImGuiFramedWindow::drawTitleBarText() {
         float padding_y = (m_config.title_bar_height - ImGui::GetTextLineHeight()) * 0.5f;
         ImGui::SetCursorPosY(padding_y);
-        ImGui::Text("%s", m_title.c_str());
+        ImGui::Text(u8"%s", m_title.c_str());
     }
 
     void ImGuiFramedWindow::drawControlButtons(float title_padding_x) {
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
 
-        ImVec2 char_size = ImGui::CalcTextSize("W");
+        ImVec2 char_size = ImGui::CalcTextSize(u8"W");
         float btn_width = char_size.x * 3.0f + ImGui::GetStyle().FramePadding.x * 2.0f;
         float btn_height = char_size.y;
         float btn_padding = ImGui::GetStyle().ItemSpacing.x * 2.0f + btn_width * 3.0f + title_padding_x;
@@ -104,7 +104,7 @@ namespace ImGuiX::Windows {
         ImVec2 btn_min, btn_max;
         float center_y = (m_config.title_bar_height - btn_size.y) * 0.5f;
         ImGui::SetCursorPos(ImVec2(ImGui::GetWindowWidth() - btn_padding, center_y));
-        if (Widgets::CircleButton("##imguix_btn_minimize", btn_diameter, ImVec4(1.0f, 0.74f, 0.18f, 1.0f))) {
+        if (Widgets::CircleButton(u8"##imguix_btn_minimize", btn_diameter, ImVec4(1.0f, 0.74f, 0.18f, 1.0f))) {
             minimize();
         }
 
@@ -120,7 +120,7 @@ namespace ImGuiX::Windows {
 #       endif
         
         ImGui::SameLine();
-        if (Widgets::CircleButton("##imguix_btn_maximize", btn_diameter, ImVec4(0.15f, 0.79f, 0.25f, 1.0f))) {
+        if (Widgets::CircleButton(u8"##imguix_btn_maximize", btn_diameter, ImVec4(0.15f, 0.79f, 0.25f, 1.0f))) {
             toggleMaximizeRestore();
         }
 
@@ -136,7 +136,7 @@ namespace ImGuiX::Windows {
 #       endif
 
         ImGui::SameLine();
-        if (Widgets::CircleButton("##imguix_btn_close", btn_diameter, ImVec4(1.0f, 0.0f, 0.0f, 1.0f))) {
+        if (Widgets::CircleButton(u8"##imguix_btn_close", btn_diameter, ImVec4(1.0f, 0.0f, 0.0f, 1.0f))) {
             close();
         }
  
@@ -164,7 +164,7 @@ namespace ImGuiX::Windows {
         ImVec2 btn_min, btn_max;
         float center_y = (m_config.title_bar_height - btn_size.y) * 0.5f;
         ImGui::SetCursorPos(ImVec2(ImGui::GetWindowWidth() - btn_padding, center_y));
-        if (Widgets::SystemButton("##imguix_btn_minimize", Widgets::SystemButtonType::Minimize, btn_size)) {
+        if (Widgets::SystemButton(u8"##imguix_btn_minimize", Widgets::SystemButtonType::Minimize, btn_size)) {
             minimize();
         }
 
@@ -180,7 +180,7 @@ namespace ImGuiX::Windows {
 #       endif
         
         ImGui::SameLine();
-        if (Widgets::SystemButton("##imguix_btn_maximize", Widgets::SystemButtonType::Maximize, btn_size)) {
+        if (Widgets::SystemButton(u8"##imguix_btn_maximize", Widgets::SystemButtonType::Maximize, btn_size)) {
             toggleMaximizeRestore();
         }
 
@@ -196,7 +196,7 @@ namespace ImGuiX::Windows {
 #       endif
 
         ImGui::SameLine();
-        if (Widgets::SystemButton("##imguix_btn_close", Widgets::SystemButtonType::Close, btn_size)) {
+        if (Widgets::SystemButton(u8"##imguix_btn_close", Widgets::SystemButtonType::Close, btn_size)) {
             close();
         }
  

--- a/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
+++ b/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
@@ -21,7 +21,7 @@ namespace ImGuiX::Windows {
         if (!ImGui::GetCurrentContext())
             ImGui::CreateContext();
         ImGui_ImplSDL2_InitForOpenGL(m_window, m_gl_context);
-        ImGui_ImplOpenGL3_Init("#version 100");
+        ImGui_ImplOpenGL3_Init(u8"#version 100");
         m_is_open = true;
         return true;
     }
@@ -47,7 +47,7 @@ namespace ImGuiX::Windows {
         ImGui::SetNextWindowPos(ImVec2(0, 0));
         ImGui::SetNextWindowSize(ImVec2((float)w, (float)h));
 
-        ImVec2 char_size = ImGui::CalcTextSize("W");
+        ImVec2 char_size = ImGui::CalcTextSize(u8"W");
         ImVec2 padding = ImGui::GetStyle().WindowPadding;
         float title_padding_x = padding.x + char_size.x * 2.0f;
 
@@ -68,14 +68,14 @@ namespace ImGuiX::Windows {
         }
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::Begin("##imguix_framed_window", nullptr, flags);
+        ImGui::Begin(u8"##imguix_framed_window", nullptr, flags);
         ImGui::PopStyleVar();
 
         if (hasFlag(m_flags, WindowFlags::DisableBackground) || m_disable_background) {
             ImGui::PopStyleColor(2);
         }
 
-        ImGui::BeginChild("##imguix_title_bar", ImVec2(0, m_config.title_bar_height), false,
+        ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(0, m_config.title_bar_height), false,
                           ImGuiWindowFlags_NoScrollbar |
                           ImGuiWindowFlags_NoDecoration);
 
@@ -102,7 +102,7 @@ namespace ImGuiX::Windows {
 
         if (hasFlag(m_flags, WindowFlags::HasMenuBar)) {
             ImGui::SetCursorPosY(m_config.title_bar_height);
-            ImGui::BeginChild("##imguix_menu_bar", ImVec2(0, 0), false,
+            ImGui::BeginChild(u8"##imguix_menu_bar", ImVec2(0, 0), false,
                               ImGuiWindowFlags_MenuBar |
                               ImGuiWindowFlags_NoScrollbar |
                               ImGuiWindowFlags_NoDecoration |

--- a/include/imguix/windows/SfmlImGuiFramedWindow.ipp
+++ b/include/imguix/windows/SfmlImGuiFramedWindow.ipp
@@ -45,7 +45,7 @@ namespace ImGuiX::Windows {
         ImGui::SetNextWindowPos({0, 0});
         ImGui::SetNextWindowSize(ImVec2((float)m_window.getSize().x, (float)m_window.getSize().y));
 
-        ImVec2 char_size = ImGui::CalcTextSize("W");
+        ImVec2 char_size = ImGui::CalcTextSize(u8"W");
         ImVec2 padding = ImGui::GetStyle().WindowPadding;
         float title_padding_x = padding.x + char_size.x * 2.0f;
 
@@ -66,7 +66,7 @@ namespace ImGuiX::Windows {
         }
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::Begin("##imguix_framed_window", nullptr, flags);
+        ImGui::Begin(u8"##imguix_framed_window", nullptr, flags);
         ImGui::PopStyleVar();
         
         if (hasFlag(m_flags, WindowFlags::DisableBackground) || m_disable_background) {
@@ -74,7 +74,7 @@ namespace ImGuiX::Windows {
         }
 
         // --- Title bar
-        ImGui::BeginChild("##imguix_title_bar", ImVec2(0, m_config.title_bar_height), false,
+        ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(0, m_config.title_bar_height), false,
                           ImGuiWindowFlags_NoScrollbar | 
                           ImGuiWindowFlags_NoDecoration);
                  
@@ -103,7 +103,7 @@ namespace ImGuiX::Windows {
         // --- Menu Bar
         if (hasFlag(m_flags, WindowFlags::HasMenuBar)) {
             ImGui::SetCursorPosY(m_config.title_bar_height);
-            ImGui::BeginChild("##imguix_menu_bar", ImVec2(0, 0), false,
+            ImGui::BeginChild(u8"##imguix_menu_bar", ImVec2(0, 0), false,
                               ImGuiWindowFlags_MenuBar | 
                               ImGuiWindowFlags_NoScrollbar | 
                               ImGuiWindowFlags_NoDecoration |


### PR DESCRIPTION
## Summary
- ensure UTF-8 encoding by adding `u8` prefix to string and raw string literals across headers
- update constants, runtime errors, and preprocessor strings to use UTF-8

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68a92c0de6a8832cb0774417a38709fb