### PR TITLE
refactor: move extension implementations to ipp files

### DIFF
--- a/include/imguix/extensions/blend_colors.hpp
+++ b/include/imguix/extensions/blend_colors.hpp
@@ -14,18 +14,12 @@ namespace ImGuiX::Extensions {
     /// \param bg Background color.
     /// \return Blended color.
     /// \note Result equals foreground over background.
-    inline ImVec4 BlendColors(const ImVec4& fg, const ImVec4& bg) {
-        float a = fg.w + bg.w * (1.0f - fg.w);
-        if (a <= 0.0f)
-            return ImVec4(0, 0, 0, 0);
-        return ImVec4(
-            (fg.x * fg.w + bg.x * bg.w * (1.0f - fg.w)) / a,
-            (fg.y * fg.w + bg.y * bg.w * (1.0f - fg.w)) / a,
-            (fg.z * fg.w + bg.z * bg.w * (1.0f - fg.w)) / a,
-            a
-        );
-    }
+    inline ImVec4 BlendColors(const ImVec4& fg, const ImVec4& bg);
 
 } // namespace ImGuiX::Extensions
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "blend_colors.ipp"
+#endif
 
 #endif // _IMGUIX_EXTENSIONS_BLEND_COLORS_HPP_INCLUDED

--- a/include/imguix/extensions/blend_colors.ipp
+++ b/include/imguix/extensions/blend_colors.ipp
@@ -1,0 +1,18 @@
+#include <imgui.h>
+
+namespace ImGuiX::Extensions {
+
+    inline ImVec4 BlendColors(const ImVec4& fg, const ImVec4& bg) {
+        float a = fg.w + bg.w * (1.0f - fg.w);
+        if (a <= 0.0f)
+            return ImVec4(0, 0, 0, 0);
+        return ImVec4(
+            (fg.x * fg.w + bg.x * bg.w * (1.0f - fg.w)) / a,
+            (fg.y * fg.w + bg.y * bg.w * (1.0f - fg.w)) / a,
+            (fg.z * fg.w + bg.z * bg.w * (1.0f - fg.w)) / a,
+            a
+        );
+    }
+
+} // namespace ImGuiX::Extensions
+

--- a/include/imguix/extensions/color_gradient.hpp
+++ b/include/imguix/extensions/color_gradient.hpp
@@ -5,7 +5,6 @@
 /// \file color_gradient.hpp
 /// \brief Generates sequential colors from HSV spectrum.
 
-#include <algorithm>
 #include <cstddef>
 
 #include <imgui.h>
@@ -18,71 +17,15 @@ namespace ImGuiX::Extensions {
         double v; /// fraction between 0 and 1
     };
 
-    inline ImVec4 hsvToRgb(const Hsv& in) {
-        double hh = in.h;
-        if (hh >= 360.0)
-            hh = 0.0;
-        hh /= 60.0;
-        long i = static_cast<long>(hh);
-        double ff = hh - i;
-        double p = in.v * (1.0 - in.s);
-        double q = in.v * (1.0 - (in.s * ff));
-        double t = in.v * (1.0 - (in.s * (1.0 - ff)));
-        ImVec4 out;
-        out.w = 1.0f;
-        switch (i) {
-        case 0:
-            out.x = in.v;
-            out.y = t;
-            out.z = p;
-            break;
-        case 1:
-            out.x = q;
-            out.y = in.v;
-            out.z = p;
-            break;
-        case 2:
-            out.x = p;
-            out.y = in.v;
-            out.z = t;
-            break;
-        case 3:
-            out.x = p;
-            out.y = q;
-            out.z = in.v;
-            break;
-        case 4:
-            out.x = t;
-            out.y = p;
-            out.z = in.v;
-            break;
-        default:
-            out.x = in.v;
-            out.y = p;
-            out.z = q;
-            break;
-        }
-        return out;
-    }
+    ImVec4 hsvToRgb(const Hsv& in);
 
