### PR TITLE
refactor(i18n): split implementations into ipp files

### DIFF
--- a/include/imguix/core/i18n/LangStore.ipp
+++ b/include/imguix/core/i18n/LangStore.ipp
@@ -1,0 +1,232 @@
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <system_error>
+#include <unordered_map>
+
+#include <nlohmann/json.hpp>
+
+#include "imguix/utils/path_utils.hpp"
+#include "imguix/utils/strip_json_comments.hpp"
+#include "imguix/core/i18n/PluralRules.hpp"
+
+namespace ImGuiX::I18N {
+
+    LangStore::LangStore(std::string base_dir, std::string default_lang)
+        : m_base_dir(std::move(base_dir)),
+          m_default_lang(std::move(default_lang)),
+          m_current_lang(m_default_lang),
+          m_plural_rules(std::make_unique<PluralRules>()) { // always present; has built-ins
+        // Load fallback language (default) once.
+        m_en_map = load_language_map(m_default_lang);
+        m_current_map = &m_en_map;
+
+        // Try optional plurals.json in <base_dir>/plurals.json (ignore if absent).
+        try_load_plural_rules_from_default_location();
+    }
+
+    void LangStore::set_language(std::string lang) {
+        if (lang == m_current_lang) return;
+        m_current_lang = std::move(lang);
+
+        if (m_current_lang == m_default_lang) {
+            m_current_map = &m_en_map;
+        } else {
+            // build or reuse from cache
+            auto it = m_lang_cache.find(m_current_lang);
+            if (it == m_lang_cache.end()) {
+                auto map = load_language_map(m_current_lang);
+                it = m_lang_cache.emplace(m_current_lang, std::move(map)).first;
+            }
+            m_current_map = &it->second;
+        }
+
+        // Reset per-language caches
+        m_label_cache.clear();
+        m_md_cache.clear();
+    }
+
+    bool LangStore::load_plural_rules_from_file(const std::string& path) {
+        return m_plural_rules ? m_plural_rules->load_from_file(path) : false;
+    }
+
+    const std::string& LangStore::text(std::string_view key) const {
+        if (const auto* s = find_in(*m_current_map, key)) return *s;
+        if (const auto* s = find_in(m_en_map, key))       return *s;
+        return missing_string();
+    }
+
+    const char* LangStore::label(std::string_view key) const {
+        if (auto it = m_label_cache.find(key); it != m_label_cache.end())
+            return it->second.c_str();
+
+        const std::string& base = text(key);
+        std::string combined;
+        combined.reserve(base.size() + 2 + key.size());
+        combined += base;
+        combined += u8"##";
+        combined.append(key.begin(), key.end());
+
+        auto [ins, _] = m_label_cache.emplace(intern_key(std::string(key)), std::move(combined));
+        return ins->second.c_str();
+    }
+
+    std::string LangStore::doc(std::string_view doc_key) const {
+        if (auto s = load_md_cached(m_current_lang, doc_key); !s.empty()) return s;
+        if (m_current_lang != m_default_lang) {
+            if (auto s = load_md_cached(m_default_lang, doc_key); !s.empty()) return s;
+        }
+        return {};
+    }
+
+    std::string LangStore::plural_suffix(long long n) const {
+        // PluralRules::category() already has built-ins for "en" and "ru".
+        return m_plural_rules ? m_plural_rules->category(m_current_lang, n)
+                              : default_plural_suffix(m_current_lang, n);
+    }
+
+    const std::string& LangStore::text_plural(std::string_view base_key, long long n) const {
+        const std::string suf = plural_suffix(n);
+        if (const auto* s = find_in(*m_current_map, join_dotted(base_key, suf))) return *s;
+        if (const auto* s = find_in(m_en_map,      join_dotted(base_key, suf)))   return *s;
+        if (const auto* s = find_in(*m_current_map, base_key)) return *s;
+        if (const auto* s = find_in(m_en_map,       base_key)) return *s;
+        return missing_string();
+    }
+
+    std::string LangStore::default_i18n_base_dir() {
+#if IMGUIX_RESOLVE_PATHS_REL_TO_EXE
+        return ImGuiX::Utils::resolveExecPath(IMGUIX_I18N_DIR);
+#else
+        return std::string(IMGUIX_I18N_DIR);
+#endif
+    }
+
+    LangStore::StrMap LangStore::load_language_map(const std::string& lang) const {
+        StrMap out;
+        const fs::path dir = fs::path(m_base_dir) / lang;
+        std::error_code ec;
+        if (!fs::exists(dir, ec) || !fs::is_directory(dir, ec)) {
+            return out; // allowed to be empty
+        }
+
+        for (auto& de : fs::directory_iterator(dir, ec)) {
+            if (ec) break;
+            if (!de.is_regular_file()) continue;
+            const auto& p = de.path();
+            if (p.extension() != u8".json") continue;
+
+            const std::string raw = read_file(p.string());
+            if (raw.empty()) continue;
+
+            const std::string clean = ImGuiX::Utils::strip_json_comments(raw, /*with_whitespace*/ false);
+
+            nlohmann::json j;
+            try {
+                j = nlohmann::json::parse(clean);
+            } catch (...) {
+                // ignore broken files (could log)
+                continue;
+            }
+
+            merge_object_for_lang(j, lang, out, *this);
+        }
+        return out;
+    }
+
+    void LangStore::merge_object_for_lang(
+            const nlohmann::json& obj,
+            const std::string& lang,
+            StrMap& out,
+            const LangStore& self
+        ) {
+        if (!obj.is_object()) return;
+
+        for (auto it = obj.begin(); it != obj.end(); ++it) {
+            const std::string& key_str = it.key();   // JSON provides std::string only once
+            KeyView k = self.intern_key(key_str);    // intern -> KeyView stays stable
+            const nlohmann::json& val = it.value();
+
+            auto get_sv = [&](const nlohmann::json& j) -> std::string {
+                if (j.is_string()) return j.get<std::string>();
+                if (j.is_array()) {
+                    std::string s;
+                    for (const auto& e : j) if (e.is_string()) s += e.get<std::string>();
+                    return s;
+                }
+                return {};
+            };
+
+            if (val.is_object()) {
+                if (auto jt = val.find(lang); jt != val.end()) {
+                    auto s = get_sv(*jt);
+                    if (!s.empty()) { out.emplace(k, std::move(s)); continue; }
+                }
+                if (auto jt = val.find(u8"en"); jt != val.end()) {
+                    auto s = get_sv(*jt);
+                    if (!s.empty()) { out.emplace(k, std::move(s)); continue; }
+                }
+            } else {
+                auto s = get_sv(val);
+                if (!s.empty()) { out.emplace(k, std::move(s)); }
+            }
+        }
+    }
+
+    std::string LangStore::get_string_or_join_array(const nlohmann::json& j) {
+        if (j.is_string()) return j.get<std::string>();
+        if (j.is_array()) {
+            std::string s;
+            for (const auto& e : j) {
+                if (e.is_string()) s += e.get<std::string>();
+            }
+            return s;
+        }
+        return {};
+    }
+
+    std::string LangStore::read_file(const std::string& path) {
+        std::ifstream ifs(path, std::ios::binary);
+        if (!ifs) return {};
+        std::ostringstream oss; oss << ifs.rdbuf();
+        return oss.str();
+    }
+
+    std::string LangStore::load_md_cached(const std::string& lang, std::string_view doc_key) const {
+        auto& by_key = m_md_cache[lang]; // creates empty sub-table on first access
+        if (auto it = by_key.find(doc_key); it != by_key.end())
+            return it->second;
+
+        const fs::path p = fs::path(m_base_dir) / lang / (std::string(doc_key) + u8".md");
+        auto s = read_file(p.string());
+        if (!s.empty()) {
+            by_key.emplace(intern_key(std::string(doc_key)), s);
+        }
+        return s;
+    }
+
+    std::string LangStore::default_plural_suffix(const std::string& lang, long long n) {
+        // Minimal fallback; PluralRules has richer built-ins.
+        if (lang == u8"ru") {
+            long long n10 = n % 10;
+            long long n100 = n % 100;
+            if (n10 == 1 && n100 != 11) return u8"one";
+            if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return u8"few";
+            if (n10 == 0 || (n10 >= 5 && n10 <= 9) || (n100 >= 11 && n100 <= 14)) return u8"many";
+            return u8"other";
+        }
+        return (n == 1) ? u8"one" : u8"other";
+    }
+
+    void LangStore::try_load_plural_rules_from_default_location() {
+        std::error_code ec;
+        const fs::path path = fs::u8path(m_base_dir) / IMGUIX_I18N_PLURALS_FILENAME;
+        if (fs::exists(path, ec) && m_plural_rules) {
+            (void)m_plural_rules->load_from_file(path.u8string()); // ignore failure
+        }
+    }
+
+} // namespace ImGuiX::I18N
+

