### PR TITLE
refactor(utils): move runtime utilities to ipp

### DIFF
--- a/include/imguix/utils/encoding_utils.hpp
+++ b/include/imguix/utils/encoding_utils.hpp
@@ -15,114 +15,37 @@ namespace ImGuiX::Utils {
     /// \brief Convert UTF-8 string to ANSI string (Windows-specific).
     /// \param utf8 UTF-8 encoded string.
     /// \return Converted ANSI string.
-    std::string Utf8ToAnsi(const std::string& utf8) noexcept {
-        int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
-        if (n_len == 0) return {};
-
-        std::wstring wide_string(n_len + 1, L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, wide_string.data(), n_len);
-
-        n_len = WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), -1, NULL, 0, NULL, NULL);
-        if (n_len == 0) return {};
-
-        std::string ansi_string(n_len - 1, '\0');
-        WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), -1, ansi_string.data(), n_len, NULL, NULL);
-        return ansi_string;
-    }
+    std::string Utf8ToAnsi(const std::string& utf8) noexcept;
 
     /// \brief Convert ANSI string to UTF-8 string (Windows-specific).
     /// \param ansi ANSI encoded string.
     /// \return Converted UTF-8 string.
-    std::string AnsiToUtf8(const std::string& ansi) noexcept {
-        int n_len = MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, NULL, 0);
-        if (n_len == 0) return {};
-
-        std::wstring wide_string(n_len, L'\0');
-        MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, wide_string.data(), n_len);
-
-        n_len = WideCharToMultiByte(CP_UTF8, 0, wide_string.c_str(), -1, NULL, 0, NULL, NULL);
-        if (n_len == 0) return {};
-
-        std::string utf8_string(n_len - 1, '\0');
-        WideCharToMultiByte(CP_UTF8, 0, wide_string.c_str(), -1, utf8_string.data(), n_len, NULL, NULL);
-        return utf8_string;
-    }
+    std::string AnsiToUtf8(const std::string& ansi) noexcept;
 
     /// \brief Convert UTF-8 string to CP866 string (DOS-specific, Windows).
     /// \param utf8 UTF-8 encoded string.
     /// \return Converted CP866 string.
-    std::string Utf8ToCp866(const std::string& utf8) noexcept {
-        std::string temp = Utf8ToAnsi(utf8);
-        CharToOem((LPSTR)temp.c_str(), temp.data());
-        return temp;
-    }
+    std::string Utf8ToCp866(const std::string& utf8) noexcept;
 
     /// \brief Validate UTF-8 string.
     /// \param message String to validate.
     /// \return `true` if string is valid UTF-8, `false` otherwise.
-    bool IsValidUtf8(const char* message) {
-        if (!message) return true;
-        const unsigned char* bytes = reinterpret_cast<const unsigned char*>(message);
-        while (*bytes != 0x00) {
-            int num = 0;
-            unsigned int cp = 0;
-            if ((*bytes & 0x80) == 0x00) { cp = (*bytes & 0x7F); num = 1; }
-            else if ((*bytes & 0xE0) == 0xC0) { cp = (*bytes & 0x1F); num = 2; }
-            else if ((*bytes & 0xF0) == 0xE0) { cp = (*bytes & 0x0F); num = 3; }
-            else if ((*bytes & 0xF8) == 0xF0) { cp = (*bytes & 0x07); num = 4; }
-            else return false;
-
-            bytes++;
-            for (int i = 1; i < num; ++i) {
-                if ((*bytes & 0xC0) != 0x80) return false;
-                cp = (cp << 6) | (*bytes & 0x3F);
-                bytes++;
-            }
-
-            if (cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)) return false;
-        }
-        return true;
-    }
+    bool IsValidUtf8(const char* message);
 
     /// \brief Convert CP1251 string to UTF-8.
     /// \param cp1251 CP1251 encoded string.
     /// \return Converted UTF-8 string.
-    std::string Cp1251ToUtf8(const std::string& cp1251) {
-        int len = MultiByteToWideChar(1251, 0, cp1251.c_str(), -1, NULL, 0);
-        if (len == 0) return {};
-
-        std::wstring wideString(len, L'\0');
-        MultiByteToWideChar(1251, 0, cp1251.c_str(), -1, wideString.data(), len);
-
-        len = WideCharToMultiByte(CP_UTF8, 0, wideString.c_str(), -1, NULL, 0, NULL, NULL);
-        if (len == 0) return {};
-
-        std::string utf8String(len, '\0');
-        WideCharToMultiByte(CP_UTF8, 0, wideString.c_str(), -1, utf8String.data(), len, NULL, NULL);
-        return utf8String;
-    }
+    std::string Cp1251ToUtf8(const std::string& cp1251);
 
     /// \brief Convert UTF-16 string to UTF-8.
     /// \param utf16String Wide character string.
     /// \return Converted UTF-8 string.
-    std::string Utf16ToUtf8(LPWSTR utf16String) {
-        int bufferSize = WideCharToMultiByte(CP_UTF8, 0, utf16String, -1, nullptr, 0, nullptr, nullptr);
-        std::string utf8String(bufferSize, '\0');
-        WideCharToMultiByte(CP_UTF8, 0, utf16String, -1, utf8String.data(), bufferSize, nullptr, nullptr);
-        return utf8String;
-    }
+    std::string Utf16ToUtf8(LPWSTR utf16String);
 
     /// \brief Convert UTF-8 string to UTF-16 wide string.
     /// \param utf8 UTF-8 encoded string.
     /// \return Converted UTF-16 string.
