### PR TITLE
refactor: split misc widget implementations into ipp

### DIFF
--- a/include/imguix/widgets/misc/loading_spinner.hpp
+++ b/include/imguix/widgets/misc/loading_spinner.hpp
@@ -8,8 +8,6 @@
 /// Original idea: https://github.com/ocornut/imgui/issues/1901 (adapted).
 
 #include <imgui.h>
-#include <algorithm>
-#include <cmath>
 
 namespace ImGuiX::Widgets {
 
@@ -28,38 +26,7 @@ namespace ImGuiX::Widgets {
     /// \param id Unique widget identifier.
     /// \param cfg Spinner parameters.
     /// \return True if the item was submitted (not clipped).
-    inline bool LoadingSpinner(const char* id, const LoadingSpinnerConfig& cfg = {}) {
-        // Validate / clamp
-        const float radius    = std::max(0.0f, cfg.radius);
-        const float thickness = std::max(1.0f, cfg.thickness);
-        const int   segments  = std::max(8, cfg.segments);
-        const float sweep_rad = std::clamp(cfg.sweep_ratio, 0.05f, 1.0f) * 6.28318530717958647692f; // TAU
-        const float phase     = static_cast<float>(ImGui::GetTime()) * std::max(0.0f, cfg.angular_speed);
-
-        // Reserve item rect using public API
-        // Make item square (2R x 2R) + optional extra top padding (keeps spacing similar to old code)
-        const ImVec2 item_size(2.0f * radius, 2.0f * radius + cfg.extra_top_padding);
-        if (!ImGui::InvisibleButton(id, item_size))
-        {
-            // Even if not clicked/hovered, the item exists and we can draw (unless clipped).
-            // If it was clipped, drawing won't be visible anyway. Continue to draw for consistency.
-        }
-
-        // Compute geometry from item rect
-        const ImVec2 pos_min = ImGui::GetItemRectMin();
-        const ImVec2 center(pos_min.x + radius, pos_min.y + cfg.extra_top_padding * 0.5f + radius);
-
-        ImDrawList* dl = ImGui::GetWindowDrawList();
-        ImU32 col = cfg.color ? cfg.color : ImGui::GetColorU32(ImGuiCol_Text);
-
-        const float a_min = phase;
-        const float a_max = phase + sweep_rad;
-
-        dl->PathClear();
-        dl->PathArcTo(center, radius, a_min, a_max, segments);
-        dl->PathStroke(col, 0 /*flags*/, thickness);
-        return true;
-    }
+    bool LoadingSpinner(const char* id, const LoadingSpinnerConfig& cfg = {});
 
     /// \brief Convenience overload with basic parameters.
     /// \param id Unique widget identifier.
@@ -76,5 +43,8 @@ namespace ImGuiX::Widgets {
     }
 
 } // namespace ImGuiX::Widgets
+#ifdef IMGUIX_HEADER_ONLY
+#   include "loading_spinner.ipp"
+#endif
 
 #endif // _IMGUIX_WIDGETS_LOADING_SPINNER_HPP_INCLUDED

--- a/include/imguix/widgets/misc/loading_spinner.ipp
+++ b/include/imguix/widgets/misc/loading_spinner.ipp
@@ -1,0 +1,38 @@
+#include <algorithm>
+#include <cmath>
+
+namespace ImGuiX::Widgets {
+
+bool LoadingSpinner(const char* id, const LoadingSpinnerConfig& cfg) {
+    // Validate / clamp
+    const float radius    = std::max(0.0f, cfg.radius);
+    const float thickness = std::max(1.0f, cfg.thickness);
+    const int   segments  = std::max(8, cfg.segments);
+    const float sweep_rad = std::clamp(cfg.sweep_ratio, 0.05f, 1.0f) * 6.28318530717958647692f; // TAU
+    const float phase     = static_cast<float>(ImGui::GetTime()) * std::max(0.0f, cfg.angular_speed);
+
+    // Reserve item rect using public API
+    // Make item square (2R x 2R) + optional extra top padding (keeps spacing similar to old code)
+    const ImVec2 item_size(2.0f * radius, 2.0f * radius + cfg.extra_top_padding);
+    if (!ImGui::InvisibleButton(id, item_size)) {
+        // Even if not clicked/hovered, the item exists and we can draw (unless clipped).
+        // If it was clipped, drawing won't be visible anyway. Continue to draw for consistency.
+    }
+
+    // Compute geometry from item rect
+    const ImVec2 pos_min = ImGui::GetItemRectMin();
+    const ImVec2 center(pos_min.x + radius, pos_min.y + cfg.extra_top_padding * 0.5f + radius);
+
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+    ImU32 col = cfg.color ? cfg.color : ImGui::GetColorU32(ImGuiCol_Text);
+
+    const float a_min = phase;
+    const float a_max = phase + sweep_rad;
+
+    dl->PathClear();
+    dl->PathArcTo(center, radius, a_min, a_max, segments);
+    dl->PathStroke(col, 0 /*flags*/, thickness);
+    return true;
+}
+
+} // namespace ImGuiX::Widgets

--- a/include/imguix/widgets/misc/markers.hpp
+++ b/include/imguix/widgets/misc/markers.hpp
@@ -7,7 +7,6 @@
 
 #include <imgui.h>
 #include <string>
-#include <cstddef>
 
 #include <imguix/config/icons.hpp>
 #include <imguix/config/colors.hpp>
@@ -19,107 +18,69 @@ namespace ImGuiX::Widgets {
         InlineText  = 1   ///< icon/label + inline wrapped text
     };
 
-    inline void TooltipWrapped(const char* desc, float wrap_cols = 35.0f) {
-        ImGui::BeginTooltip();
-        ImGui::PushTextWrapPos(ImGui::GetFontSize() * wrap_cols);
-        ImGui::TextUnformatted(desc);
-        ImGui::PopTextWrapPos();
-        ImGui::EndTooltip();
-    }
+    void TooltipWrapped(const char* desc, float wrap_cols = 35.0f);
     
-    inline void IconMarker(
-            const char* icon_utf8, 
+    void IconMarker(
+            const char* icon_utf8,
             const ImVec4& color,
-            const char* desc, 
-            MarkerMode mode, 
+            const char* desc,
+            MarkerMode mode,
             float wrap_cols = 35.0f
-        ) {
-        ImGui::PushStyleColor(ImGuiCol_Text, color);
-        ImGui::TextUnformatted(icon_utf8);
-        ImGui::PopStyleColor();
-
-        if (mode == MarkerMode::InlineText) {
-            ImGui::SameLine();
-            ImGui::TextWrapped("%s", desc);
-        } else 
-        if (ImGui::IsItemHovered()) {
-            TooltipWrapped(desc, wrap_cols);
-        }
-    }
+        );
 
     /// \brief Draw label in custom color with tooltip.
     /// \param label Text displayed on screen.
     /// \param desc Tooltip text shown when hovered.
     /// \param color Text color.
-    inline void ColoredMarker(
-            const char* label, 
-            const char* desc, 
+    void ColoredMarker(
+            const char* label,
+            const char* desc,
             const ImVec4& color
-        ) {
-        ImGui::PushStyleColor(ImGuiCol_Text, color);
-        ImGui::TextUnformatted(label);
-        ImGui::PopStyleColor();
-        if (ImGui::IsItemHovered()) TooltipWrapped(desc);
-    }
+        );
 
     /// \brief Selectable label with tooltip echoing its text.
     /// \param text Text shown and displayed in tooltip.
     /// \return True if selected.
-    inline bool SelectableMarker(const std::string& text) {
-        bool clicked = ImGui::Selectable(text.c_str());
-        if (ImGui::IsItemHovered()) TooltipWrapped(text.c_str());
-        return clicked;
-    }
+    bool SelectableMarker(const std::string& text);
 
     /// \brief Help marker using a question icon with tooltip.
     /// \param desc Help text.
-    inline void HelpMarker(
-            const char* desc, 
-            MarkerMode mode = MarkerMode::TooltipOnly, 
+    void HelpMarker(
+            const char* desc,
+            MarkerMode mode = MarkerMode::TooltipOnly,
             const char* icon_utf8 = IMGUIX_ICON_HELP
-        ) {
-        ImGui::TextDisabled(icon_utf8);
-        if (mode == MarkerMode::InlineText) {
-            ImGui::SameLine();
-            ImGui::TextWrapped("%s", desc);
-        } else if (ImGui::IsItemHovered()) {
-            TooltipWrapped(desc);
-        }
-    }
+        );
 
     /// \brief Warning marker with yellow icon and text.
     /// \param desc Warning message.
-    inline void WarningMarker(
+    void WarningMarker(
             const char* desc,
-            MarkerMode mode = MarkerMode::TooltipOnly, 
+            MarkerMode mode = MarkerMode::TooltipOnly,
             const ImVec4& color = IMGUIX_COLOR_WARNING,
             const char* icon_utf8 = IMGUIX_ICON_WARNING
-        ) {
-        IconMarker(icon_utf8, color, desc, mode);
-    }
+        );
 
     /// \brief Info marker with blue icon and text.
     /// \param desc Information message.
-    inline void InfoMarker(
+    void InfoMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,
             const ImVec4& color = IMGUIX_COLOR_INFO,
             const char* icon_utf8 = IMGUIX_ICON_INFO
-        ) {
-        IconMarker(icon_utf8, color, desc, mode);
-    }
+        );
 
     /// \brief Success marker with green icon and text.
     /// \param desc Success message.
