### PR TITLE
Centralize widget visuals via config macros

### DIFF
--- a/docs/STYLE-GUIDE-RU.md
+++ b/docs/STYLE-GUIDE-RU.md
@@ -75,6 +75,9 @@
   constexpr float kAnimationSpeed = 0.15f;
   #define IMGUIX_API_VERSION "1.0"
   ```
+- **UI-макросы**: общие иконки и цвета виджетов определены в
+  `include/imguix/config/icons.hpp` и `include/imguix/config/colors.hpp`.
+  Используйте их вместо "жёстко" прописанных литералов.
 
 ### События (EventBus)
 - **Стиль**: PascalCase с суффиксом `Event`

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -75,6 +75,9 @@
   constexpr float kAnimationSpeed = 0.15f;
   #define IMGUIX_API_VERSION "1.0"
   ```
+- **UI macros**: shared widget icons and colors are defined in
+  `include/imguix/config/icons.hpp` and `include/imguix/config/colors.hpp`.
+  Prefer these macros over hard-coded literals.
 
 ### Events (EventBus)
 - **Style**: PascalCase with the `Event` suffix

--- a/include/imguix/config.hpp
+++ b/include/imguix/config.hpp
@@ -8,5 +8,8 @@
 #include "config/paths.hpp"
 #include "config/fonts.hpp"
 #include "config/i18n.hpp"
+#include "config/icons.hpp"
+#include "config/colors.hpp"
+#include "config/sizing.hpp"
 
 #endif // _IMGUIX_CONFIG_HPP_INCLUDED

--- a/include/imguix/config/colors.hpp
+++ b/include/imguix/config/colors.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#ifndef _IMGUIX_CONFIG_COLORS_HPP_INCLUDED
+#define _IMGUIX_CONFIG_COLORS_HPP_INCLUDED
+
+/// \file colors.hpp
+/// \brief Default color constants for ImGuiX widgets.
+
+#include <imgui.h>
+
+/// \brief RGBA color applied to invalid inputs.
+#define IMGUIX_COLOR_ERROR ImVec4(0.9f, 0.5f, 0.5f, 1.0f)
+
+/// \brief RGBA color for warning markers.
+#define IMGUIX_COLOR_WARNING ImVec4(1.0f, 1.0f, 0.0f, 1.0f)
+
+/// \brief RGBA color for informational markers.
+#define IMGUIX_COLOR_INFO ImVec4(0.10f, 0.45f, 0.95f, 1.0f)
+
+/// \brief RGBA color for success markers.
+#define IMGUIX_COLOR_SUCCESS ImVec4(0.0f, 0.60f, 0.0f, 1.0f)
+
+#endif // _IMGUIX_CONFIG_COLORS_HPP_INCLUDED

--- a/include/imguix/config/icons.hpp
+++ b/include/imguix/config/icons.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#ifndef _IMGUIX_CONFIG_ICONS_HPP_INCLUDED
+#define _IMGUIX_CONFIG_ICONS_HPP_INCLUDED
+
+/// \file icons.hpp
+/// \brief Default UTF-8 icon literals for ImGuiX widgets.
+
+/// \brief Keyboard toggle button icon (Material: keyboard).
+#define IMGUIX_ICON_KEYBOARD u8"\uE312"
+
+/// \brief Help marker icon.
+#define IMGUIX_ICON_HELP u8"\uE887"
+
+/// \brief Warning marker icon.
+#define IMGUIX_ICON_WARNING u8"\uE002"
+
+/// \brief Information marker icon.
+#define IMGUIX_ICON_INFO u8"\uE88E"
+
+/// \brief Success marker icon.
+#define IMGUIX_ICON_SUCCESS u8"\uE88E"
+
+/// \brief ListEditor "add" icon.
+#define IMGUIX_ICON_ADD u8"\uE148"
+
+/// \brief ListEditor "remove" icon.
+#define IMGUIX_ICON_REMOVE u8"\uE15D"
+
+/// \brief Password toggle "show" icon.
+#define IMGUIX_ICON_EYE_SHOW u8"\uE8F4"
+
+/// \brief Password toggle "hide" icon.
+#define IMGUIX_ICON_EYE_HIDE u8"\uE8F5"
+
+/// \brief Clipboard copy icon.
+#define IMGUIX_ICON_COPY u8"\uE14D"
+
+/// \brief Clipboard paste icon.
+#define IMGUIX_ICON_PASTE u8"\uE2C8"
+
+#endif // _IMGUIX_CONFIG_ICONS_HPP_INCLUDED