--- a/include/imguix/core/i18n/PluralRules.hpp
+++ b/include/imguix/core/i18n/PluralRules.hpp
@@ -17,65 +17,14 @@ namespace ImGuiX::I18N {
         /// \brief Load rules from a JSON file.
         /// \param path Path to JSON file.
         /// \return True on success.
-        bool load_from_file(const std::string& path) {
-            std::error_code ec;
-            if (!fs::exists(path, ec)) return false;
-
-            const auto content = read_file(path);
-            if (content.empty()) return false;
-
-            nlohmann::json j;
-            try {
-                j = nlohmann::json::parse(content);
-            } catch (...) {
-                return false;
-            }
-
-            rules_.clear();
-            for (auto it = j.begin(); it != j.end(); ++it) {
-                const std::string lang = it.key();
-                const auto& node = it.value();
-                if (!node.contains(u8"cardinal") || !node[u8"cardinal"].is_array()) continue;
-                LangRules lr;
-                for (const auto& r : node[u8"cardinal"]) {
-                    if (!r.contains(u8"cat") || !r[u8"cat"].is_string()) continue;
-                    Rule rule;
-                    rule.category = r[u8"cat"].get<std::string>();
-                    rule.cond = r; // keep entire object; evaluator will inspect keys
-                    lr.rules.emplace_back(std::move(rule));
-                }
-                if (!lr.rules.empty()) {
-                    rules_.emplace(lang, std::move(lr));
-                }
-            }
-            return !rules_.empty();
-        }
+        bool load_from_file(const std::string& path);
 
         /// \brief Determine plural category for number in given language.
         /// \param lang Language code (e.g., "en").
         /// \param n Numeric value.
         /// \return Category string such as "one" or "other".
         /// \note Built-in fallback supports English (one/other) and Russian (one/few/many/other).
-        std::string category(const std::string& lang, long long n) const {
-            // Try loaded rules first
-            if (auto it = rules_.find(lang); it != rules_.end()) {
-                for (const auto& r : it->second.rules) {
-                    if (eval_rule(r.cond, n)) return r.category;
-                }
-            }
-
-            // Fallbacks
-            if (lang == u8"ru") {
-                long long n10 = n % 10;
-                long long n100 = n % 100;
-                if (n10 == 1 && n100 != 11) return u8"one";
-                if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return u8"few";
-                if (n10 == 0 || (n10 >= 5 && n10 <= 9) || (n100 >= 11 && n100 <= 14)) return u8"many";
-                return u8"other";
-            }
-            // default English-like
-            return (n == 1) ? u8"one" : u8"other";
-        }
+        std::string category(const std::string& lang, long long n) const;
 
     private:
         struct Rule {
@@ -87,85 +36,17 @@ namespace ImGuiX::I18N {
         };
         std::unordered_map<std::string, LangRules> rules_;
 
-        static std::string read_file(const std::string& path) {
-            std::ifstream ifs(path, std::ios::binary);
-            if (!ifs) return {};
-            std::ostringstream oss; oss << ifs.rdbuf();
-            return oss.str();
-        }
+        static std::string read_file(const std::string& path);
 
         // --- evaluator ---
 
-        static bool eval_rule(const nlohmann::json& r, long long n) {
-            // order of precedence: structural keys (all/any/not/true), then simple predicates in this node
-            if (r.contains(u8"true") && r[u8"true"].is_boolean() && r[u8"true"].get<bool>()) return true;
-
-            if (r.contains(u8"all") && r[u8"all"].is_array()) {
-                for (const auto& sub : r[u8"all"]) if (!eval_rule(sub, n)) return false;
-                return true;
-            }
-            if (r.contains(u8"any") && r[u8"any"].is_array()) {
-                for (const auto& sub : r[u8"any"]) if (eval_rule(sub, n)) return true;
-                return false;
-            }
-            if (r.contains(u8"not")) {
-                return !eval_rule(r[u8"not"], n);
-            }
-
-            // Simple numeric predicates at this node
-            if (r.contains(u8"eq")) {
-                const auto& v = r[u8"eq"];
-                if (v.is_number_integer()) return n == v.get<long long>();
-            }
-            if (r.contains(u8"in") && r[u8"in"].is_array()) {
-                for (const auto& x : r[u8"in"]) {
-                    if (x.is_number_integer() && n == x.get<long long>()) return true;
-                }
-                return false;
-            }
-            if (r.contains(u8"range") && r[u8"range"].is_array() && r[u8"range"].size() == 2) {
-                const auto a = r[u8"range"][0].get<long long>();
-                const auto b = r[u8"range"][1].get<long long>();
-                return (n >= a && n <= b);
-            }
-            if (r.contains(u8"mod_eq") && r[u8"mod_eq"].is_object()) {
-                const auto& me = r[u8"mod_eq"];
-                if (me.contains(u8"mod") && me.contains(u8"eq")) {
-                    const auto mod = me[u8"mod"].get<long long>();
-                    const auto eq  = me[u8"eq"].get<long long>();
-                    if (mod != 0) return (n % mod) == eq;
-                }
-            }
-            if (r.contains(u8"mod_in_list") && r[u8"mod_in_list"].is_object()) {
-                const auto& ml = r[u8"mod_in_list"];
-                if (ml.contains(u8"mod") && ml.contains(u8"list") && ml[u8"list"].is_array()) {
-                    const auto mod = ml[u8"mod"].get<long long>();
-                    if (mod == 0) return false;
-                    const long long v = n % mod;
-                    for (const auto& x : ml[u8"list"]) {
-                        if (x.is_number_integer() && v == x.get<long long>()) return true;
-                    }
-                    return false;
-                }
-            }
-            if (r.contains(u8"mod_in_range") && r[u8"mod_in_range"].is_object()) {
-                const auto& mr = r[u8"mod_in_range"];
-                if (mr.contains(u8"mod") && mr.contains(u8"range") &&
-                    mr[u8"range"].is_array() && mr[u8"range"].size() == 2) {
-                    const auto mod = mr[u8"mod"].get<long long>();
-                    if (mod == 0) return false;
-                    const long long v = n % mod;
-                    const auto a = mr[u8"range"][0].get<long long>();
-                    const auto b = mr[u8"range"][1].get<long long>();
-                    return (v >= a && v <= b);
-                }
-            }
-
-            // If no predicate matched in this node, consider it non-matching.
-            return false;
-        }
+        static bool eval_rule(const nlohmann::json& r, long long n);
     };
 
 } // namespace ImGuiX::I18N
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "PluralRules.ipp"
+#endif
 
 #endif // _IMGUIX_UTILS_I18N_PLURAL_RULES_HPP_INCLUDED

