### PR TITLE
refactor(config): centralize default file paths

### DIFF
--- a/include/imguix/config/fonts.hpp
+++ b/include/imguix/config/fonts.hpp
@@ -10,4 +10,16 @@
 #   define IMGUIX_FONTS_CONFIG u8"data/resources/fonts/fonts.json"
 #endif
 
+#ifndef IMGUIX_FONTS_CONFIG_BASENAME
+#   define IMGUIX_FONTS_CONFIG_BASENAME u8"fonts.json"
+#endif
+
+#ifndef IMGUIX_FONTS_FALLBACK_BODY_BASENAME
+#   define IMGUIX_FONTS_FALLBACK_BODY_BASENAME u8"Roboto-Medium.ttf"
+#endif
+
+#ifndef IMGUIX_FONTS_FALLBACK_ICONS_BASENAME
+#   define IMGUIX_FONTS_FALLBACK_ICONS_BASENAME u8"forkawesome-webfont.ttf"
+#endif
+
 #endif // _IMGUIX_CONFIG_FONTS_HPP_INCLUDED

--- a/include/imguix/config/paths.hpp
+++ b/include/imguix/config/paths.hpp
@@ -6,4 +6,8 @@
 #   define IMGUIX_CONFIG_DIR u8"data/config"
 #endif
 
+#ifndef IMGUIX_OPTIONS_FILENAME
+#   define IMGUIX_OPTIONS_FILENAME u8"options.json"
+#endif
+
 #endif // _IMGUIX_CONFIG_PATHS_HPP_INCLUDED

--- a/include/imguix/core/fonts/FontManager.ipp
+++ b/include/imguix/core/fonts/FontManager.ipp
@@ -563,12 +563,12 @@ namespace ImGuiX::Fonts {
         // If still no Body, try a minimal fallback (Roboto + Icons) using base_dir
         if (!body) {
           FontFile fb{};
-          fb.path = u8"Roboto-Medium.ttf";
+          fb.path = IMGUIX_FONTS_FALLBACK_BODY_BASENAME;
           fb.size_px = m_px_body;
           body = add_single(FontRole::Body, fb);
 
           FontFile ic{};
-          ic.path = u8"forkawesome-webfont.ttf";
+          ic.path = IMGUIX_FONTS_FALLBACK_ICONS_BASENAME;
           ic.size_px = m_px_body;
           ic.merge = true;
           addFontFile(ic, m_params, ranges, base_dir_abs, cfg);
@@ -681,7 +681,7 @@ namespace ImGuiX::Fonts {
         // Fallback: if empty or not found, try base_dir/fonts.json
         if (readTextFile(cfg_path).empty()) {
             const auto base_abs = ImGuiX::Utils::resolveExecPath(m_params.base_dir);
-            cfg_path = ImGuiX::Utils::joinPaths(base_abs, u8"fonts.json");
+            cfg_path = ImGuiX::Utils::joinPaths(base_abs, IMGUIX_FONTS_CONFIG_BASENAME);
         }
 #       endif
 

--- a/include/imguix/core/options/OptionsStore.ipp
+++ b/include/imguix/core/options/OptionsStore.ipp
@@ -166,7 +166,7 @@ namespace ImGuiX {
         : m_impl(std::make_unique<Impl>()) {
         const std::string base_dir(IMGUIX_CONFIG_DIR);
         const auto base_abs = ImGuiX::Utils::resolveExecPath(base_dir);
-        std::string path = ImGuiX::Utils::joinPaths(base_abs, u8"options.json");
+        std::string path = ImGuiX::Utils::joinPaths(base_abs, IMGUIX_OPTIONS_FILENAME);
         m_impl->m_path = std::move(path);
         m_impl->m_tmp_path = m_impl->m_path + u8".tmp";
         m_impl->m_save_delay = 0.5;


### PR DESCRIPTION
## Summary
- use IMGUIX_OPTIONS_FILENAME to resolve options store location
- add macros for fallback fonts and config file names
- switch font manager to the new macros

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: Could not find UDev library)*
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: Could NOT find OpenGL)*
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: Could not find UDev library)*
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON` *(fails: Could NOT find OpenGL)*


------
https://chatgpt.com/codex/tasks/task_e_68ae49a52e4c832cb3fffd6d7ef86794