-    inline void SuccessMarker(
+    void SuccessMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,
             const ImVec4& color = IMGUIX_COLOR_SUCCESS,
             const char* icon_utf8 = IMGUIX_ICON_SUCCESS
-        ) {
-        IconMarker(icon_utf8, color, desc, mode);
-    }
+        );
 
 } // namespace ImGuiX::Widgets
+#ifdef IMGUIX_HEADER_ONLY
+#   include "markers.ipp"
+#endif
 
 #endif // _IMGUIX_WIDGETS_MARKERS_HPP_INCLUDED

--- a/include/imguix/widgets/misc/markers.ipp
+++ b/include/imguix/widgets/misc/markers.ipp
@@ -1,0 +1,90 @@
+#include <imgui.h>
+#include <string>
+
+#include <imguix/config/icons.hpp>
+#include <imguix/config/colors.hpp>
+
+namespace ImGuiX::Widgets {
+
+void TooltipWrapped(const char* desc, float wrap_cols) {
+    ImGui::BeginTooltip();
+    ImGui::PushTextWrapPos(ImGui::GetFontSize() * wrap_cols);
+    ImGui::TextUnformatted(desc);
+    ImGui::PopTextWrapPos();
+    ImGui::EndTooltip();
+}
+
+void IconMarker(
+        const char* icon_utf8,
+        const ImVec4& color,
+        const char* desc,
+        MarkerMode mode,
+        float wrap_cols) {
+    ImGui::PushStyleColor(ImGuiCol_Text, color);
+    ImGui::TextUnformatted(icon_utf8);
+    ImGui::PopStyleColor();
+
+    if (mode == MarkerMode::InlineText) {
+        ImGui::SameLine();
+        ImGui::TextWrapped("%s", desc);
+    } else if (ImGui::IsItemHovered()) {
+        TooltipWrapped(desc, wrap_cols);
+    }
+}
+
+void ColoredMarker(
+        const char* label,
+        const char* desc,
+        const ImVec4& color) {
+    ImGui::PushStyleColor(ImGuiCol_Text, color);
+    ImGui::TextUnformatted(label);
+    ImGui::PopStyleColor();
+    if (ImGui::IsItemHovered())
+        TooltipWrapped(desc);
+}
+
+bool SelectableMarker(const std::string& text) {
+    bool clicked = ImGui::Selectable(text.c_str());
+    if (ImGui::IsItemHovered())
+        TooltipWrapped(text.c_str());
+    return clicked;
+}
+
+void HelpMarker(
+        const char* desc,
+        MarkerMode mode,
+        const char* icon_utf8) {
+    ImGui::TextDisabled(icon_utf8);
+    if (mode == MarkerMode::InlineText) {
+        ImGui::SameLine();
+        ImGui::TextWrapped("%s", desc);
+    } else if (ImGui::IsItemHovered()) {
+        TooltipWrapped(desc);
+    }
+}
+
+void WarningMarker(
+        const char* desc,
+        MarkerMode mode,
+        const ImVec4& color,
+        const char* icon_utf8) {
+    IconMarker(icon_utf8, color, desc, mode);
+}
+
+void InfoMarker(
+        const char* desc,
+        MarkerMode mode,
+        const ImVec4& color,
+        const char* icon_utf8) {
+    IconMarker(icon_utf8, color, desc, mode);
+}
+
+void SuccessMarker(
+        const char* desc,
+        MarkerMode mode,
+        const ImVec4& color,
+        const char* icon_utf8) {
+    IconMarker(icon_utf8, color, desc, mode);
+}
+
+} // namespace ImGuiX::Widgets