--- a/include/imguix/core/i18n/PluralRules.ipp
+++ b/include/imguix/core/i18n/PluralRules.ipp
@@ -1,0 +1,145 @@
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <unordered_map>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace ImGuiX::I18N {
+
+    bool PluralRules::load_from_file(const std::string& path) {
+        std::error_code ec;
+        if (!fs::exists(path, ec)) return false;
+
+        const auto content = read_file(path);
+        if (content.empty()) return false;
+
+        nlohmann::json j;
+        try {
+            j = nlohmann::json::parse(content);
+        } catch (...) {
+            return false;
+        }
+
+        rules_.clear();
+        for (auto it = j.begin(); it != j.end(); ++it) {
+            const std::string lang = it.key();
+            const auto& node = it.value();
+            if (!node.contains(u8"cardinal") || !node[u8"cardinal"].is_array()) continue;
+            LangRules lr;
+            for (const auto& r : node[u8"cardinal"]) {
+                if (!r.contains(u8"cat") || !r[u8"cat"].is_string()) continue;
+                Rule rule;
+                rule.category = r[u8"cat"].get<std::string>();
+                rule.cond = r; // keep entire object; evaluator will inspect keys
+                lr.rules.emplace_back(std::move(rule));
+            }
+            if (!lr.rules.empty()) {
+                rules_.emplace(lang, std::move(lr));
+            }
+        }
+        return !rules_.empty();
+    }
+
+    std::string PluralRules::category(const std::string& lang, long long n) const {
+        // Try loaded rules first
+        if (auto it = rules_.find(lang); it != rules_.end()) {
+            for (const auto& r : it->second.rules) {
+                if (eval_rule(r.cond, n)) return r.category;
+            }
+        }
+
+        // Fallbacks
+        if (lang == u8"ru") {
+            long long n10 = n % 10;
+            long long n100 = n % 100;
+            if (n10 == 1 && n100 != 11) return u8"one";
+            if (n10 >= 2 && n10 <= 4 && !(n100 >= 12 && n100 <= 14)) return u8"few";
+            if (n10 == 0 || (n10 >= 5 && n10 <= 9) || (n100 >= 11 && n100 <= 14)) return u8"many";
+            return u8"other";
+        }
+        // default English-like
+        return (n == 1) ? u8"one" : u8"other";
+    }
+
+    std::string PluralRules::read_file(const std::string& path) {
+        std::ifstream ifs(path, std::ios::binary);
+        if (!ifs) return {};
+        std::ostringstream oss; oss << ifs.rdbuf();
+        return oss.str();
+    }
+
+    bool PluralRules::eval_rule(const nlohmann::json& r, long long n) {
+        // order of precedence: structural keys (all/any/not/true), then simple predicates in this node
+        if (r.contains(u8"true") && r[u8"true"].is_boolean() && r[u8"true"].get<bool>()) return true;
+
+        if (r.contains(u8"all") && r[u8"all"].is_array()) {
+            for (const auto& sub : r[u8"all"]) if (!eval_rule(sub, n)) return false;
+            return true;
+        }
+        if (r.contains(u8"any") && r[u8"any"].is_array()) {
+            for (const auto& sub : r[u8"any"]) if (eval_rule(sub, n)) return true;
+            return false;
+        }
+        if (r.contains(u8"not")) {
+            return !eval_rule(r[u8"not"], n);
+        }
+
+        // Simple numeric predicates at this node
+        if (r.contains(u8"eq")) {
+            const auto& v = r[u8"eq"];
+            if (v.is_number_integer()) return n == v.get<long long>();
+        }
+        if (r.contains(u8"in") && r[u8"in"].is_array()) {
+            for (const auto& x : r[u8"in"]) {
+                if (x.is_number_integer() && n == x.get<long long>()) return true;
+            }
+            return false;
+        }
+        if (r.contains(u8"range") && r[u8"range"].is_array() && r[u8"range"].size() == 2) {
+            const auto a = r[u8"range"][0].get<long long>();
+            const auto b = r[u8"range"][1].get<long long>();
+            return (n >= a && n <= b);
+        }
+        if (r.contains(u8"mod_eq") && r[u8"mod_eq"].is_object()) {
+            const auto& me = r[u8"mod_eq"];
+            if (me.contains(u8"mod") && me.contains(u8"eq")) {
+                const auto mod = me[u8"mod"].get<long long>();
+                const auto eq  = me[u8"eq"].get<long long>();
+                if (mod != 0) return (n % mod) == eq;
+            }
+        }
+        if (r.contains(u8"mod_in_list") && r[u8"mod_in_list"].is_object()) {
+            const auto& ml = r[u8"mod_in_list"];
+            if (ml.contains(u8"mod") && ml.contains(u8"list") && ml[u8"list"].is_array()) {
+                const auto mod = ml[u8"mod"].get<long long>();
+                if (mod == 0) return false;
+                const long long v = n % mod;
+                for (const auto& x : ml[u8"list"]) {
+                    if (x.is_number_integer() && v == x.get<long long>()) return true;
+                }
+                return false;
+            }
+        }
+        if (r.contains(u8"mod_in_range") && r[u8"mod_in_range"].is_object()) {
+            const auto& mr = r[u8"mod_in_range"];
+            if (mr.contains(u8"mod") && mr.contains(u8"range") &&
+                mr[u8"range"].is_array() && mr[u8"range"].size() == 2) {
+                const auto mod = mr[u8"mod"].get<long long>();
+                if (mod == 0) return false;
+                const long long v = n % mod;
+                const auto a = mr[u8"range"][0].get<long long>();
+                const auto b = mr[u8"range"][1].get<long long>();
+                return (v >= a && v <= b);
+            }
+        }
+
+        // If no predicate matched in this node, consider it non-matching.
+        return false;
+    }
+
+} // namespace ImGuiX::I18N
+


### PR DESCRIPTION
## Summary
- move LangStore non-template definitions to LangStore.ipp and include conditionally for header-only builds
- move PluralRules logic to PluralRules.ipp and add header-only include hook

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca522549c832c82d32d96f551aa08