-    std::wstring Utf8ToUtf16(const std::string& utf8) noexcept {
-        int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
-        if (n_len == 0) return {};
-
-        std::wstring utf16_string(n_len, L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, utf16_string.data(), n_len);
-        return utf16_string;
-    }
+    std::wstring Utf8ToUtf16(const std::string& utf8) noexcept;
 
 } // namespace ImGuiX::Utils
 #else
@@ -177,5 +100,9 @@ namespace ImGuiX::Utils {
 } // namespace ImGuiX::Utils
 
 #endif // defined(_WIN32) || defined(_WIN64)
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "encoding_utils.ipp"
+#endif
 
 #endif // _IMGUIX_UTILS_ENCODING_UTILS_HPP_INCLUDED

--- a/include/imguix/utils/encoding_utils.ipp
+++ b/include/imguix/utils/encoding_utils.ipp
@@ -1,0 +1,99 @@
+#if defined(_WIN32) || defined(_WIN64)
+
+namespace ImGuiX::Utils {
+
+    std::string Utf8ToAnsi(const std::string& utf8) noexcept {
+        int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
+        if (n_len == 0) return {};
+
+        std::wstring wide_string(n_len + 1, L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, wide_string.data(), n_len);
+
+        n_len = WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), -1, NULL, 0, NULL, NULL);
+        if (n_len == 0) return {};
+
+        std::string ansi_string(n_len - 1, '\0');
+        WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), -1, ansi_string.data(), n_len, NULL, NULL);
+        return ansi_string;
+    }
+
+    std::string AnsiToUtf8(const std::string& ansi) noexcept {
+        int n_len = MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, NULL, 0);
+        if (n_len == 0) return {};
+
+        std::wstring wide_string(n_len, L'\0');
+        MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, wide_string.data(), n_len);
+
+        n_len = WideCharToMultiByte(CP_UTF8, 0, wide_string.c_str(), -1, NULL, 0, NULL, NULL);
+        if (n_len == 0) return {};
+
+        std::string utf8_string(n_len - 1, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, wide_string.c_str(), -1, utf8_string.data(), n_len, NULL, NULL);
+        return utf8_string;
+    }
+
+    std::string Utf8ToCp866(const std::string& utf8) noexcept {
+        std::string temp = Utf8ToAnsi(utf8);
+        CharToOem((LPSTR)temp.c_str(), temp.data());
+        return temp;
+    }
+
+    bool IsValidUtf8(const char* message) {
+        if (!message) return true;
+        const unsigned char* bytes = reinterpret_cast<const unsigned char*>(message);
+        while (*bytes != 0x00) {
+            int num = 0;
+            unsigned int cp = 0;
+            if ((*bytes & 0x80) == 0x00) { cp = (*bytes & 0x7F); num = 1; }
+            else if ((*bytes & 0xE0) == 0xC0) { cp = (*bytes & 0x1F); num = 2; }
+            else if ((*bytes & 0xF0) == 0xE0) { cp = (*bytes & 0x0F); num = 3; }
+            else if ((*bytes & 0xF8) == 0xF0) { cp = (*bytes & 0x07); num = 4; }
+            else return false;
+
+            bytes++;
+            for (int i = 1; i < num; ++i) {
+                if ((*bytes & 0xC0) != 0x80) return false;
+                cp = (cp << 6) | (*bytes & 0x3F);
+                bytes++;
+            }
+
+            if (cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)) return false;
+        }
+        return true;
+    }
+
+    std::string Cp1251ToUtf8(const std::string& cp1251) {
+        int len = MultiByteToWideChar(1251, 0, cp1251.c_str(), -1, NULL, 0);
+        if (len == 0) return {};
+
+        std::wstring wideString(len, L'\0');
+        MultiByteToWideChar(1251, 0, cp1251.c_str(), -1, wideString.data(), len);
+
+        len = WideCharToMultiByte(CP_UTF8, 0, wideString.c_str(), -1, NULL, 0, NULL, NULL);
+        if (len == 0) return {};
+
+        std::string utf8String(len, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, wideString.c_str(), -1, utf8String.data(), len, NULL, NULL);
+        return utf8String;
+    }
+
+    std::string Utf16ToUtf8(LPWSTR utf16String) {
+        int bufferSize = WideCharToMultiByte(CP_UTF8, 0, utf16String, -1, nullptr, 0, nullptr, nullptr);
+        std::string utf8String(bufferSize, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, utf16String, -1, utf8String.data(), bufferSize, nullptr, nullptr);
+        return utf8String;
+    }
+
+    std::wstring Utf8ToUtf16(const std::string& utf8) noexcept {
+        int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
+        if (n_len == 0) return {};
+
+        std::wstring utf16_string(n_len, L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, utf16_string.data(), n_len);
+        return utf16_string;
+    }
+
+} // namespace ImGuiX::Utils
+
+#endif // defined(_WIN32) || defined(_WIN64)
+

--- a/include/imguix/utils/path_utils.hpp
+++ b/include/imguix/utils/path_utils.hpp
@@ -176,4 +176,8 @@ namespace ImGuiX::Utils {
 
 } // namespace ImGuiX::Utils
 
+#ifdef IMGUIX_HEADER_ONLY
+#   include "path_utils.ipp"
+#endif
+
 #endif // _IMGUIX_UTILS_PATH_UTILS_HPP_INCLUDED

--- a/include/imguix/utils/path_utils.ipp
+++ b/include/imguix/utils/path_utils.ipp
@@ -1,0 +1,2 @@
+// Implementation file for path_utils.hpp (no non-template definitions).
+