-    class ColorGradient {
+class ColorGradient {
     public:
-        explicit ColorGradient(std::size_t count)
-            : m_offset(count / 2 + 2 * count / 3),
-              m_max_item(count) {}
+        explicit ColorGradient(std::size_t count);
 
         /// \brief Retrieve next color from gradient.
         /// \return RGBA color with alpha = 1.
-        ImVec4 next() {
-            Hsv col;
-            col.h = static_cast<double>((m_next_index + m_offset) % m_max_item)
-                    / static_cast<double>(m_max_item) * 360.0;
-            m_next_index += std::max<std::size_t>(1, m_max_item / 12);
-            col.s = static_cast<double>((m_next_index * 2) % m_max_item)
-                    / static_cast<double>(m_max_item);
-            col.v = 0.9;
-            return hsvToRgb(col);
-        }
+        ImVec4 next();
 
     private:
         std::size_t m_next_index = 0;
@@ -91,5 +34,9 @@ namespace ImGuiX::Extensions {
     };
 
 } // namespace ImGuiX::Extensions
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "color_gradient.ipp"
+#endif
 
 #endif // _IMGUIX_EXTENSIONS_COLOR_GRADIENT_HPP_INCLUDED

--- a/include/imguix/extensions/color_gradient.ipp
+++ b/include/imguix/extensions/color_gradient.ipp
@@ -1,0 +1,70 @@
+#include <algorithm>
+#include <cstddef>
+#include <imgui.h>
+
+namespace ImGuiX::Extensions {
+
+    inline ImVec4 hsvToRgb(const Hsv& in) {
+        double hh = in.h;
+        if (hh >= 360.0)
+            hh = 0.0;
+        hh /= 60.0;
+        long i = static_cast<long>(hh);
+        double ff = hh - i;
+        double p = in.v * (1.0 - in.s);
+        double q = in.v * (1.0 - (in.s * ff));
+        double t = in.v * (1.0 - (in.s * (1.0 - ff)));
+        ImVec4 out;
+        out.w = 1.0f;
+        switch (i) {
+        case 0:
+            out.x = in.v;
+            out.y = t;
+            out.z = p;
+            break;
+        case 1:
+            out.x = q;
+            out.y = in.v;
+            out.z = p;
+            break;
+        case 2:
+            out.x = p;
+            out.y = in.v;
+            out.z = t;
+            break;
+        case 3:
+            out.x = p;
+            out.y = q;
+            out.z = in.v;
+            break;
+        case 4:
+            out.x = t;
+            out.y = p;
+            out.z = in.v;
+            break;
+        default:
+            out.x = in.v;
+            out.y = p;
+            out.z = q;
+            break;
+        }
+        return out;
+    }
+
+    inline ColorGradient::ColorGradient(std::size_t count) :
+        m_offset(count / 2 + 2 * count / 3),
+        m_max_item(count) {}
+
+    inline ImVec4 ColorGradient::next() {
+        Hsv col;
+        col.h = static_cast<double>((m_next_index + m_offset) % m_max_item)
+                / static_cast<double>(m_max_item) * 360.0;
+        m_next_index += std::max<std::size_t>(1, m_max_item / 12);
+        col.s = static_cast<double>((m_next_index * 2) % m_max_item)
+                / static_cast<double>(m_max_item);
+        col.v = 0.9;
+        return hsvToRgb(col);
+    }
+
+} // namespace ImGuiX::Extensions
+

--- a/include/imguix/extensions/color_utils.hpp
+++ b/include/imguix/extensions/color_utils.hpp
@@ -9,7 +9,6 @@
 
 #if defined(IMGUIX_USE_SFML_BACKEND)
     #include <SFML/Graphics/Color.hpp>
-    #include <cstdint>
 #endif
 
 namespace ImGuiX::Extensions {
@@ -19,26 +18,14 @@ namespace ImGuiX::Extensions {
     /// \brief Convert ImVec4 color to sf::Color.
     /// \param color Color with components in [0,1].
     /// \return 8-bit RGBA color.
-    inline sf::Color ColorToSfml(const ImVec4& color) {
-    #if defined(SFML_VERSION_MAJOR) && SFML_VERSION_MAJOR >= 3
-        return sf::Color(
-            static_cast<std::uint8_t>(color.x * 255.0f),
-            static_cast<std::uint8_t>(color.y * 255.0f),
-            static_cast<std::uint8_t>(color.z * 255.0f),
-            static_cast<std::uint8_t>(color.w * 255.0f)
-        );
-    #else
-        return sf::Color(
-            static_cast<sf::Uint8>(color.x * 255.0f),
-            static_cast<sf::Uint8>(color.y * 255.0f),
-            static_cast<sf::Uint8>(color.z * 255.0f),
-            static_cast<sf::Uint8>(color.w * 255.0f)
-        );
-    #endif
-    }
+    inline sf::Color ColorToSfml(const ImVec4& color);
 
 #endif // IMGUIX_USE_SFML_BACKEND
 
 } // namespace ImGuiX::Extensions
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "color_utils.ipp"
+#endif
 
 #endif // _IMGUIX_EXTENSIONS_COLOR_UTILS_HPP_INCLUDED

--- a/include/imguix/extensions/color_utils.ipp
+++ b/include/imguix/extensions/color_utils.ipp
@@ -1,0 +1,33 @@
+#include <imgui.h>
+
+#if defined(IMGUIX_USE_SFML_BACKEND)
+#   include <SFML/Graphics/Color.hpp>
+#   include <cstdint>
+#endif
+
+namespace ImGuiX::Extensions {
+
+#if defined(IMGUIX_USE_SFML_BACKEND)
+
+    inline sf::Color ColorToSfml(const ImVec4& color) {
+    #if defined(SFML_VERSION_MAJOR) && SFML_VERSION_MAJOR >= 3
+        return sf::Color(
+            static_cast<std::uint8_t>(color.x * 255.0f),
+            static_cast<std::uint8_t>(color.y * 255.0f),
+            static_cast<std::uint8_t>(color.z * 255.0f),
+            static_cast<std::uint8_t>(color.w * 255.0f)
+        );
+    #else
+        return sf::Color(
+            static_cast<sf::Uint8>(color.x * 255.0f),
+            static_cast<sf::Uint8>(color.y * 255.0f),
+            static_cast<sf::Uint8>(color.z * 255.0f),
+            static_cast<sf::Uint8>(color.w * 255.0f)
+        );
+    #endif
+    }
+
+#endif // IMGUIX_USE_SFML_BACKEND
+
+} // namespace ImGuiX::Extensions
+

--- a/include/imguix/extensions/force_opaque_style.hpp
+++ b/include/imguix/extensions/force_opaque_style.hpp
@@ -12,37 +12,17 @@ namespace ImGuiX::Extensions {
     /// \brief Set ImGui style to fully opaque.
     /// \note Applies `style.Alpha = 1.0f` and sets all style colors' alpha to 1.0f.
     /// \note Useful when using DWM transparency or to prevent unwanted background blending.
-    inline void ForceOpaqueStyle() {
-        ImGuiStyle& style = ImGui::GetStyle();
-        style.Alpha = 1.0f;
-        for (int i = 0; i < ImGuiCol_COUNT; ++i) {
-            style.Colors[i].w = 1.0f;
-        }
-    }
+    inline void ForceOpaqueStyle();
 
     /// \brief RAII-style scope to enforce fully opaque ImGui style.
     /// \note Restores all style colors and alpha after scope ends.
     class ScopedOpaqueStyle {
     public:
         /// \brief Save current style and apply fully opaque style.
-        ScopedOpaqueStyle() {
-            ImGuiStyle& style = ImGui::GetStyle();
-            m_old_alpha = style.Alpha;
-            for (int i = 0; i < ImGuiCol_COUNT; ++i) {
-                m_old_colors[i] = style.Colors[i];
-                style.Colors[i].w = 1.0f;
-            }
-            style.Alpha = 1.0f;
-        }
+        ScopedOpaqueStyle();
 
         /// \brief Restore previous style on destruction.
-        ~ScopedOpaqueStyle() {
-            ImGuiStyle& style = ImGui::GetStyle();
-            style.Alpha = m_old_alpha;
-            for (int i = 0; i < ImGuiCol_COUNT; ++i) {
-                style.Colors[i] = m_old_colors[i];
-            }
-        }
+        ~ScopedOpaqueStyle();
 
     private:
         ImVec4 m_old_colors[ImGuiCol_COUNT];
@@ -50,5 +30,9 @@ namespace ImGuiX::Extensions {
     };
 
 } // namespace ImGuiX::Extensions
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "force_opaque_style.ipp"
+#endif
 
 #endif // _IMGUIX_EXTENSIONS_FORCE_OPAQUE_STYLE_HPP_INCLUDED

--- a/include/imguix/extensions/force_opaque_style.ipp
+++ b/include/imguix/extensions/force_opaque_style.ipp
@@ -1,0 +1,32 @@
+#include <imgui.h>
+
+namespace ImGuiX::Extensions {
+
+    inline void ForceOpaqueStyle() {
+        ImGuiStyle& style = ImGui::GetStyle();
+        style.Alpha = 1.0f;
+        for (int i = 0; i < ImGuiCol_COUNT; ++i) {
+            style.Colors[i].w = 1.0f;
+        }
+    }
+
+    inline ScopedOpaqueStyle::ScopedOpaqueStyle() {
+        ImGuiStyle& style = ImGui::GetStyle();
+        m_old_alpha = style.Alpha;
+        for (int i = 0; i < ImGuiCol_COUNT; ++i) {
+            m_old_colors[i] = style.Colors[i];
+            style.Colors[i].w = 1.0f;
+        }
+        style.Alpha = 1.0f;
+    }
+
+    inline ScopedOpaqueStyle::~ScopedOpaqueStyle() {
+        ImGuiStyle& style = ImGui::GetStyle();
+        style.Alpha = m_old_alpha;
+        for (int i = 0; i < ImGuiCol_COUNT; ++i) {
+            style.Colors[i] = m_old_colors[i];
+        }
+    }
+
+} // namespace ImGuiX::Extensions
+

--- a/include/imguix/extensions/scoped_disable.hpp
+++ b/include/imguix/extensions/scoped_disable.hpp
@@ -11,40 +11,30 @@ namespace ImGuiX::Extensions {
 
     /// \brief Begin disabled block with optional alpha fade.
     /// \param disable When true, subsequent widgets are disabled.
-    inline void BeginDisable(bool disable) {
-        if (!disable)
-            return;
-        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-        ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
-    }
+    inline void BeginDisable(bool disable);
 
     /// \brief End disabled block started with BeginDisable.
     /// \param disable When true, pops style changes.
-    inline void EndDisable(bool disable) {
-        if (!disable)
-            return;
-        ImGui::PopItemFlag();
-        ImGui::PopStyleVar();
-    }
+    inline void EndDisable(bool disable);
 
     /// \brief RAII scope disabling contained widgets.
     class ScopedDisable {
     public:
         /// \brief Construct scope and optionally disable widgets.
         /// \param disable True to disable widgets within scope.
-        explicit ScopedDisable(bool disable) : m_is_disabled(disable) {
-            BeginDisable(m_is_disabled);
-        }
+        explicit ScopedDisable(bool disable);
 
         /// \brief Restore previous widget state.
-        ~ScopedDisable() {
-            EndDisable(m_is_disabled);
-        }
+        ~ScopedDisable();
 
     private:
         bool m_is_disabled = false;
     };
 
 } // namespace ImGuiX::Extensions
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "scoped_disable.ipp"
+#endif
 
 #endif // _IMGUIX_EXTENSIONS_SCOPED_DISABLE_HPP_INCLUDED

--- a/include/imguix/extensions/scoped_disable.ipp
+++ b/include/imguix/extensions/scoped_disable.ipp
@@ -1,0 +1,29 @@
+#include <imgui.h>
+
+namespace ImGuiX::Extensions {
+
+    inline void BeginDisable(bool disable) {
+        if (!disable)
+            return;
+        ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+        ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+    }
+
+    inline void EndDisable(bool disable) {
+        if (!disable)
+            return;
+        ImGui::PopItemFlag();
+        ImGui::PopStyleVar();
+    }
+
+    inline ScopedDisable::ScopedDisable(bool disable) :
+        m_is_disabled(disable) {
+        BeginDisable(m_is_disabled);
+    }
+
+    inline ScopedDisable::~ScopedDisable() {
+        EndDisable(m_is_disabled);
+    }
+
+} // namespace ImGuiX::Extensions
+

--- a/include/imguix/extensions/validation.hpp
+++ b/include/imguix/extensions/validation.hpp
@@ -6,7 +6,6 @@
 /// \brief Lightweight helpers for input validation and scoped styling.
 
 #include <imgui.h>
-#include <regex>
 #include <string>
 
 namespace ImGuiX::Extensions {
@@ -14,11 +13,7 @@ namespace ImGuiX::Extensions {
     /// \brief Safe regex match. Returns true if matches or if regex is invalid (fail-open).
     /// \param s       Input string to validate.
     /// \param pattern Regex pattern (std::string). If empty or invalid, returns true.
-    inline bool RegexMatchSafe(const std::string& s, const std::string& pattern) {
-        if (pattern.empty()) return true;
-        try { std::regex re(pattern); return std::regex_match(s, re); }
-        catch (...) { return true; } // invalid regex -> don't block UI
-    }
+    inline bool RegexMatchSafe(const std::string& s, const std::string& pattern);
 
     /// \brief Begin invalid styling if condition is true.
     /// \param is_invalid Whether to push error color.
@@ -26,16 +21,12 @@ namespace ImGuiX::Extensions {
     /// \param target     ImGuiCol to tint (default: Text).
     inline void BeginInvalid(bool is_invalid,
                              ImVec4 color = ImVec4(0.9f, 0.5f, 0.5f, 1.0f),
-                             ImGuiCol target = ImGuiCol_Text) {
-        if (is_invalid) ImGui::PushStyleColor(target, color);
-    }
+                             ImGuiCol target = ImGuiCol_Text);
 
     /// \brief End invalid styling if condition is true.
     /// \param is_invalid Whether BeginInvalid was used.
     /// \param count      Number of colors to pop (usually 1).
-    inline void EndInvalid(bool is_invalid, int count = 1) {
-        if (is_invalid) ImGui::PopStyleColor(count);
-    }
+    inline void EndInvalid(bool is_invalid, int count = 1);
 
     /// \brief RAII scope for invalid styling (push on ctor, pop on dtor).
     class ScopedInvalid {
@@ -46,29 +37,25 @@ namespace ImGuiX::Extensions {
         /// \param target     ImGuiCol to affect (default: Text).
         explicit ScopedInvalid(bool is_invalid,
                                ImVec4 color = ImVec4(0.9f, 0.5f, 0.5f, 1.0f),
-                               ImGuiCol target = ImGuiCol_Text)
-            : m_active(is_invalid) {
-            if (m_active) ImGui::PushStyleColor(target, color);
-        }
+                               ImGuiCol target = ImGuiCol_Text);
 
         /// \brief Pop style color if still active.
-        ~ScopedInvalid() { end(); }
+        ~ScopedInvalid();
 
         ScopedInvalid(const ScopedInvalid&) = delete;
         ScopedInvalid& operator=(const ScopedInvalid&) = delete;
 
         /// \brief End invalid tinting early (idempotent).
         /// \details Useful to stop tinting before drawing adjacent widgets (e.g., buttons).
-        void end() {
-            if (m_active) {
-                ImGui::PopStyleColor();
-                m_active = false;
-            }
-        }
+        void end();
     private:
         bool m_active = false;
     };
 
 } // namespace ImGuiX::Extensions
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "validation.ipp"
+#endif
 
 #endif // _IMGUIX_EXTENSIONS_VALIDATION_HPP_INCLUDED

--- a/include/imguix/extensions/validation.ipp
+++ b/include/imguix/extensions/validation.ipp
@@ -1,0 +1,50 @@
+#include <imgui.h>
+#include <regex>
+#include <string>
+
+namespace ImGuiX::Extensions {
+
+    inline bool RegexMatchSafe(const std::string& s, const std::string& pattern) {
+        if (pattern.empty())
+            return true;
+        try {
+            std::regex re(pattern);
+            return std::regex_match(s, re);
+        } catch (...) {
+            return true; // invalid regex -> don't block UI
+        }
+    }
+
+    inline void BeginInvalid(bool is_invalid,
+                             ImVec4 color,
+                             ImGuiCol target) {
+        if (is_invalid)
+            ImGui::PushStyleColor(target, color);
+    }
+
+    inline void EndInvalid(bool is_invalid, int count) {
+        if (is_invalid)
+            ImGui::PopStyleColor(count);
+    }
+
+    inline ScopedInvalid::ScopedInvalid(bool is_invalid,
+                                        ImVec4 color,
+                                        ImGuiCol target) :
+        m_active(is_invalid) {
+        if (m_active)
+            ImGui::PushStyleColor(target, color);
+    }
+
+    inline ScopedInvalid::~ScopedInvalid() {
+        end();
+    }
+
+    inline void ScopedInvalid::end() {
+        if (m_active) {
+            ImGui::PopStyleColor();
+            m_active = false;
+        }
+    }
+
+} // namespace ImGuiX::Extensions
+


### PR DESCRIPTION
## Summary
- move non-template code from extension headers into new .ipp files
- allow header-only or library builds via IMGUIX_HEADER_ONLY include blocks

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca15d7fe0832c9b56ee6074cea19f