--- a/include/imguix/config/sizing.hpp
+++ b/include/imguix/config/sizing.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#ifndef _IMGUIX_CONFIG_SIZING_HPP_INCLUDED
+#define _IMGUIX_CONFIG_SIZING_HPP_INCLUDED
+
+/// \file sizing.hpp
+/// \brief Sample strings for sizing calculations.
+
+/// \brief Sample time with sign used for combo width estimates.
+#define IMGUIX_SIZING_TIME_SIGNED "+23:59:59"
+
+/// \brief Sample time without sign used for combo width estimates.
+#define IMGUIX_SIZING_TIME_UNSIGNED "23:59:59"
+
+/// \brief Sample hours/minutes/seconds field used for width estimates.
+#define IMGUIX_SIZING_HMS "+88"
+
+/// \brief Sample date string used for combo width estimates.
+#define IMGUIX_SIZING_DATE "Mon +8888-88-88"
+
+/// \brief Sample signed year used for width estimates.
+#define IMGUIX_SIZING_YEAR_SIGNED "+8888"
+
+/// \brief Sample unsigned year used for width estimates.
+#define IMGUIX_SIZING_YEAR_UNSIGNED "8888"
+
+/// \brief Sample weekday list used for combo width estimates.
+#define IMGUIX_SIZING_WEEKDAYS "Mon, Tue, Wed, Thu, Fri, Sat, Sun"
+
+#endif // _IMGUIX_CONFIG_SIZING_HPP_INCLUDED

--- a/include/imguix/extensions/sizing.hpp
+++ b/include/imguix/extensions/sizing.hpp
@@ -6,6 +6,7 @@
 /// \brief Helpers to compute widths for Combo preview, fields, and time widgets.
 
 #include <imgui.h>
