### PR TITLE
feat(options): add Emscripten persistence

### DIFF
--- a/include/imguix/core/application/Application.ipp
+++ b/include/imguix/core/application/Application.ipp
@@ -3,6 +3,7 @@
 #endif
 
 #include <imguix/config/paths.hpp>
+#include <imguix/core/options/OptionsStore.hpp>
 
 namespace ImGuiX {
 
@@ -97,7 +98,10 @@ namespace ImGuiX {
             FS.mkdir('/imguix_fs');
             FS.mount(IDBFS, {}, '/imguix_fs');
             FS.syncfs(true, function(){});
+            try { FS.mkdir('/imguix_fs/data'); } catch (e) {}
+            try { FS.mkdir('/imguix_fs/data/config'); } catch (e) {}
         });
+        m_registry.getResource<OptionsStore>().load();
 #   endif
 #endif
         // Ensure initial windows and models are ready before entering loop


### PR DESCRIPTION
## Summary
- persist OptionsStore on Emscripten using IDBFS and FS.syncfs
- load settings after mounting IDBFS during application startup

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF` *(fails: Cannot find source file: libs/imgui/imgui.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68ae56fdc180832c9a6d174ce76a6f91