### PR TITLE
refactor(widgets): split control implementations

### DIFF
--- a/include/imguix/widgets/controls/circle_button.hpp
+++ b/include/imguix/widgets/controls/circle_button.hpp
@@ -1,6 +1,7 @@
-#include <imgui.h>
 #ifndef _IMGUIX_WIDGETS_CIRCLE_BUTTON_HPP_INCLUDED
 #define _IMGUIX_WIDGETS_CIRCLE_BUTTON_HPP_INCLUDED
+
+#include <imgui.h>
 
 /// \file circle_button.hpp
 /// \brief Provides a utility for drawing circular ImGui buttons.
@@ -13,23 +14,12 @@ namespace ImGuiX::Widgets {
     /// \param color Base color.
     /// \return True if button was clicked.
     /// \note Button changes color on hover or active using style.
-    bool CircleButton(const char* id, float diameter, const ImVec4& color) {
-        ImVec2 size = ImVec2(diameter, diameter);
-        ImVec2 pos = ImGui::GetCursorScreenPos();
-        ImGui::InvisibleButton(id, size);
-
-        ImDrawList* draw_list = ImGui::GetWindowDrawList();
-        ImVec2 center = ImVec2(pos.x + diameter * 0.5f, pos.y + diameter * 0.5f);
-
-        ImVec4 final_col = color;
-        if (ImGui::IsItemHovered()) final_col = ImGui::GetStyleColorVec4(ImGuiCol_ButtonHovered);
-        if (ImGui::IsItemActive()) final_col = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
-
-        draw_list->AddCircleFilled(center, diameter * 0.5f, ImGui::ColorConvertFloat4ToU32(final_col), 16);
-
-        return ImGui::IsItemClicked();
-    }
+    bool CircleButton(const char* id, float diameter, const ImVec4& color);
 
 } // namespace ImGuiX::Widgets
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "circle_button.ipp"
+#endif
 
 #endif // _IMGUIX_WIDGETS_CIRCLE_BUTTON_HPP_INCLUDED

--- a/include/imguix/widgets/controls/circle_button.ipp
+++ b/include/imguix/widgets/controls/circle_button.ipp
@@ -1,0 +1,21 @@
+namespace ImGuiX::Widgets {
+
+    bool CircleButton(const char* id, float diameter, const ImVec4& color) {
+        ImVec2 size = ImVec2(diameter, diameter);
+        ImVec2 pos = ImGui::GetCursorScreenPos();
+        ImGui::InvisibleButton(id, size);
+
+        ImDrawList* draw_list = ImGui::GetWindowDrawList();
+        ImVec2 center = ImVec2(pos.x + diameter * 0.5f, pos.y + diameter * 0.5f);
+
+        ImVec4 final_col = color;
+        if (ImGui::IsItemHovered()) final_col = ImGui::GetStyleColorVec4(ImGuiCol_ButtonHovered);
+        if (ImGui::IsItemActive()) final_col = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
+
+        draw_list->AddCircleFilled(center, diameter * 0.5f, ImGui::ColorConvertFloat4ToU32(final_col), 16);
+
+        return ImGui::IsItemClicked();
+    }
+
+} // namespace ImGuiX::Widgets
+