+#include <imguix/config/sizing.hpp>
 
 namespace ImGuiX::Extensions {
 
@@ -72,13 +73,13 @@ namespace ImGuiX::Extensions {
             bool signed_preview = true,
             ImGuiComboFlags flags = 0
         ) {
-        return CalcComboWidthForPreview(signed_preview ? "+23:59:59" : "23:59:59",
+        return CalcComboWidthForPreview(signed_preview ? IMGUIX_SIZING_TIME_SIGNED : IMGUIX_SIZING_TIME_UNSIGNED,
                                         flags, ImGui::GetStyle().ItemSpacing.x * 0.5f);
     }
 
     /// \brief Recommended field width for HH/MM/SS steppers (fits "+88").
     inline float CalcHMSFieldWidth() {
-        return CalcFieldWidthForSample("+88", ImGui::GetStyle().ItemSpacing.x * 0.25f);
+        return CalcFieldWidthForSample(IMGUIX_SIZING_HMS, ImGui::GetStyle().ItemSpacing.x * 0.25f);
     }
 
     /// \brief Recommended combo width for date preview like "Mon +8888-88-88".
@@ -86,23 +87,23 @@ namespace ImGuiX::Extensions {
     inline float CalcDateComboWidth(
             ImGuiComboFlags flags = 0
         ) {
-		return CalcComboWidthForPreview(
-			"Mon +8888-88-88", flags, ImGui::GetStyle().ItemSpacing.x * 0.5f
-		);
+                return CalcComboWidthForPreview(
+                        IMGUIX_SIZING_DATE, flags, ImGui::GetStyle().ItemSpacing.x * 0.5f
+                );
 	}
 
     /// \brief Recommended field width for a year edit (fits "+8888" or "8888").
     /// \param signed_year If true, reserves '+' for signed years (смещения/офсеты).
     inline float CalcYearFieldWidth(bool signed_year = true) {
         return CalcFieldWidthForSample(
-			signed_year ? "+8888" : "8888",
-			ImGui::GetStyle().ItemSpacing.x * 0.25f
-		);
+                        signed_year ? IMGUIX_SIZING_YEAR_SIGNED : IMGUIX_SIZING_YEAR_UNSIGNED,
+                        ImGui::GetStyle().ItemSpacing.x * 0.25f
+                );
     }
 	
 	inline float CalcWeekdayComboWidth(ImGuiComboFlags flags = 0) {
-		return CalcComboWidthForPreview("Mon, Tue, Wed, Thu, Fri, Sat, Sun",
-										flags, ImGui::GetStyle().ItemSpacing.x * 0.5f);
+                return CalcComboWidthForPreview(IMGUIX_SIZING_WEEKDAYS,
+                                                                                flags, ImGui::GetStyle().ItemSpacing.x * 0.5f);
 	}
 
 } // namespace ImGuiX::Extensions

--- a/include/imguix/widgets/auth/auth_js_panel.hpp
+++ b/include/imguix/widgets/auth/auth_js_panel.hpp
@@ -7,6 +7,7 @@
 /// Uses InputTextWithVKValidated (validation + on-screen keyboard trigger).
 
 #include <imguix/widgets/input/validated_input.hpp> // InputTextWithVKValidated, KeyboardToggleConfig, InputValidatePolicy
+#include <imguix/config/colors.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -34,7 +35,7 @@ namespace ImGuiX::Widgets {
         bool        validate_user_agent      = true;
         bool        validate_accept_language = true;
         ImGuiX::Widgets::InputValidatePolicy policy = ImGuiX::Widgets::InputValidatePolicy::OnTouch;
-        ImVec4      error_color           = ImVec4(0.9f, 0.5f, 0.5f, 1.0f);
+        ImVec4      error_color           = IMGUIX_COLOR_ERROR;
 
         // Pragmatic regexes (ECMAScript for std::regex)
         // UA: printable ASCII (space through ~), at least 1 char

--- a/include/imguix/widgets/auth/auth_panel.hpp
+++ b/include/imguix/widgets/auth/auth_panel.hpp
@@ -12,8 +12,10 @@
 #include <cstring>
 #include <algorithm>
 #include <type_traits>
+
 #include <imguix/config/fonts.hpp>
 #include <imguix/widgets/input/validated_password_input.hpp>
+#include <imguix/config/colors.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -122,7 +124,7 @@ namespace ImGuiX::Widgets {
         const char* api_key_regex    = u8R"(^(?:[A-Za-z0-9._\-]{16,256})$)"; ///< 
         const char* api_secret_regex = u8R"(^(?:[A-Za-z0-9._\-]{16,256})$)"; ///< 
 
-        ImVec4      error_color      = ImVec4(0.9f, 0.5f, 0.5f, 1.0f);
+        ImVec4      error_color      = IMGUIX_COLOR_ERROR;
     };
     
     /// \brief All auth-related fields passed in/out by reference.

--- a/include/imguix/widgets/auth/domain_selector.hpp
+++ b/include/imguix/widgets/auth/domain_selector.hpp
@@ -6,6 +6,7 @@
 /// \brief Domain chooser widget (combo with "Custom" fallback or validated input with VK).
 
 #include <imguix/widgets/input/validated_input.hpp> // InputTextWithVKValidated, KeyboardToggleConfig, InputValidatePolicy
