### PR TITLE
fix(utils): correct char check for string start

### DIFF
--- a/include/imguix/utils/strip_json_comments.hpp
+++ b/include/imguix/utils/strip_json_comments.hpp
@@ -70,7 +70,7 @@ namespace ImGuiX::Utils {
             const char next = (i + 1 < n) ? json_string[i + 1] : '\0';
 
             // Handle string boundaries only outside comments
-            if (comment == Comment::None && c == 'u8"') {
+            if (comment == Comment::None && c == '"') {
                 if (!detail::is_escaped_quote(json_string, i)) {
                     in_string = !in_string;
                 }
@@ -159,7 +159,7 @@ namespace ImGuiX::Utils {
             }
 
             if (comment == Comment::Block) {
-                // End of block comment "*/u8"
+                // End of block comment "*/"
                 if (c == '*' && next == '/') {
                     const std::size_t comment_end_inclusive = i + 1; // include '/'
                     if (with_whitespace) {


### PR DESCRIPTION
## Summary
- fix incorrect comparison against `'u8"'` in JSON comment stripper
- tidy block comment description

## Testing
- `cmake ..`
- `cmake --build . --target imguix -j 2` *(fails: windowsx.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a93238f46c832c80e09065b2942c1e