--- a/include/imguix/utils/strip_json_comments.hpp
+++ b/include/imguix/utils/strip_json_comments.hpp
@@ -10,32 +10,6 @@
 /// \note When with_whitespace is true, removed characters become spaces while newlines stay.
 
 #include <string>
-#include <algorithm>
-#include <cstddef>
-
-namespace ImGuiX::Utils::detail {
-
-    // Returns true if quote at position 'pos' is escaped by an odd number of backslashes.
-    inline bool is_escaped_quote(const std::string& s, std::size_t pos) noexcept {
-        // Preconditions: pos < s.size() && s[pos] == '"'
-        std::size_t backslash_count = 0;
-        while (pos > 0 && s[--pos] == '\\') {
-            ++backslash_count;
-        }
-        return (backslash_count % 2) == 1;
-    }
-
-    // Replace every non-newline char with space; keep '\n' and '\r' intact.
-    inline void append_spaces_preserve_newlines(std::string& out, const std::string& src,
-                                                std::size_t from, std::size_t to_exclusive) {
-        out.reserve(out.size() + (to_exclusive - from));
-        for (std::size_t i = from; i < to_exclusive; ++i) {
-            const char c = src[i];
-            out.push_back((c == '\n' || c == '\r') ? c : ' ');
-        }
-    }
-
-} // namespace ImGuiX::Utils::detail
 
 namespace ImGuiX::Utils {
 
@@ -43,154 +17,15 @@ namespace ImGuiX::Utils {
     /// \param json_string Input string (can be empty).
     /// \param with_whitespace If true, replaced comment regions are filled with spaces (newlines preserved).
     /// \return String with comments removed.
-    inline std::string strip_json_comments(
+    std::string strip_json_comments(
             const std::string& json_string,
             const bool with_whitespace = false
-        ) noexcept {
-        enum class Comment : unsigned char { None, Line, Block };
-
-        const std::size_t n = json_string.size();
-        if (n == 0) return {};
-
-        std::string out;
-        out.reserve(n);
-
-        bool in_string = false;
-        Comment comment = Comment::None;
-
-        // We track the start of the current "uncommented chunk".
-        std::size_t chunk_begin = 0;
-
-        // For recognizing '#' as a comment only at line start or after whitespace,
-        // we track whether the previous non-output char was a line break.
-        bool at_line_start = true; // true at very beginning
-
-        for (std::size_t i = 0; i < n; ++i) {
-            const char c = json_string[i];
-            const char next = (i + 1 < n) ? json_string[i + 1] : '\0';
-
-            // Handle string boundaries only outside comments
-            if (comment == Comment::None && c == '"') {
-                if (!detail::is_escaped_quote(json_string, i)) {
-                    in_string = !in_string;
-                }
-                // Strings affect at_line_start only if they include line breaks
-                if (c == '\n' || c == '\r') at_line_start = true;
-                else if (c != ' ' && c != '\t' && c != '\f' && c != '\v') at_line_start = false;
-                continue;
-            }
-
-            if (in_string) {
-                // Inside string, just continue scanning; line starts update:
-                if (c == '\n' || c == '\r') at_line_start = true;
-                else if (c != ' ' && c != '\t' && c != '\f' && c != '\v') at_line_start = false;
-                continue;
-            }
-
-            // --- Not in string: detect comment starts/ends ---
-            if (comment == Comment::None) {
-                // Start of '//' line comment
-                if (c == '/' && next == '/') {
-                    // flush the chunk before comment
-                    out.append(json_string, chunk_begin, i - chunk_begin);
-                    // enter line comment
-                    comment = Comment::Line;
-                    // comment starts at i; skip the second '/'
-                    ++i;
-                    // chunk restarts after the comment end
-                    continue;
-                }
-                // Start of '/* ... */' block comment
-                if (c == '/' && next == '*') {
-                    out.append(json_string, chunk_begin, i - chunk_begin);
-                    comment = Comment::Block;
-                    ++i; // skip '*'
-                    continue;
-                }
-                // '#' single-line comment only if at line start or preceded by whitespace
-                if (c == '#') {
-                    // If previous emitted char was line start, or previous char is space-like:
-                    // We approximate: treat as comment if at_line_start == true
-                    // OR the previous char exists and is whitespace.
-                    bool prev_whitespace = (i == 0) ? true : !!std::isspace(static_cast<unsigned char>(json_string[i - 1]));
-                    if (at_line_start || prev_whitespace) {
-                        out.append(json_string, chunk_begin, i - chunk_begin);
-                        comment = Comment::Line;
-                        continue;
-                    }
-                }
-
-                // Update line start tracking when not in comment
-                if (c == '\n' || c == '\r') at_line_start = true;
-                else if (c != ' ' && c != '\t' && c != '\f' && c != '\v') at_line_start = false;
-
-                continue;
-            }
-
-            if (comment == Comment::Line) {
-                // End line comment at '\n' or CRLF boundaries
-                if (c == '\n') {
-                    // include comment in [chunk_begin, i) — replaced with spaces if needed
-                    if (with_whitespace) {
-                        detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, i);
-                        out.push_back('\n'); // keep newline itself
-                    } else {
-                        // drop the comment segment; keep newline
-                        out.push_back('\n');
-                    }
-                    chunk_begin = i + 1;
-                    comment = Comment::None;
-                    at_line_start = true;
-                } else if (c == '\r' && next == '\n') {
-                    if (with_whitespace) {
-                        detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, i);
-                        out.push_back('\r');
-                        out.push_back('\n');
-                    } else {
-                        out.push_back('\r');
-                        out.push_back('\n');
-                    }
-                    chunk_begin = i + 2;
-                    ++i; // consumed '\n'
-                    comment = Comment::None;
-                    at_line_start = true;
-                }
-                continue;
-            }
-
-            if (comment == Comment::Block) {
-                // End of block comment "*/"
-                if (c == '*' && next == '/') {
-                    const std::size_t comment_end_inclusive = i + 1; // include '/'
-                    if (with_whitespace) {
-                        detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, comment_end_inclusive + 1);
-                    }
-                    chunk_begin = comment_end_inclusive + 1;
-                    ++i; // skip '/'
-                    comment = Comment::None;
-                    // line start status after block depends on next char; keep conservative:
-                    // if next char is newline, at_line_start will be updated in the main loop;
-                    continue;
-                }
-                // while inside block comment — do nothing
-                continue;
-            }
-        }
-
-        // Flush tail
-        if (comment == Comment::None) {
-            out.append(json_string, chunk_begin, n - chunk_begin);
-        } else {
-            // ended inside a comment: drop it or replace with spaces
-            if (with_whitespace) {
-                detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, n);
-            }
-            // else: drop
-        }
-
-        return out;
-    }
+        ) noexcept;
 
 } // namespace ImGuiX::Utils
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "strip_json_comments.ipp"
+#endif
 
 #endif // _IMGUIX_UTILS_STRIP_JSON_COMMENTS_HPP_INCLUDED

