### PR TITLE
docs: translate agent guide and sync Russian manuals

### DIFF
--- a/docs/FONTS-GUIDE.md
+++ b/docs/FONTS-GUIDE.md
@@ -145,7 +145,7 @@ ImGui::TextUnformatted(u8"\uE8F4"); // Material icon 'visibility' for example
 ```cpp
 ImFont* f = ImGui::GetFont();
 bool has_text  = f->FindGlyphNoFallback((ImWchar)'A');
-bool has_cyr   = f->FindGlyphNoFallback((ImWchar)0x0410); // 'А'
+bool has_cyr   = f->FindGlyphNoFallback((ImWchar)0x0410); // Cyrillic 'A'
 bool has_icon  = f->FindGlyphNoFallback((ImWchar)0xE8F4); // Material icon
 ```
 


### PR DESCRIPTION
## Summary
- translate combo sizing guidance and anti-patterns to English in AGENTS.md
- update Russian README and fonts guide with PUA ranges and troubleshooting
- clarify glyph check comment in English fonts guide

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=OFF` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3f5845f8832c897c84809df1b4bc