### PR TITLE
feat(widgets): add dynamic list editor widget

### DIFF
--- a/examples/list_editor/CMakeLists.txt
+++ b/examples/list_editor/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.18)
+project(imguix_list_editor LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ImGuiX REQUIRED)
+
+add_executable(imguix_list_editor main.cpp)
+target_link_libraries(imguix_list_editor PRIVATE ImGuiX::imguix)
+
+if(DEFINED IMGUIX_SDK_DIR)
+    target_include_directories(imguix_list_editor PRIVATE "${IMGUIX_SDK_DIR}/include")
+    target_link_directories(imguix_list_editor PRIVATE "${IMGUIX_SDK_DIR}/lib")
+endif()
+
+if(NOT DEFINED IMGUIX_SDK_DIR AND DEFINED ImGuiX_DIR)
+    get_filename_component(_imx_prefix "${ImGuiX_DIR}/../.." ABSOLUTE)
+    target_include_directories(imguix_list_editor PRIVATE "${_imx_prefix}/include")
+    target_link_directories(imguix_list_editor PRIVATE "${_imx_prefix}/lib")
+endif()
+
+if(MINGW)
+    target_link_libraries(imguix_list_editor PRIVATE
+        sfml-graphics-s sfml-window-s sfml-system-s ImGui-SFML freetype
+        gdi32 user32 comctl32 dwmapi opengl32)
+endif()

--- a/examples/list_editor/main.cpp
+++ b/examples/list_editor/main.cpp
@@ -1,0 +1,44 @@
+#include <SFML/Graphics.hpp>
+#include <imgui.h>
+#include <imgui-SFML.h>
+
+#include <imguix/widgets/list_editor.hpp>
+#include <vector>
+#include <string>
+
+int main() {
+    sf::RenderWindow window(sf::VideoMode(800, 600), "ListEditor example");
+    window.setFramerateLimit(60);
+
+    ImGui::CreateContext();
+    ImGui::StyleColorsDark();
+    ImGui::SFML::Init(window);
+
+    bool show_demo = false;
+    sf::Clock clk;
+
+    std::vector<std::string> names {"Alice", "Bob"};
+    std::vector<int> numbers {1, 2, 3};
+
+    while (window.isOpen()) {
+        sf::Event ev;
+        while (window.pollEvent(ev)) {
+            ImGui::SFML::ProcessEvent(window, ev);
+            if (ev.type == sf::Event::Closed) window.close();
+        }
+
+        ImGui::SFML::Update(window, clk.restart());
+
+        if (show_demo) ImGui::ShowDemoWindow(&show_demo);
+        ImGui::Begin("List editor");
+        ImGuiX::Widgets::ListEditor("names", names);
+        ImGuiX::Widgets::ListEditor("numbers", numbers);
+        ImGui::End();
+
+        window.clear();
+        ImGui::SFML::Render(window);
+        window.display();
+    }
+    ImGui::SFML::Shutdown();
+    return 0;
+}

--- a/include/imguix/widgets/list_editor.hpp
+++ b/include/imguix/widgets/list_editor.hpp
@@ -1,0 +1,93 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_LIST_EDITOR_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_LIST_EDITOR_HPP_INCLUDED
+
+/// \file list_editor.hpp
+/// \brief Dynamic list editor for strings or integers.
+
+#include <string>
+#include <vector>
+#include <cstring>
+
+#include <imgui.h>
+
+namespace ImGuiX::Widgets {
+
+    /// \brief Configuration for ListEditor.
+    struct ListEditorConfig {
+        std::string add_label    = u8"+"; ///< Label for the add button.
+        std::string remove_label = u8"x"; ///< Label for the remove button.
+        std::string new_item_hint;         ///< Initial value for new string items.
+    };
+
+    /// \brief Edit a dynamic list of strings with add/remove controls.
+    /// \param id Unique widget ID.
+    /// \param items List of strings to modify.
+    /// \param cfg Additional configuration options.
+    /// \return True if the list changed this frame.
+    inline bool ListEditor(const char* id, std::vector<std::string>& items, const ListEditorConfig& cfg = {}) {
+        bool changed = false;
+        ImGui::PushID(id);
+
+        for (size_t i = 0; i < items.size(); ++i) {
+            ImGui::PushID(static_cast<int>(i));
+            char buf[256];
+            std::strncpy(buf, items[i].c_str(), sizeof(buf));
+            buf[sizeof(buf) - 1] = '\0';
+            if (ImGui::InputText(u8"##item", buf, sizeof(buf))) {
+                items[i] = buf;
+                changed = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton(cfg.remove_label.c_str())) {
+                items.erase(items.begin() + static_cast<long>(i));
+                --i;
+                changed = true;
+            }
+            ImGui::PopID();
+        }
+
+        if (ImGui::SmallButton(cfg.add_label.c_str())) {
+            items.emplace_back(cfg.new_item_hint);
+            changed = true;
+        }
+
+        ImGui::PopID();
+        return changed;
+    }
+
+    /// \brief Edit a dynamic list of integers with add/remove controls.
+    /// \param id Unique widget ID.
+    /// \param items List of integers to modify.
+    /// \param cfg Additional configuration options.
+    /// \return True if the list changed this frame.
+    inline bool ListEditor(const char* id, std::vector<int>& items, const ListEditorConfig& cfg = {}) {
+        bool changed = false;
+        ImGui::PushID(id);
+
+        for (size_t i = 0; i < items.size(); ++i) {
+            ImGui::PushID(static_cast<int>(i));
+            if (ImGui::InputInt(u8"##item", &items[i])) {
+                changed = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton(cfg.remove_label.c_str())) {
+                items.erase(items.begin() + static_cast<long>(i));
+                --i;
+                changed = true;
+            }
+            ImGui::PopID();
+        }
+
+        if (ImGui::SmallButton(cfg.add_label.c_str())) {
+            items.emplace_back(0);
+            changed = true;
+        }
+
+        ImGui::PopID();
+        return changed;
+    }
+
+} // namespace ImGuiX::Widgets
+
+#endif // _IMGUIX_WIDGETS_LIST_EDITOR_HPP_INCLUDED

--- a/tests/test-list-editor.cpp
+++ b/tests/test-list-editor.cpp
@@ -1,0 +1,21 @@
+#include <imgui.h>
+
+#include <imguix/widgets/list_editor.hpp>
+#include <vector>
+#include <string>
+
+int main() {
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui::NewFrame();
+
+    std::vector<std::string> strings {"a", "b"};
+    std::vector<int> numbers {1, 2};
+
+    ImGuiX::Widgets::ListEditor("strings", strings);
+    ImGuiX::Widgets::ListEditor("numbers", numbers);
+
+    ImGui::Render();
+    ImGui::DestroyContext();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add ListEditor widget to edit vectors of strings or integers
- provide example demonstrating ListEditor usage
- add minimal tests for ListEditor

## Testing
- `cmake -S . -B build` (fails: missing ImGui sources)


------
https://chatgpt.com/codex/tasks/task_e_68a93b3fdea0832cbaf9a7cc646f2935