--- a/include/imguix/widgets/misc/text_center.hpp
+++ b/include/imguix/widgets/misc/text_center.hpp
@@ -8,64 +8,24 @@
 /// ImGui 1.92.* compatible: uses only public API + <cstdio> for formatting.
 
 #include <imgui.h>
-#include <algorithm>
 #include <string>
-#include <cstdarg>
-#include <cstdio>
 
 namespace ImGuiX::Widgets {
 
     /// \brief Center a single-line formatted text using ImGui::Text.
     /// \param fmt Format string for std::vsnprintf.
     /// \note If text width exceeds available width, falls back to left alignment.
-    inline void TextCenteredFmt(const char* fmt, ...) {
-        char buf[1024];
-        va_list args;
-        va_start(args, fmt);
-        std::vsnprintf(buf, sizeof(buf), fmt, args);
-        va_end(args);
-
-        const float avail_w = ImGui::GetContentRegionAvail().x;
-        const float text_w  = ImGui::CalcTextSize(buf).x;
-
-        const float x0 = ImGui::GetCursorPosX();
-        const float x  = (text_w < avail_w) ? x0 + (avail_w - text_w) * 0.5f : x0;
-        ImGui::SetCursorPosX(x);
-        ImGui::TextUnformatted(buf);
-    }
+    void TextCenteredFmt(const char* fmt, ...);
 
     /// \brief Center an unformatted string (no printf parsing).
     /// \param text UTF-8 string to render.
-    inline void TextUnformattedCentered(const char* text) {
-        if (!text) return;
-        const float avail_w = ImGui::GetContentRegionAvail().x;
-        const float text_w  = ImGui::CalcTextSize(text).x;
-
-        const float x0 = ImGui::GetCursorPosX();
-        const float x  = (text_w < avail_w) ? x0 + (avail_w - text_w) * 0.5f : x0;
-        ImGui::SetCursorPosX(x);
-        ImGui::TextUnformatted(text);
-    }
+    void TextUnformattedCentered(const char* text);
 
     /// \brief Center a wrapped text block by placing it into a centered child.
     /// \param text Text to render.
     /// \param wrap_width Desired wrap width in pixels (<= avail). If <= 0, uses available width.
     /// \note The function creates a child region of the target width and centers it, then uses TextWrapped inside.
-    inline void TextWrappedCentered(const char* text, float wrap_width = 0.0f) {
-        if (!text) return;
-
-        const float avail_w = ImGui::GetContentRegionAvail().x;
-        const float block_w = (wrap_width > 0.0f) ? std::min(wrap_width, avail_w) : avail_w;
-
-        const float x0 = ImGui::GetCursorPosX();
-        const float x  = x0 + (avail_w - block_w) * 0.5f; // центрируем «контейнер»
-
-        ImGui::SetCursorPosX(x);
-        // wrap позиция задаётся в ЛОКАЛЬНЫХ координатах текущего окна:
-        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + block_w);
-        ImGui::TextUnformatted(text);
-        ImGui::PopTextWrapPos();
-    }
+    void TextWrappedCentered(const char* text, float wrap_width = 0.0f);
     
     /// \brief Overload for std::string (unformatted).
     inline void TextUnformattedCentered(const std::string& s) {
@@ -78,5 +38,8 @@ namespace ImGuiX::Widgets {
     }
 
 } // namespace ImGuiX::Widgets