--- a/include/imguix/utils/strip_json_comments.ipp
+++ b/include/imguix/utils/strip_json_comments.ipp
@@ -1,0 +1,181 @@
+#include <cctype>
+#include <cstddef>
+
+namespace ImGuiX::Utils::detail {
+
+    // Returns true if quote at position 'pos' is escaped by an odd number of backslashes.
+    inline bool is_escaped_quote(const std::string& s, std::size_t pos) noexcept {
+        // Preconditions: pos < s.size() && s[pos] == '"'
+        std::size_t backslash_count = 0;
+        while (pos > 0 && s[--pos] == '\\') {
+            ++backslash_count;
+        }
+        return (backslash_count % 2) == 1;
+    }
+
+    // Replace every non-newline char with space; keep '\n' and '\r' intact.
+    inline void append_spaces_preserve_newlines(
+            std::string& out,
+            const std::string& src,
+            std::size_t from,
+            std::size_t to_exclusive) {
+        out.reserve(out.size() + (to_exclusive - from));
+        for (std::size_t i = from; i < to_exclusive; ++i) {
+            const char c = src[i];
+            out.push_back((c == '\n' || c == '\r') ? c : ' ');
+        }
+    }
+
+} // namespace ImGuiX::Utils::detail
+
+namespace ImGuiX::Utils {
+
+    std::string strip_json_comments(
+            const std::string& json_string,
+            const bool with_whitespace) noexcept {
+        enum class Comment : unsigned char { None, Line, Block };
+
+        const std::size_t n = json_string.size();
+        if (n == 0) return {};
+
+        std::string out;
+        out.reserve(n);
+
+        bool in_string = false;
+        Comment comment = Comment::None;
+
+        // Track the start of the current "uncommented chunk".
+        std::size_t chunk_begin = 0;
+
+        // For recognizing '#' as a comment only at line start or after whitespace,
+        // track whether the previous non-output char was a line break.
+        bool at_line_start = true; // true at very beginning
+
+        for (std::size_t i = 0; i < n; ++i) {
+            const char c = json_string[i];
+            const char next = (i + 1 < n) ? json_string[i + 1] : '\0';
+
+            // Handle string boundaries only outside comments
+            if (comment == Comment::None && c == '"') {
+                if (!detail::is_escaped_quote(json_string, i)) {
+                    in_string = !in_string;
+                }
+                // Strings affect at_line_start only if they include line breaks
+                if (c == '\n' || c == '\r') at_line_start = true;
+                else if (c != ' ' && c != '\t' && c != '\f' && c != '\v') at_line_start = false;
+                continue;
+            }
+
+            if (in_string) {
+                // Inside string, just continue scanning; line starts update:
+                if (c == '\n' || c == '\r') at_line_start = true;
+                else if (c != ' ' && c != '\t' && c != '\f' && c != '\v') at_line_start = false;
+                continue;
+            }
+
+            // --- Not in string: detect comment starts/ends ---
+            if (comment == Comment::None) {
+                // Start of '//' line comment
+                if (c == '/' && next == '/') {
+                    // Flush the chunk before comment
+                    out.append(json_string, chunk_begin, i - chunk_begin);
+                    // Enter line comment
+                    comment = Comment::Line;
+                    // Comment starts at i; skip the second '/'
+                    ++i;
+                    // Chunk restarts after the comment end
+                    continue;
+                }
+                // Start of '/* ... */' block comment
+                if (c == '/' && next == '*') {
+                    out.append(json_string, chunk_begin, i - chunk_begin);
+                    comment = Comment::Block;
+                    ++i; // skip '*'
+                    continue;
+                }
+                // '#' single-line comment only if at line start or preceded by whitespace
+                if (c == '#') {
+                    // If previous emitted char was line start, or previous char is space-like:
+                    // treat as comment if at_line_start == true
+                    // OR the previous char exists and is whitespace.
+                    bool prev_whitespace = (i == 0) ? true : !!std::isspace(static_cast<unsigned char>(json_string[i - 1]));
+                    if (at_line_start || prev_whitespace) {
+                        out.append(json_string, chunk_begin, i - chunk_begin);
+                        comment = Comment::Line;
+                        continue;
+                    }
+                }
+
+                // Update line start tracking when not in comment
+                if (c == '\n' || c == '\r') at_line_start = true;
+                else if (c != ' ' && c != '\t' && c != '\f' && c != '\v') at_line_start = false;
+
+                continue;
+            }
+
+            if (comment == Comment::Line) {
+                // End line comment at '\n' or CRLF boundaries
+                if (c == '\n') {
+                    // Include comment in [chunk_begin, i) — replaced with spaces if needed
+                    if (with_whitespace) {
+                        detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, i);
+                        out.push_back('\n'); // keep newline itself
+                    } else {
+                        // Drop the comment segment; keep newline
+                        out.push_back('\n');
+                    }
+                    chunk_begin = i + 1;
+                    comment = Comment::None;
+                    at_line_start = true;
+                } else if (c == '\r' && next == '\n') {
+                    if (with_whitespace) {
+                        detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, i);
+                        out.push_back('\r');
+                        out.push_back('\n');
+                    } else {
+                        out.push_back('\r');
+                        out.push_back('\n');
+                    }
+                    chunk_begin = i + 2;
+                    ++i; // consumed '\n'
+                    comment = Comment::None;
+                    at_line_start = true;
+                }
+                continue;
+            }
+
+            if (comment == Comment::Block) {
+                // End of block comment "*/"
+                if (c == '*' && next == '/') {
+                    const std::size_t comment_end_inclusive = i + 1; // include '/'
+                    if (with_whitespace) {
+                        detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, comment_end_inclusive + 1);
+                    }
+                    chunk_begin = comment_end_inclusive + 1;
+                    ++i; // skip '/'
+                    comment = Comment::None;
+                    // Line start status after block depends on next char; keep conservative:
+                    // if next char is newline, at_line_start will be updated in the main loop;
+                    continue;
+                }
+                // While inside block comment — do nothing
+                continue;
+            }
+        }
+
+        // Flush tail
+        if (comment == Comment::None) {
+            out.append(json_string, chunk_begin, n - chunk_begin);
+        } else {
+            // Ended inside a comment: drop it or replace with spaces
+            if (with_whitespace) {
+                detail::append_spaces_preserve_newlines(out, json_string, chunk_begin, n);
+            }
+            // else: drop
+        }
+
+        return out;
+    }
+
+} // namespace ImGuiX::Utils
+

