### PR TITLE
docs: align i18n and options headers with style guide

### DIFF
--- a/include/imguix/core/i18n/PluralRules.hpp
+++ b/include/imguix/core/i18n/PluralRules.hpp
@@ -10,9 +10,13 @@ namespace ImGuiX::I18N {
 
     namespace fs = std::filesystem;
 
+    /// \class PluralRules
+    /// \brief Runtime-pluggable pluralization rules with JSON loading.
     class PluralRules {
     public:
-        // Load rules from JSON file. Returns true on success.
+        /// \brief Load rules from a JSON file.
+        /// \param path Path to JSON file.
+        /// \return True on success.
         bool load_from_file(const std::string& path) {
             std::error_code ec;
             if (!fs::exists(path, ec)) return false;
@@ -47,8 +51,11 @@ namespace ImGuiX::I18N {
             return !rules_.empty();
         }
 
-        // Return category for number n in language 'lang'.
-        // Built-in fallback: 'en' (one/other) and 'ru' (one/few/many/other).
+        /// \brief Determine plural category for number in given language.
+        /// \param lang Language code (e.g., "en").
+        /// \param n Numeric value.
+        /// \return Category string such as "one" or "other".
+        /// \note Built-in fallback supports English (one/other) and Russian (one/few/many/other).
         std::string category(const std::string& lang, long long n) const {
             // Try loaded rules first
             if (auto it = rules_.find(lang); it != rules_.end()) {

--- a/include/imguix/core/options/OptionsStore.hpp
+++ b/include/imguix/core/options/OptionsStore.hpp
@@ -3,7 +3,7 @@
 #define _IMGUIX_CORE_OPTIONS_STORE_HPP_INCLUDED
 
 /// \file OptionsStore.hpp
-/// \brief 
+/// \brief Persistent JSON-backed key-value options store.
 
 #include <cstdint>
 #include <memory>

--- a/include/imguix/core/options/OptionsStoreControlCRTP.hpp
+++ b/include/imguix/core/options/OptionsStoreControlCRTP.hpp
@@ -3,7 +3,7 @@
 #define _IMGUIX_CORE_OPTIONS_STORE_CONTROL_CRTP_HPP_INCLUDED
 
 /// \file OptionsStoreControlCRTP.hpp
-/// \brief 
+/// \brief Mutable facade providing full access to \c OptionsStore.
 
 #include <string>
 #include <vector>
@@ -15,106 +15,131 @@ namespace ImGuiX {
     /// \tparam Impl Concrete OptionsStore implementation.
     template<class Impl>
     struct OptionsStoreControlCRTP {
+        /// \copydoc OptionsStore::has
         bool has(const std::string& key) const noexcept {
             return static_cast<const Impl*>(this)->has(key);
         }
 
+        /// \copydoc OptionsStore::erase
         bool erase(const std::string& key) {
             return static_cast<Impl*>(this)->erase(key);
         }
 
+        /// \copydoc OptionsStore::keys
         std::vector<std::string> keys() const {
             return static_cast<const Impl*>(this)->keys();
         }
 
+        /// \copydoc OptionsStore::setBool
         void setBool(const std::string& key, bool v) {
             static_cast<Impl*>(this)->setBool(key, v);
         }
 
+        /// \copydoc OptionsStore::setI32
         void setI32(const std::string& key, std::int32_t v) {
             static_cast<Impl*>(this)->setI32(key, v);
         }
 
+        /// \copydoc OptionsStore::setI64
         void setI64(const std::string& key, std::int64_t v) {
             static_cast<Impl*>(this)->setI64(key, v);
         }
 
+        /// \copydoc OptionsStore::setF32
         void setF32(const std::string& key, float v) {
             static_cast<Impl*>(this)->setF32(key, v);
         }
 
+        /// \copydoc OptionsStore::setF64
         void setF64(const std::string& key, double v) {
             static_cast<Impl*>(this)->setF64(key, v);
         }
 
+        /// \copydoc OptionsStore::setStr
         void setStr(const std::string& key, const std::string& v) {
             static_cast<Impl*>(this)->setStr(key, v);
         }
 
+        /// \copydoc OptionsStore::setStrVec
         void setStrVec(
                 const std::string& key,
                 const std::vector<std::string>& v) {
             static_cast<Impl*>(this)->setStrVec(key, v);
         }
 
+        /// \copydoc OptionsStore::getBool
         bool getBool(const std::string& key) const {
             return static_cast<const Impl*>(this)->getBool(key);
         }
 
+        /// \copydoc OptionsStore::getI32
         std::int32_t getI32(const std::string& key) const {
             return static_cast<const Impl*>(this)->getI32(key);
         }
 
+        /// \copydoc OptionsStore::getI64
         std::int64_t getI64(const std::string& key) const {
             return static_cast<const Impl*>(this)->getI64(key);
         }
 
+        /// \copydoc OptionsStore::getF32
         float getF32(const std::string& key) const {
             return static_cast<const Impl*>(this)->getF32(key);
         }
 
+        /// \copydoc OptionsStore::getF64
         double getF64(const std::string& key) const {
             return static_cast<const Impl*>(this)->getF64(key);
         }
 
+        /// \copydoc OptionsStore::getStr
         std::string getStr(const std::string& key) const {
             return static_cast<const Impl*>(this)->getStr(key);
         }
 
+        /// \copydoc OptionsStore::getStrVec
         std::vector<std::string> getStrVec(const std::string& key) const {
             return static_cast<const Impl*>(this)->getStrVec(key);
         }
 
+        /// \copydoc OptionsStore::getBoolOr
         bool getBoolOr(const std::string& key, bool def) const noexcept {
             return static_cast<const Impl*>(this)->getBoolOr(key, def);
         }
 
+        /// \copydoc OptionsStore::getI32Or
         std::int32_t getI32Or(const std::string& key, std::int32_t def) const noexcept {
             return static_cast<const Impl*>(this)->getI32Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getI64Or
         std::int64_t getI64Or(const std::string& key, std::int64_t def) const noexcept {
             return static_cast<const Impl*>(this)->getI64Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getF32Or
         float getF32Or(const std::string& key, float def) const noexcept {
             return static_cast<const Impl*>(this)->getF32Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getF64Or
         double getF64Or(const std::string& key, double def) const noexcept {
             return static_cast<const Impl*>(this)->getF64Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getStrOr
         std::string getStrOr(const std::string& key, std::string def) const noexcept {
             return static_cast<const Impl*>(this)->getStrOr(key, std::move(def));
         }
 
+        /// \copydoc OptionsStore::getStrVecOr
         std::vector<std::string> getStrVecOr(
                 const std::string& key,
                 std::vector<std::string> def) const noexcept {
             return static_cast<const Impl*>(this)->getStrVecOr(key, std::move(def));
         }
 
+        /// \copydoc OptionsStore::version
         std::int32_t version() const noexcept {
             return static_cast<const Impl*>(this)->version();
         }

--- a/include/imguix/core/options/OptionsStoreViewCRTP.hpp
+++ b/include/imguix/core/options/OptionsStoreViewCRTP.hpp
@@ -3,7 +3,7 @@
 #define _IMGUIX_CORE_OPTIONS_STORE_VIEW_CRTP_HPP_INCLUDED
 
 /// \file OptionsStoreViewCRTP.hpp
-/// \brief 
+/// \brief Read-only facade for \c OptionsStore access.
 
 #include <string>
 #include <vector>
@@ -15,72 +15,89 @@ namespace ImGuiX {
     /// \tparam Impl Concrete OptionsStore implementation.
     template<class Impl>
     struct OptionsStoreViewCRTP {
+        /// \copydoc OptionsStore::has
         bool has(const std::string& key) const noexcept {
             return static_cast<const Impl*>(this)->has(key);
         }
 
+        /// \copydoc OptionsStore::keys
         std::vector<std::string> keys() const {
             return static_cast<const Impl*>(this)->keys();
         }
 
+        /// \copydoc OptionsStore::getBool
         bool getBool(const std::string& key) const {
             return static_cast<const Impl*>(this)->getBool(key);
         }
 
+        /// \copydoc OptionsStore::getI32
         std::int32_t getI32(const std::string& key) const {
             return static_cast<const Impl*>(this)->getI32(key);
         }
 
+        /// \copydoc OptionsStore::getI64
         std::int64_t getI64(const std::string& key) const {
             return static_cast<const Impl*>(this)->getI64(key);
         }
 
+        /// \copydoc OptionsStore::getF32
         float getF32(const std::string& key) const {
             return static_cast<const Impl*>(this)->getF32(key);
         }
 
+        /// \copydoc OptionsStore::getF64
         double getF64(const std::string& key) const {
             return static_cast<const Impl*>(this)->getF64(key);
         }
 
+        /// \copydoc OptionsStore::getStr
         std::string getStr(const std::string& key) const {
             return static_cast<const Impl*>(this)->getStr(key);
         }
 
+        /// \copydoc OptionsStore::getStrVec
         std::vector<std::string> getStrVec(const std::string& key) const {
             return static_cast<const Impl*>(this)->getStrVec(key);
         }
 
+        /// \copydoc OptionsStore::getBoolOr
         bool getBoolOr(const std::string& key, bool def) const noexcept {
             return static_cast<const Impl*>(this)->getBoolOr(key, def);
         }
 
+        /// \copydoc OptionsStore::getI32Or
         std::int32_t getI32Or(const std::string& key, std::int32_t def) const noexcept {
             return static_cast<const Impl*>(this)->getI32Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getI64Or
         std::int64_t getI64Or(const std::string& key, std::int64_t def) const noexcept {
             return static_cast<const Impl*>(this)->getI64Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getF32Or
         float getF32Or(const std::string& key, float def) const noexcept {
             return static_cast<const Impl*>(this)->getF32Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getF64Or
         double getF64Or(const std::string& key, double def) const noexcept {
             return static_cast<const Impl*>(this)->getF64Or(key, def);
         }
 
+        /// \copydoc OptionsStore::getStrOr
         std::string getStrOr(const std::string& key, std::string def) const noexcept {
             return static_cast<const Impl*>(this)->getStrOr(key, std::move(def));
         }
 
+        /// \copydoc OptionsStore::getStrVecOr
         std::vector<std::string> getStrVecOr(
                 const std::string& key,
                 std::vector<std::string> def) const noexcept {
             return static_cast<const Impl*>(this)->getStrVecOr(key, std::move(def));
         }
 
+        /// \copydoc OptionsStore::version
         std::int32_t version() const noexcept {
             return static_cast<const Impl*>(this)->version();
         }


### PR DESCRIPTION
## Summary
- document LangStore API and translate internal comments to English
- add Doxygen for PluralRules and OptionsStore facades
- clarify file-level descriptions for OptionsStore headers

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9337a5630832ca821c12ed97da5be