+#include <imguix/config/colors.hpp>
 #include <imguix/widgets/misc/markers.hpp> // HelpMarker
 
 namespace ImGuiX::Widgets {
@@ -30,7 +31,7 @@ namespace ImGuiX::Widgets {
         // Validation (ECMAScript regex for std::regex)
         bool        validate_domain = true;
         ImGuiX::Widgets::InputValidatePolicy policy = ImGuiX::Widgets::InputValidatePolicy::OnTouch;
-        ImVec4      error_color = ImVec4(0.9f, 0.5f, 0.5f, 1.0f);
+        ImVec4      error_color = IMGUIX_COLOR_ERROR;
 
         // Pragmatic host/domain pattern (allows subdomains and optional :port)
         const char* domain_regex = u8R"(^[A-Za-z0-9.\-:]+$)";

--- a/include/imguix/widgets/auth/proxy_panel.hpp
+++ b/include/imguix/widgets/auth/proxy_panel.hpp
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <cstring>
 
+#include <imguix/config/colors.hpp>
+
 namespace ImGuiX::Widgets {
 
     /// \brief Proxy type.
@@ -86,7 +88,7 @@ namespace ImGuiX::Widgets {
         float field_width_type        = 0.0f;
 
         // Style
-        ImVec4 error_color = ImVec4(0.9f, 0.5f, 0.5f, 1.0f);
+        ImVec4 error_color = IMGUIX_COLOR_ERROR;
     };
 
     /// \brief Draw proxy settings panel.

--- a/include/imguix/widgets/input/list_editor.hpp
+++ b/include/imguix/widgets/input/list_editor.hpp
@@ -14,6 +14,8 @@
 #include <cstring>
 #include <algorithm>
 
+#include <imguix/config/icons.hpp>
+
 namespace ImGuiX::Widgets {
 
     /// \brief Config for ListEditor.
@@ -23,8 +25,8 @@ namespace ImGuiX::Widgets {
         const char* empty_desc  = u8"(empty)";            ///< Preview when list is empty.
 
         // Default to Material Icons PUA. Make sure the font is loaded with PUA ranges.
-        const char* icon_add    = u8"\uE148";             ///< 'add'
-        const char* icon_remove = u8"\uE15D";             ///< 'remove_circle'
+        const char* icon_add    = IMGUIX_ICON_ADD;        ///< 'add'
+        const char* icon_remove = IMGUIX_ICON_REMOVE;     ///< 'remove_circle'
 
         bool       delete_on_right = true;                ///< Remove button placed at right side.
         bool       deduplicate     = false;               ///< Keep unique values on add.

--- a/include/imguix/widgets/input/validated_input.hpp
+++ b/include/imguix/widgets/input/validated_input.hpp
@@ -6,7 +6,10 @@
 /// \brief InputTextWithHint for std::string with regex validation and error tinting.
 
 #include <imgui_stdlib.h>
+
 #include <imguix/extensions/validation.hpp>
+#include <imguix/config/icons.hpp>
+#include <imguix/config/colors.hpp>
 #include "virtual_keyboard_overlay.hpp"
 
 namespace ImGuiX::Widgets {
@@ -22,7 +25,7 @@ namespace ImGuiX::Widgets {
     /// \brief Visual config for the VK trigger button (reusable across inputs).
     struct KeyboardToggleConfig {
         bool        use_icon           = true;                  ///< icon or text
-        const char* icon_text          = u8"\uE312";            ///< PUA 'keyboard' (e.g. Material)
+        const char* icon_text          = IMGUIX_ICON_KEYBOARD;  ///< PUA 'keyboard' (e.g. Material)
         const char* text               = u8"[KB]";              ///< text if use_icon==false
         ImFont*     icon_font          = nullptr;               ///< icon font (nullptr => current)
         ImVec2      button_size        = ImVec2(0,0);           ///< (0,0) => square by frame height
@@ -55,7 +58,7 @@ namespace ImGuiX::Widgets {
             InputValidatePolicy policy,
             const std::string& pattern,
             bool& out_valid,
-            ImVec4 error_color = ImVec4(0.9f,0.5f,0.5f,1.0f),
+            ImVec4 error_color = IMGUIX_COLOR_ERROR,
             ImGuiInputTextFlags flags = 0,
             ImGuiInputTextCallback callback = nullptr,
             void* user_data = nullptr
@@ -179,7 +182,7 @@ namespace ImGuiX::Widgets {
             ImGuiX::Widgets::InputValidatePolicy policy,
             const std::string& pattern,
             bool& out_valid,
-            ImVec4 error_color = ImVec4(0.9f,0.5f,0.5f,1.0f),
+            ImVec4 error_color = IMGUIX_COLOR_ERROR,
             ImGuiInputTextFlags extra_flags = 0,
             ImGuiInputTextCallback callback = nullptr,
             void* user_data = nullptr,

--- a/include/imguix/widgets/input/validated_password_input.hpp
+++ b/include/imguix/widgets/input/validated_password_input.hpp
@@ -7,9 +7,12 @@
 
 #include <imgui.h>
 #include <string>
+#include <algorithm>
+
+#include <imguix/config/icons.hpp>
+#include <imguix/config/colors.hpp>
 #include "validated_input.hpp" // InputTextValidated, InputValidatePolicy, KeyboardToggleConf
 #include <imguix/widgets/controls/icon_button.hpp>     // IconButtonCentered
-#include <algorithm>
 
 namespace ImGuiX::Widgets {
 
@@ -20,8 +23,8 @@ namespace ImGuiX::Widgets {
     /// Rounding is applied through style var override if \ref icon_rounding >= 0.
     struct PasswordToggleConfig {
         bool        use_icon      = true;        ///< true: icon button; false: checkbox + optional text label.
-        const char* icon_show     = u8"\ue8f4";  ///< Glyph for "show" (depends on your icon font).
-        const char* icon_hide     = u8"\ue8f5";  ///< Glyph for "hide".
+        const char* icon_show     = IMGUIX_ICON_EYE_SHOW;  ///< Glyph for "show" (depends on your icon font).
+        const char* icon_hide     = IMGUIX_ICON_EYE_HIDE;  ///< Glyph for "hide".
         ImVec2      button_size   = ImVec2(0,0); ///< (0,0) => square by current frame height.
         float       same_line_w   = 0.0f;        ///< SameLine(offset) before the eye button; 0 => default spacing.
         const char* tooltip_show  = u8"Show password"; ///< Tooltip when currently hidden.
@@ -59,7 +62,7 @@ namespace ImGuiX::Widgets {
             const std::string& pattern,
             bool& out_valid,
             const PasswordToggleConfig& toggle_cfg,
-            ImVec4 error_color = ImVec4(0.9f,0.5f,0.5f,1.0f),
+            ImVec4 error_color = IMGUIX_COLOR_ERROR,
             ImGuiInputTextFlags extra_flags = 0
         ) {
         ImGui::PushID(label);
@@ -208,7 +211,7 @@ namespace ImGuiX::Widgets {
             const PasswordToggleConfig& toggle_cfg,
             const KeyboardToggleConfig& kb_cfg = {},
             VirtualKeyboardConfig vk_cfg = {},
-            ImVec4 error_color = ImVec4(0.9f,0.5f,0.5f,1.0f),
+            ImVec4 error_color = IMGUIX_COLOR_ERROR,
             ImGuiInputTextFlags extra_flags = 0
         ) {
         ImGui::PushID(label);

--- a/include/imguix/widgets/input/virtual_keyboard.hpp
+++ b/include/imguix/widgets/input/virtual_keyboard.hpp
@@ -18,7 +18,9 @@
 #include <cstring>
 #include <algorithm>
 #include <regex>
+
 #include <imguix/widgets/controls/icon_button.hpp>
+#include <imguix/config/icons.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -67,8 +69,8 @@ namespace ImGuiX::Widgets {
             {u8"Enter",   u8"Enter"},
             {u8"Symbols", u8"Symbols"},
             {u8"Accents", u8"Accents"},
-            {u8"Copy",    u8"\uE14D"},
-            {u8"Paste",   u8"\uE14F"}
+            {u8"Copy",    IMGUIX_ICON_COPY},
+            {u8"Paste",   IMGUIX_ICON_PASTE}
         };
         
         std::unordered_map<std::string, const char*> tooltips{
@@ -648,8 +650,8 @@ namespace ImGuiX::Widgets {
         ImVec2 wide_size (wide_w,                        key_size.y);
         ImVec2 space_size(wide_w * cfg.space_width_multiplier, key_size.y);
 
-        const char* ICON_COPY  = u8"\uE14D"; // content_copy
-        const char* ICON_PASTE = u8"\uE2C8"; // content_paste
+        const char* ICON_COPY  = IMGUIX_ICON_COPY;   // content_copy
+        const char* ICON_PASTE = IMGUIX_ICON_PASTE;  // content_paste
         ImVec2 clip_size(frame_h, frame_h);
 
         const float btn_h    = cfg.show_bottom ? key_size.y : 0.0f;

--- a/include/imguix/widgets/misc/markers.hpp
+++ b/include/imguix/widgets/misc/markers.hpp
@@ -9,6 +9,9 @@
 #include <string>
 #include <cstddef>
 
+#include <imguix/config/icons.hpp>
+#include <imguix/config/colors.hpp>
+
 namespace ImGuiX::Widgets {
     
     enum class MarkerMode : int {
@@ -73,7 +76,7 @@ namespace ImGuiX::Widgets {
     inline void HelpMarker(
             const char* desc, 
             MarkerMode mode = MarkerMode::TooltipOnly, 
-            const char* icon_utf8 = u8"\uE887"
+            const char* icon_utf8 = IMGUIX_ICON_HELP
         ) {
         ImGui::TextDisabled(icon_utf8);
         if (mode == MarkerMode::InlineText) {
@@ -89,8 +92,8 @@ namespace ImGuiX::Widgets {
     inline void WarningMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly, 
-            const ImVec4& color = ImVec4(1.0f, 1.0f, 0.0f, 1.0f),
-            const char* icon_utf8 = u8"\uE002"
+            const ImVec4& color = IMGUIX_COLOR_WARNING,
+            const char* icon_utf8 = IMGUIX_ICON_WARNING
         ) {
         IconMarker(icon_utf8, color, desc, mode);
     }
@@ -100,8 +103,8 @@ namespace ImGuiX::Widgets {
     inline void InfoMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,
-            const ImVec4& color = ImVec4(0.10f, 0.45f, 0.95f, 1.0f),
-            const char* icon_utf8 = u8"\uE88E"
+            const ImVec4& color = IMGUIX_COLOR_INFO,
+            const char* icon_utf8 = IMGUIX_ICON_INFO
         ) {
         IconMarker(icon_utf8, color, desc, mode);
     }
@@ -111,8 +114,8 @@ namespace ImGuiX::Widgets {
     inline void SuccessMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,
-            const ImVec4& color = ImVec4(0.0f, 0.60f, 0.0f, 1.0f),
-            const char* icon_utf8 = u8"\uE88E"
+            const ImVec4& color = IMGUIX_COLOR_SUCCESS,
+            const char* icon_utf8 = IMGUIX_ICON_SUCCESS
         ) {
         IconMarker(icon_utf8, color, desc, mode);
     }


### PR DESCRIPTION
## Summary
- add configurable icon, color and sizing macros
- refactor widgets to use shared UI constants
- document macros in style guides

## Testing
- `cmake ..` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3e548518832caade43d89319dcf8