--- a/include/imguix/utils/time_utils.hpp
+++ b/include/imguix/utils/time_utils.hpp
@@ -4,11 +4,10 @@
 
 /// \file time_utils.hpp
 /// \brief Time/date utilities: civil<->days, timestamp<->ymdhms, H:M:S helpers, weekdays.
-/// \note Header-only, C++17.
+/// \note Supports optional header-only mode via IMGUIX_HEADER_ONLY.
 
 #include <algorithm>
 #include <cstdint>
-#include <cstdio>
 #include <string>
 
 namespace ImGuiX::Utils {
@@ -20,33 +19,15 @@ namespace ImGuiX::Utils {
     // ---------- civil date algorithms (Howard Hinnant) ----------
 
     /// @brief Leap year check for civil year.
-    constexpr bool is_leap_year_date(int64_t y) noexcept {
+    inline bool is_leap_year_date(int64_t y) noexcept {
         return (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
     }
 
     /// @brief Days since 1970-01-01 for civil y-m-d.
-    constexpr int64_t days_from_civil(int64_t y, unsigned m, unsigned d) noexcept {
-        y -= m <= 2;
-        const int64_t era = (y >= 0 ? y : y - 399) / 400;
-        const unsigned yoe = static_cast<unsigned>(y - era * 400);                 // [0, 399]
-        const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;       // [0, 365]
-        const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + yoe / 400 + doy;    // [0, 146096]
-        return era * 146097 + static_cast<int64_t>(doe) - 719468;
-    }
+    int64_t days_from_civil(int64_t y, unsigned m, unsigned d) noexcept;
 
     /// @brief Civil y-m-d from days since 1970-01-01.
-    constexpr void civil_from_days(int64_t z, int64_t& y, unsigned& m, unsigned& d) noexcept {
-        z += 719468;
-        const int64_t era = (z >= 0 ? z : z - 146096) / 146097;
-        const unsigned doe = static_cast<unsigned>(z - era * 146097);              // [0, 146096]
-        const unsigned yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;// [0, 399]
-        y = static_cast<int64_t>(yoe) + era * 400;
-        const unsigned doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-        const unsigned mp = (5 * doy + 2) / 153;
-        d = doy - (153 * mp + 2) / 5 + 1;
-        m = mp + (mp < 10 ? 3 : -9);
-        y += (m <= 2);
-    }
+    void civil_from_days(int64_t z, int64_t& y, unsigned& m, unsigned& d) noexcept;
 
     // ---------- timestamp <-> ymdhms ----------
 
@@ -59,15 +40,15 @@ namespace ImGuiX::Utils {
     }
 
     /// @brief Clamp Y/M/D/h/m/s into sane ranges (with year bounds).
-    inline void clamp_ymdhms(int64_t& y, int& m, int& d, int& hh, int& mm, int& ss,
-                             int min_year, int max_year) {
-        y = std::max<int64_t>(min_year, std::min<int64_t>(max_year, y));
-        m = std::clamp(m, 1, 12);
-        d = std::clamp(d, 1, num_days_in_month(y, m));
-        hh = std::clamp(hh, 0, 23);
-        mm = std::clamp(mm, 0, 59);
-        ss = std::clamp(ss, 0, 59);
-    }
+    void clamp_ymdhms(
+            int64_t& y,
+            int& m,
+            int& d,
+            int& hh,
+            int& mm,
+            int& ss,
+            int min_year,
+            int max_year);
     
     /// \brief Clamp Y/M/D to sane ranges using Utils::clamp_ymdhms.
     inline void clamp_ymd(int64_t& y, int& m, int& d, int min_y, int max_y) {
@@ -76,37 +57,23 @@ namespace ImGuiX::Utils {
     }
 
     /// @brief Split POSIX seconds into Y/M/D/h/m/s.
-    inline void timestamp_to_ymdhms(
+    void timestamp_to_ymdhms(
             ts_t ts,
             int64_t& year,
             int& month,
             int& day,
             int& hour,
             int& minute,
-            int& second) {
-        int64_t days = ts / 86400;
-        int64_t rem  = ts % 86400;
-        if (rem < 0) { rem += 86400; --days; }
-        unsigned m, d;
-        civil_from_days(days, year, m, d);
-        month = static_cast<int>(m);
-        day   = static_cast<int>(d);
-        hour  = static_cast<int>(rem / 3600); rem %= 3600;
-        minute= static_cast<int>(rem / 60);
-        second= static_cast<int>(rem % 60);
-    }
+            int& second);
 
     /// @brief Compose POSIX seconds from Y/M/D/h/m/s.
-    inline int64_t ymdhms_to_timestamp(
+    int64_t ymdhms_to_timestamp(
             int64_t year,
             int month,
             int day,
             int hour,
             int minute,
-            int second) {
-        int64_t days = days_from_civil(year, static_cast<unsigned>(month), static_cast<unsigned>(day));
-        return days * 86400 + static_cast<int64_t>(hour) * 3600 + minute * 60 + second;
-    }
+            int second);
 
     // ---------- H:M:S helpers ----------
 
@@ -133,11 +100,7 @@ namespace ImGuiX::Utils {
     // ---------- weekdays ----------
 
     /// @brief Weekday 0=Sun..6=Sat for civil date.
-    inline int weekday_sun0_from_ymd(int64_t y, int m, int d) {
-        int64_t z = days_from_civil(y, (unsigned)m, (unsigned)d); // days since 1970-01-01
-        int w = int((z + 4) % 7); if (w < 0) w += 7;              // 1970-01-01 is Thu
-        return w;                                                 // 0=Sun..6=Sat
-    }
+    int weekday_sun0_from_ymd(int64_t y, int m, int d);
 
     /// @brief Convert Sunday-based index (Sun=0..Sat=6) to Monday-based (Mon=0..Sun=6).
     inline int to_monday0(int sun0) { return (sun0 + 6) % 7; }
@@ -151,117 +114,27 @@ namespace ImGuiX::Utils {
     
     // ---------- format ----------
 
-    inline std::string format_hms(int sec) {
-        int h, m, s; ImGuiX::Utils::seconds_to_hms(sec, h, m, s);
-        char buf[16]; std::snprintf(buf, sizeof(buf), u8"%02d:%02d:%02d", h, m, s);
-        return std::string(buf);
-    }
+    std::string format_hms(int sec);
 
-    inline std::string format_signed_hms(int64_t off_sec) {
-        bool pos = off_sec >= 0;
-        uint32_t a = static_cast<uint32_t>(pos ? off_sec : -off_sec);
-        char buf[20];
-        int h, m, s; ImGuiX::Utils::seconds_to_hms(static_cast<int>(a), h, m, s);
-        std::snprintf(buf, sizeof(buf), u8"%c%02d:%02d:%02d", pos ? '+' : '-', h, m, s);
-        return std::string(buf);
-    }
-    
+    std::string format_signed_hms(int64_t off_sec);
+
     /// \brief Format YYYY-MM-DD.
-    inline std::string format_ymd(int64_t y, int m, int d) {
-        char buf[32];
-        std::snprintf(buf, sizeof(buf), "%04lld-%02d-%02d",
-                      static_cast<long long>(y), m, d);
-        return std::string(buf);
-    }
-    
+    std::string format_ymd(int64_t y, int m, int d);
+
     /// \brief Optional human hint like "Mon 2025-08-25" based on Utils weekday.
-    inline std::string format_with_weekday(int64_t y, int m, int d) {
-        static const char* WD[7] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
-        int w_sun0 = ImGuiX::Utils::weekday_sun0_from_ymd(y, m, d);
-        int w_mon0 = ImGuiX::Utils::to_monday0(w_sun0);
-        (void)w_mon0; // keep for possible future Mon-based
-        char buf[48];
-        std::snprintf(buf, sizeof(buf), "%s %s",
-            WD[w_sun0], 
-            ImGuiX::Utils::format_ymd(y, m, d).c_str()
-        );
-        return std::string(buf);
-    }
+    std::string format_with_weekday(int64_t y, int m, int d);
 
     /// @brief Parse "+03:00", "-05:30:15", "3:00", "0300" into signed seconds.
-    inline bool parse_signed_hms(const char* txt, int64_t& out_sec) {
-        if (!txt) return false;
-        while (*txt == ' ' || *txt == '\t') ++txt;
-        int sign = +1;
-        if (*txt == '+') { sign = +1; ++txt; }
-        else if (*txt == '-') { sign = -1; ++txt; }
+    bool parse_signed_hms(const char* txt, int64_t& out_sec);
 
-        int h = 0, m = 0, s = 0, n = 0;
-
-        if (std::sscanf(txt, u8"%d:%d:%d%n", &h, &m, &s, &n) >= 2 && n > 0) {
-            // ok
-        } else if (std::sscanf(txt, u8"%d:%d%n", &h, &m, &n) == 2) {
-            s = 0;
-        } else {
-            int packed = 0;
-            if (std::sscanf(txt, u8"%d%n", &packed, &n) == 1) {
-                if (packed < 0) packed = -packed;
-                if (packed >= 0 && packed <= 235959) {
-                    if (packed <= 959) {       // HMM
-                        h = packed / 100; m = packed % 100; s = 0;
-                    } else if (packed <= 2359) { // HHMM
-                        h = packed / 100; m = packed % 100; s = 0;
-                    } else {                    // HHMMSS
-                        h = packed / 10000; m = (packed / 100) % 100; s = packed % 100;
-                    }
-                } else return false;
-            } else return false;
-        }
-
-        if (h < 0 || h > 23 || m < 0 || m > 59 || s < 0 || s > 59) return false;
-        out_sec = static_cast<int64_t>(sign) * static_cast<int64_t>(hms_to_seconds(h, m, s));
-        return true;
-    }
-    
     /// \brief Parse "YYYY-MM-DD", "YYYY/MM/DD", "YYYY.MM.DD", or "YYYYMMDD".
     /// Accepts optional spaces; rejects invalid ranges.
-    inline bool parse_ymd(const char* txt, int64_t& y, int& m, int& d) {
-        if (!txt) return false;
-        while (*txt==' ' || *txt=='\t') ++txt;
-
-        int yy=0, mm=0, dd=0, n=0;
-        // Try dashed/slashed/dotted
-        if (std::sscanf(txt, "%d-%d-%d%n", &yy, &mm, &dd, &n) == 3 && n>0) {
-            // ok
-        } else if (std::sscanf(txt, "%d/%d/%d%n", &yy, &mm, &dd, &n) == 3 && n>0) {
-            // ok
-        } else if (std::sscanf(txt, "%d.%d.%d%n", &yy, &mm, &dd, &n) == 3 && n>0) {
-            // ok
-        } else {
-            // Packed YYYYMMDD
-            long long packed = 0;
-            if (std::sscanf(txt, "%lld%n", &packed, &n) == 1) {
-                if (packed < 0) packed = -packed;
-                if (packed >= 10101 && packed <= 99991231) {
-                    yy = static_cast<int>(packed / 10000);
-                    mm = static_cast<int>((packed / 100) % 100);
-                    dd = static_cast<int>(packed % 100);
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-
-        // Basic range check (month/day will be clamped later if needed)
-        if (mm < 1 || mm > 12) return false;
-        if (dd < 1 || dd > 31) return false;
-
-        y = yy; m = mm; d = dd;
-        return true;
-    }
+    bool parse_ymd(const char* txt, int64_t& y, int& m, int& d);
 
 } // namespace ImGuiX::Utils
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "time_utils.ipp"
+#endif
 
 #endif // _IMGUIX_UTILS_TIME_UTILS_HPP_INCLUDED

--- a/include/imguix/utils/time_utils.ipp
+++ b/include/imguix/utils/time_utils.ipp
@@ -1,0 +1,188 @@
+#include <cstdio>
+
+namespace ImGuiX::Utils {
+
+    int64_t days_from_civil(int64_t y, unsigned m, unsigned d) noexcept {
+        y -= m <= 2;
+        const int64_t era = (y >= 0 ? y : y - 399) / 400;
+        const unsigned yoe = static_cast<unsigned>(y - era * 400);                 // [0, 399]
+        const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;       // [0, 365]
+        const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + yoe / 400 + doy;    // [0, 146096]
+        return era * 146097 + static_cast<int64_t>(doe) - 719468;
+    }
+
+    void civil_from_days(int64_t z, int64_t& y, unsigned& m, unsigned& d) noexcept {
+        z += 719468;
+        const int64_t era = (z >= 0 ? z : z - 146096) / 146097;
+        const unsigned doe = static_cast<unsigned>(z - era * 146097);              // [0, 146096]
+        const unsigned yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;// [0, 399]
+        y = static_cast<int64_t>(yoe) + era * 400;
+        const unsigned doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        const unsigned mp = (5 * doy + 2) / 153;
+        d = doy - (153 * mp + 2) / 5 + 1;
+        m = mp + (mp < 10 ? 3 : -9);
+        y += (m <= 2);
+    }
+
+    void clamp_ymdhms(
+            int64_t& y,
+            int& m,
+            int& d,
+            int& hh,
+            int& mm,
+            int& ss,
+            int min_year,
+            int max_year) {
+        y = std::max<int64_t>(min_year, std::min<int64_t>(max_year, y));
+        m = std::clamp(m, 1, 12);
+        d = std::clamp(d, 1, num_days_in_month(y, m));
+        hh = std::clamp(hh, 0, 23);
+        mm = std::clamp(mm, 0, 59);
+        ss = std::clamp(ss, 0, 59);
+    }
+
+    void timestamp_to_ymdhms(
+            ts_t ts,
+            int64_t& year,
+            int& month,
+            int& day,
+            int& hour,
+            int& minute,
+            int& second) {
+        int64_t days = ts / 86400;
+        int64_t rem  = ts % 86400;
+        if (rem < 0) { rem += 86400; --days; }
+        unsigned m, d;
+        civil_from_days(days, year, m, d);
+        month = static_cast<int>(m);
+        day   = static_cast<int>(d);
+        hour  = static_cast<int>(rem / 3600); rem %= 3600;
+        minute= static_cast<int>(rem / 60);
+        second= static_cast<int>(rem % 60);
+    }
+
+    int64_t ymdhms_to_timestamp(
+            int64_t year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second) {
+        int64_t days = days_from_civil(year, static_cast<unsigned>(month), static_cast<unsigned>(day));
+        return days * 86400 + static_cast<int64_t>(hour) * 3600 + minute * 60 + second;
+    }
+
+    int weekday_sun0_from_ymd(int64_t y, int m, int d) {
+        int64_t z = days_from_civil(y, static_cast<unsigned>(m), static_cast<unsigned>(d)); // days since 1970-01-01
+        int w = int((z + 4) % 7); if (w < 0) w += 7;              // 1970-01-01 is Thu
+        return w;                                                 // 0=Sun..6=Sat
+    }
+
+    std::string format_hms(int sec) {
+        int h, m, s; ImGuiX::Utils::seconds_to_hms(sec, h, m, s);
+        char buf[16]; std::snprintf(buf, sizeof(buf), u8"%02d:%02d:%02d", h, m, s);
+        return std::string(buf);
+    }
+
+    std::string format_signed_hms(int64_t off_sec) {
+        bool pos = off_sec >= 0;
+        uint32_t a = static_cast<uint32_t>(pos ? off_sec : -off_sec);
+        char buf[20];
+        int h, m, s; ImGuiX::Utils::seconds_to_hms(static_cast<int>(a), h, m, s);
+        std::snprintf(buf, sizeof(buf), u8"%c%02d:%02d:%02d", pos ? '+' : '-', h, m, s);
+        return std::string(buf);
+    }
+
+    std::string format_ymd(int64_t y, int m, int d) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%04lld-%02d-%02d",
+                      static_cast<long long>(y), m, d);
+        return std::string(buf);
+    }
+
+    std::string format_with_weekday(int64_t y, int m, int d) {
+        static const char* WD[7] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
+        int w_sun0 = ImGuiX::Utils::weekday_sun0_from_ymd(y, m, d);
+        int w_mon0 = ImGuiX::Utils::to_monday0(w_sun0);
+        (void)w_mon0; // keep for possible future Mon-based
+        char buf[48];
+        std::snprintf(buf, sizeof(buf), "%s %s",
+            WD[w_sun0],
+            ImGuiX::Utils::format_ymd(y, m, d).c_str()
+        );
+        return std::string(buf);
+    }
+
+    bool parse_signed_hms(const char* txt, int64_t& out_sec) {
+        if (!txt) return false;
+        while (*txt == ' ' || *txt == '\t') ++txt;
+        int sign = +1;
+        if (*txt == '+') { sign = +1; ++txt; }
+        else if (*txt == '-') { sign = -1; ++txt; }
+
+        int h = 0, m = 0, s = 0, n = 0;
+
+        if (std::sscanf(txt, u8"%d:%d:%d%n", &h, &m, &s, &n) >= 2 && n > 0) {
+            // ok
+        } else if (std::sscanf(txt, u8"%d:%d%n", &h, &m, &n) == 2) {
+            s = 0;
+        } else {
+            int packed = 0;
+            if (std::sscanf(txt, u8"%d%n", &packed, &n) == 1) {
+                if (packed < 0) packed = -packed;
+                if (packed >= 0 && packed <= 235959) {
+                    if (packed <= 959) {       // HMM
+                        h = packed / 100; m = packed % 100; s = 0;
+                    } else if (packed <= 2359) { // HHMM
+                        h = packed / 100; m = packed % 100; s = 0;
+                    } else {                    // HHMMSS
+                        h = packed / 10000; m = (packed / 100) % 100; s = packed % 100;
+                    }
+                } else return false;
+            } else return false;
+        }
+
+        if (h < 0 || h > 23 || m < 0 || m > 59 || s < 0 || s > 59) return false;
+        out_sec = static_cast<int64_t>(sign) * static_cast<int64_t>(hms_to_seconds(h, m, s));
+        return true;
+    }
+
+    bool parse_ymd(const char* txt, int64_t& y, int& m, int& d) {
+        if (!txt) return false;
+        while (*txt==' ' || *txt=='\t') ++txt;
+
+        int yy=0, mm=0, dd=0, n=0;
+        // Try dashed/slashed/dotted
+        if (std::sscanf(txt, "%d-%d-%d%n", &yy, &mm, &dd, &n) == 3 && n>0) {
+            // ok
+        } else if (std::sscanf(txt, "%d/%d/%d%n", &yy, &mm, &dd, &n) == 3 && n>0) {
+            // ok
+        } else if (std::sscanf(txt, "%d.%d.%d%n", &yy, &mm, &dd, &n) == 3 && n>0) {
+            // ok
+        } else {
+            // Packed YYYYMMDD
+            long long packed = 0;
+            if (std::sscanf(txt, "%lld%n", &packed, &n) == 1) {
+                if (packed < 0) packed = -packed;
+                if (packed >= 10101 && packed <= 99991231) {
+                    yy = static_cast<int>(packed / 10000);
+                    mm = static_cast<int>((packed / 100) % 100);
+                    dd = static_cast<int>(packed % 100);
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        // Basic range check (month/day will be clamped later if needed)
+        if (mm < 1 || mm > 12) return false;
+        if (dd < 1 || dd > 31) return false;
+
+        y = yy; m = mm; d = dd;
+        return true;
+    }
+
+} // namespace ImGuiX::Utils
+


### PR DESCRIPTION
## Summary
- move heavy time utilities from header into time_utils.ipp
- keep small helpers inline and enable optional header-only mode
- shift JSON comment stripping helpers and implementation into strip_json_comments.ipp

## Testing
- `cmake -S . -B build` (fails: nlohmann_json: no system package and no submodule at libs/json)
- `cmake --build build` (fails: No rule to make target 'Makefile')

------
https://chatgpt.com/codex/tasks/task_e_68ac979d06c0832c899cd1c44839d86c