--- a/include/imguix/widgets/controls/icon_button.hpp
+++ b/include/imguix/widgets/controls/icon_button.hpp
@@ -22,50 +22,16 @@ namespace ImGuiX::Widgets {
     /// \param text UTF-8 text or icon string.
     /// \param cfg Button appearance options.
     /// \return True if clicked with left mouse button.
-    inline bool IconButtonCentered(
-			const char* id,
-			const char* text,
-			const IconButtonConfig& cfg = {}
-		) {
-        ImDrawList* dl = ImGui::GetWindowDrawList();
-        const ImVec2 p0 = ImGui::GetCursorScreenPos();
-
-        ImVec2 sz = cfg.size;
-        if (sz.x <= 0.0f || sz.y <= 0.0f) {
-            const float h = ImGui::GetFrameHeight();
-            sz = ImVec2(h, h); // square sized to current frame height
-        }
-
-        ImGui::InvisibleButton(id, sz);
-        const bool hovered = ImGui::IsItemHovered();
-        const bool held    = ImGui::IsItemActive();
-        const bool clicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
-
-        const ImGuiStyle& style = ImGui::GetStyle();
-        float rounding = (cfg.rounding < 0.0f) ? style.FrameRounding : cfg.rounding;
-
-        const ImU32 bg = ImGui::GetColorU32(
-            held ? ImGuiCol_ButtonActive :
-            hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
-        dl->AddRectFilled(p0, ImVec2(p0.x + sz.x, p0.y + sz.y), bg, rounding);
-
-        if (cfg.draw_border) {
-            const ImU32 bc = cfg.border_col ? cfg.border_col : ImGui::GetColorU32(ImGuiCol_Border);
-            dl->AddRect(p0, ImVec2(p0.x + sz.x, p0.y + sz.y), bc, rounding, 0, cfg.border_thickness);
-        }
-
-        if (cfg.font) ImGui::PushFont(cfg.font);
-        const ImVec2 ts = ImGui::CalcTextSize(text);
-
-        auto snap = [](float v) { return std::floor(v) + 0.5f; };
-        const float tx = snap(p0.x + (sz.x - ts.x) * 0.5f + cfg.text_offset.x);
-        const float ty = snap(p0.y + (sz.y - ts.y) * 0.5f + cfg.text_offset.y);
-        dl->AddText(ImVec2(tx, ty), ImGui::GetColorU32(ImGuiCol_Text), text);
-        if (cfg.font) ImGui::PopFont();
-
-        return clicked;
-    }
+    bool IconButtonCentered(
+            const char* id,
+            const char* text,
+            const IconButtonConfig& cfg = {}
+    );
 
 } // namespace ImGuiX::Widgets
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "icon_button.ipp"
+#endif
 
 #endif // _IMGUIX_WIDGETS_ICON_BUTTON_HPP_INCLUDED

--- a/include/imguix/widgets/controls/icon_button.ipp
+++ b/include/imguix/widgets/controls/icon_button.ipp
@@ -1,0 +1,51 @@
+#include <cmath>
+
+namespace ImGuiX::Widgets {
+
+    bool IconButtonCentered(
+            const char* id,
+            const char* text,
+            const IconButtonConfig& cfg
+    ) {
+        ImDrawList* dl = ImGui::GetWindowDrawList();
+        const ImVec2 p0 = ImGui::GetCursorScreenPos();
+
+        ImVec2 sz = cfg.size;
+        if (sz.x <= 0.0f || sz.y <= 0.0f) {
+            const float h = ImGui::GetFrameHeight();
+            sz = ImVec2(h, h); // square sized to current frame height
+        }
+
+        ImGui::InvisibleButton(id, sz);
+        const bool hovered = ImGui::IsItemHovered();
+        const bool held    = ImGui::IsItemActive();
+        const bool clicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
+
+        const ImGuiStyle& style = ImGui::GetStyle();
+        float rounding = (cfg.rounding < 0.0f) ? style.FrameRounding : cfg.rounding;
+
+        const ImU32 bg = ImGui::GetColorU32(
+            held ? ImGuiCol_ButtonActive :
+            hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button
+        );
+        dl->AddRectFilled(p0, ImVec2(p0.x + sz.x, p0.y + sz.y), bg, rounding);
+
+        if (cfg.draw_border) {
+            const ImU32 bc = cfg.border_col ? cfg.border_col : ImGui::GetColorU32(ImGuiCol_Border);
+            dl->AddRect(p0, ImVec2(p0.x + sz.x, p0.y + sz.y), bc, rounding, 0, cfg.border_thickness);
+        }
+
+        if (cfg.font) ImGui::PushFont(cfg.font);
+        const ImVec2 ts = ImGui::CalcTextSize(text);
+
+        auto snap = [](float v) { return std::floor(v) + 0.5f; };
+        const float tx = snap(p0.x + (sz.x - ts.x) * 0.5f + cfg.text_offset.x);
+        const float ty = snap(p0.y + (sz.y - ts.y) * 0.5f + cfg.text_offset.y);
+        dl->AddText(ImVec2(tx, ty), ImGui::GetColorU32(ImGuiCol_Text), text);
+        if (cfg.font) ImGui::PopFont();
+
+        return clicked;
+    }
+
+} // namespace ImGuiX::Widgets
+

--- a/include/imguix/widgets/controls/system_button.hpp
+++ b/include/imguix/widgets/controls/system_button.hpp
@@ -6,8 +6,6 @@
 /// \brief Provides custom system-style buttons (close, minimize, maximize) for ImGui windows.
 
 #include <imgui.h>
-#include <algorithm>
-#include <cmath>
 
 /// \brief Extent multiplier for system button icons (default 0.25f).
 #ifndef IMGUIX_SYSBTN_CROSS_EXTENT
@@ -39,51 +37,12 @@ namespace ImGuiX::Widgets {
     /// \param size Button size in pixels.
     /// \return True if button was clicked.
     /// \note Button is highlighted on hover or active using style colors.
-    inline bool SystemButton(const char* id, SystemButtonType type, ImVec2 size) {
-        ImVec2 pos = ImGui::GetCursorScreenPos();
-        ImGui::InvisibleButton(id, size);
-        ImDrawList* dl = ImGui::GetWindowDrawList();
-
-        if (ImGui::IsItemHovered() || ImGui::IsItemActive()) {
-            ImVec4 bg = ImGui::GetStyleColorVec4(ImGui::IsItemActive() ? ImGuiCol_ButtonActive : ImGuiCol_ButtonHovered);
-            dl->AddRectFilled(pos, ImVec2(pos.x + size.x, pos.y + size.y),
-                              ImGui::ColorConvertFloat4ToU32(bg), 2.0f);
-        }
-
-        ImU32 col = ImGui::GetColorU32(ImGuiCol_Text);
-        const float thickness = IMGUIX_SYSBTN_LINE_THICKNESS;
-
-        auto snap = [](float v) -> float { return std::floor(v) + 0.5f; };
-
-        // Center of button
-        ImVec2 c(snap(pos.x + size.x * 0.5f), snap(pos.y + size.y * 0.5f));
-
-        // Extent of icon
-        float min_side = std::min(size.x, size.y);
-        float e = IMGUIX_SYSBTN_CROSS_EXTENT * min_side;
-        e = std::min(e, 0.5f * min_side - IMGUIX_SYSBTN_MARGIN);
-
-        if (type == SystemButtonType::Close) {
-            ImVec2 a1(snap(c.x - e), snap(c.y - e));
-            ImVec2 b1(snap(c.x + e), snap(c.y + e));
-            ImVec2 a2(snap(c.x - e), snap(c.y + e));
-            ImVec2 b2(snap(c.x + e), snap(c.y - e));
-            dl->AddLine(a1, b1, col, thickness);
-            dl->AddLine(a2, b2, col, thickness);
-        } else if (type == SystemButtonType::Minimize) {
-            //float y = snap(pos.y + size.y - IMGUIX_SYSBTN_MARGIN - 1.0f);
-            ImVec2 a(snap(c.x - e), snap(c.y + e));
-            ImVec2 b(snap(c.x + e), snap(c.y + e));
-            dl->AddLine(a, b, col, thickness);
-        } else if (type == SystemButtonType::Maximize) {
-            ImVec2 tl(snap(c.x - e), snap(c.y - e));
-            ImVec2 br(snap(c.x + e), snap(c.y + e));
-            dl->AddRect(tl, br, col, 0.0f, 0, thickness);
-        }
-
-        return ImGui::IsItemClicked(ImGuiMouseButton_Left);
-    }
+    bool SystemButton(const char* id, SystemButtonType type, ImVec2 size);
 
 } // namespace ImGuiX::Widgets
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "system_button.ipp"
+#endif
 
 #endif // _IMGUIX_WIDGETS_SYSTEM_BUTTON_HPP_INCLUDED

--- a/include/imguix/widgets/controls/system_button.ipp
+++ b/include/imguix/widgets/controls/system_button.ipp
@@ -1,0 +1,53 @@
+#include <algorithm>
+#include <cmath>
+
+namespace ImGuiX::Widgets {
+
+    bool SystemButton(const char* id, SystemButtonType type, ImVec2 size) {
+        ImVec2 pos = ImGui::GetCursorScreenPos();
+        ImGui::InvisibleButton(id, size);
+        ImDrawList* dl = ImGui::GetWindowDrawList();
+
+        if (ImGui::IsItemHovered() || ImGui::IsItemActive()) {
+            ImVec4 bg = ImGui::GetStyleColorVec4(
+                    ImGui::IsItemActive() ?
+                        ImGuiCol_ButtonActive :
+                        ImGuiCol_ButtonHovered
+            );
+            dl->AddRectFilled(pos, ImVec2(pos.x + size.x, pos.y + size.y),
+                              ImGui::ColorConvertFloat4ToU32(bg), 2.0f);
+        }
+
+        ImU32 col = ImGui::GetColorU32(ImGuiCol_Text);
+        const float thickness = IMGUIX_SYSBTN_LINE_THICKNESS;
+
+        auto snap = [](float v) -> float { return std::floor(v) + 0.5f; };
+
+        ImVec2 c(snap(pos.x + size.x * 0.5f), snap(pos.y + size.y * 0.5f));
+
+        float min_side = std::min(size.x, size.y);
+        float e = IMGUIX_SYSBTN_CROSS_EXTENT * min_side;
+        e = std::min(e, 0.5f * min_side - IMGUIX_SYSBTN_MARGIN);
+
+        if (type == SystemButtonType::Close) {
+            ImVec2 a1(snap(c.x - e), snap(c.y - e));
+            ImVec2 b1(snap(c.x + e), snap(c.y + e));
+            ImVec2 a2(snap(c.x - e), snap(c.y + e));
+            ImVec2 b2(snap(c.x + e), snap(c.y - e));
+            dl->AddLine(a1, b1, col, thickness);
+            dl->AddLine(a2, b2, col, thickness);
+        } else if (type == SystemButtonType::Minimize) {
+            ImVec2 a(snap(c.x - e), snap(c.y + e));
+            ImVec2 b(snap(c.x + e), snap(c.y + e));
+            dl->AddLine(a, b, col, thickness);
+        } else if (type == SystemButtonType::Maximize) {
+            ImVec2 tl(snap(c.x - e), snap(c.y - e));
+            ImVec2 br(snap(c.x + e), snap(c.y + e));
+            dl->AddRect(tl, br, col, 0.0f, 0, thickness);
+        }
+
+        return ImGui::IsItemClicked(ImGuiMouseButton_Left);
+    }
+
+} // namespace ImGuiX::Widgets
+

--- a/include/imguix/widgets/controls/toggle_button.hpp
+++ b/include/imguix/widgets/controls/toggle_button.hpp
@@ -6,85 +6,19 @@
 /// \brief Provides a simple animated toggle switch for ImGui (public API only).
 
 #include <imgui.h>
-#include <algorithm> // min/max
 
 namespace ImGuiX::Widgets {
 
     /// \brief Draw an animated toggle switch (no imgui_internal.h).
     /// \param id Unique string identifier.
     /// \param state Pointer to boolean storing current state.
-    inline void ToggleButton(const char* id, bool* state) {
-        // Geometry
-        const float h = ImGui::GetFrameHeight();
-        const float w = h * 1.55f;
-        const float r = h * 0.50f;
-
-        ImVec2 pos = ImGui::GetCursorScreenPos();
-        ImDrawList* dl = ImGui::GetWindowDrawList();
-
-        // Click area
-        ImGui::InvisibleButton(id, ImVec2(w, h));
-        if (ImGui::IsItemClicked() && state) *state = !*state;
-
-        // --- Animation (public API) -----------------------------------------
-        // Store per-widget animation progress in window storage.
-        ImGuiStorage* st = ImGui::GetStateStorage();
-        ImGui::PushID(id);
-        const ImGuiID key_anim = ImGui::GetID("anim");
-        ImGui::PopID();
-
-        float anim = st->GetFloat(key_anim, (*state ? 1.0f : 0.0f));
-        const float target = (*state ? 1.0f : 0.0f);
-
-        // Linear approach to target with ~0.08s time to settle (like old kAnimSpeed)
-        const float dt = ImGui::GetIO().DeltaTime;
-        const float step = (dt > 0 ? dt / 0.08f : 1.0f); // 0.08s to travel 0->1
-        if (target > anim) anim = std::min(1.0f, anim + step);
-        else               anim = std::max(0.0f, anim - step);
-
-        st->SetFloat(key_anim, anim);
-        const float t = anim; // 0..1
-
-        // Small helpers (no ImLerp/ImSaturate from internals)
-        auto lerp4 = [](const ImVec4& a, const ImVec4& b, float k) {
-            if (k < 0.0f) k = 0.0f; else if (k > 1.0f) k = 1.0f;
-            return ImVec4(a.x + (b.x - a.x) * k,
-                          a.y + (b.y - a.y) * k,
-                          a.z + (b.z - a.z) * k,
-                          a.w + (b.w - a.w) * k);
-        };
-
-        // Colors
-        const bool hovered = ImGui::IsItemHovered();
-        const ImVec4 off_hov = ImVec4(0.78f, 0.78f, 0.78f, 1.0f);
-        const ImVec4 on_hov  = ImVec4(0.64f, 0.83f, 0.34f, 1.0f);
-        const ImVec4 off     = ImVec4(0.85f, 0.85f, 0.85f, 1.0f);
-        const ImVec4 on      = ImVec4(0.56f, 0.83f, 0.26f, 1.0f);
-
-        const ImU32 col_bg = ImGui::GetColorU32( hovered ? lerp4(off_hov, on_hov, t)
-                                                          : lerp4(off,     on,     t) );
-
-        // Track background
-        dl->AddRectFilled(
-            pos,
-            ImVec2(pos.x + w, pos.y + h),
-            col_bg,
-            h * 0.5f
-        );
-
-        // Knob
-        const float x0 = pos.x + r;
-        const float x1 = pos.x + (w - r);
-        const float x  = x0 + (x1 - x0) * t;
-
-        dl->AddCircleFilled(
-            ImVec2(x, pos.y + r),
-            r - 1.5f,
-            IM_COL32(255,255,255,255)
-        );
-    }
+    void ToggleButton(const char* id, bool* state);
 
 } // namespace ImGuiX::Widgets
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "toggle_button.ipp"
+#endif
 
 #endif // _IMGUIX_WIDGETS_TOGGLE_BUTTON_HPP_INCLUDED
 

--- a/include/imguix/widgets/controls/toggle_button.ipp
+++ b/include/imguix/widgets/controls/toggle_button.ipp
@@ -1,0 +1,77 @@
+#include <algorithm>
+
+namespace ImGuiX::Widgets {
+
+    void ToggleButton(const char* id, bool* state) {
+        // Geometry
+        const float h = ImGui::GetFrameHeight();
+        const float w = h * 1.55f;
+        const float r = h * 0.50f;
+
+        ImVec2 pos = ImGui::GetCursorScreenPos();
+        ImDrawList* dl = ImGui::GetWindowDrawList();
+
+        // Click area
+        ImGui::InvisibleButton(id, ImVec2(w, h));
+        if (ImGui::IsItemClicked() && state) *state = !*state;
+
+        // --- Animation (public API) -----------------------------------------
+        // Store per-widget animation progress in window storage.
+        ImGuiStorage* st = ImGui::GetStateStorage();
+        ImGui::PushID(id);
+        const ImGuiID key_anim = ImGui::GetID("anim");
+        ImGui::PopID();
+
+        float anim = st->GetFloat(key_anim, (*state ? 1.0f : 0.0f));
+        const float target = (*state ? 1.0f : 0.0f);
+
+        // Linear approach to target with ~0.08s time to settle (like old kAnimSpeed)
+        const float dt = ImGui::GetIO().DeltaTime;
+        const float step = (dt > 0 ? dt / 0.08f : 1.0f); // 0.08s to travel 0->1
+        if (target > anim) anim = std::min(1.0f, anim + step);
+        else               anim = std::max(0.0f, anim - step);
+
+        st->SetFloat(key_anim, anim);
+        const float t = anim; // 0..1
+
+        // Small helpers (no ImLerp/ImSaturate from internals)
+        auto lerp4 = [](const ImVec4& a, const ImVec4& b, float k) {
+            if (k < 0.0f) k = 0.0f; else if (k > 1.0f) k = 1.0f;
+            return ImVec4(a.x + (b.x - a.x) * k,
+                          a.y + (b.y - a.y) * k,
+                          a.z + (b.z - a.z) * k,
+                          a.w + (b.w - a.w) * k);
+        };
+
+        // Colors
+        const bool hovered = ImGui::IsItemHovered();
+        const ImVec4 off_hov = ImVec4(0.78f, 0.78f, 0.78f, 1.0f);
+        const ImVec4 on_hov  = ImVec4(0.64f, 0.83f, 0.34f, 1.0f);
+        const ImVec4 off     = ImVec4(0.85f, 0.85f, 0.85f, 1.0f);
+        const ImVec4 on      = ImVec4(0.56f, 0.83f, 0.26f, 1.0f);
+
+        const ImU32 col_bg = ImGui::GetColorU32( hovered ? lerp4(off_hov, on_hov, t)
+                                                          : lerp4(off,     on,     t) );
+
+        // Track background
+        dl->AddRectFilled(
+            pos,
+            ImVec2(pos.x + w, pos.y + h),
+            col_bg,
+            h * 0.5f
+        );
+
+        // Knob
+        const float x0 = pos.x + r;
+        const float x1 = pos.x + (w - r);
+        const float x  = x0 + (x1 - x0) * t;
+
+        dl->AddCircleFilled(
+            ImVec2(x, pos.y + r),
+            r - 1.5f,
+            IM_COL32(255,255,255,255)
+        );
+    }
+
+} // namespace ImGuiX::Widgets
+


### PR DESCRIPTION
## Summary
- move CircleButton, SystemButton, ToggleButton, and IconButton implementations into `.ipp` files
- remove self-includes from widget control `.ipp` files and support header-only builds

## Testing
- `apt-get install -y nlohmann-json3-dev`
- `apt-get install -y libsfml-dev`
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing in the config)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4a43ddc4832ca199846fce0ff450