+#ifdef IMGUIX_HEADER_ONLY
+#   include "text_center.ipp"
+#endif
 
 #endif // _IMGUIX_WIDGETS_TEXT_CENTER_HPP_INCLUDED

--- a/include/imguix/widgets/misc/text_center.ipp
+++ b/include/imguix/widgets/misc/text_center.ipp
@@ -1,0 +1,50 @@
+#include <algorithm>
+#include <cstdarg>
+#include <cstdio>
+
+namespace ImGuiX::Widgets {
+
+void TextCenteredFmt(const char* fmt, ...) {
+    char buf[1024];
+    va_list args;
+    va_start(args, fmt);
+    std::vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    const float avail_w = ImGui::GetContentRegionAvail().x;
+    const float text_w  = ImGui::CalcTextSize(buf).x;
+
+    const float x0 = ImGui::GetCursorPosX();
+    const float x  = (text_w < avail_w) ? x0 + (avail_w - text_w) * 0.5f : x0;
+    ImGui::SetCursorPosX(x);
+    ImGui::TextUnformatted(buf);
+}
+
+void TextUnformattedCentered(const char* text) {
+    if (!text) return;
+    const float avail_w = ImGui::GetContentRegionAvail().x;
+    const float text_w  = ImGui::CalcTextSize(text).x;
+
+    const float x0 = ImGui::GetCursorPosX();
+    const float x  = (text_w < avail_w) ? x0 + (avail_w - text_w) * 0.5f : x0;
+    ImGui::SetCursorPosX(x);
+    ImGui::TextUnformatted(text);
+}
+
+void TextWrappedCentered(const char* text, float wrap_width) {
+    if (!text) return;
+
+    const float avail_w = ImGui::GetContentRegionAvail().x;
+    const float block_w = (wrap_width > 0.0f) ? std::min(wrap_width, avail_w) : avail_w;
+
+    const float x0 = ImGui::GetCursorPosX();
+    const float x  = x0 + (avail_w - block_w) * 0.5f; // центрируем «контейнер»
+
+    ImGui::SetCursorPosX(x);
+    // wrap позиция задаётся в ЛОКАЛЬНЫХ координатах текущего окна:
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + block_w);
+    ImGui::TextUnformatted(text);
+    ImGui::PopTextWrapPos();
+}
+
+} // namespace ImGuiX::Widgets


### PR DESCRIPTION
## Summary
- move non-inline loading spinner code to `loading_spinner.ipp`
- extract marker widget implementations to `markers.ipp`
- shift text centering helpers into `text_center.ipp`

## Testing
- `cmake -S . -B build` *(fails: SFML 'System' component missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae513e6908832cb4035578bf2b9984