### PR TITLE
feat: add theme manager and default themes

### DIFF
--- a/include/imguix/core.hpp
+++ b/include/imguix/core.hpp
@@ -44,6 +44,9 @@
 // --- Resource system ---
 #include "core/resource/ResourceRegistry.hpp"      ///< Global registry for shared resources
 
+// --- Theme system ---
+#include "themes/ThemeManager.hpp"                 ///< Theme manager for ImGui styles
+
 // --- Controller and model interfaces ---
 #include "core/application/ApplicationContext.hpp" ///< Interface for application access
 #include "core/window/WindowInterface.hpp"         ///< Interface for window control

--- a/include/imguix/core/controller/Controller.hpp
+++ b/include/imguix/core/controller/Controller.hpp
@@ -64,6 +64,12 @@ namespace ImGuiX {
             return m_window.langStore();
         }
 
+        /// \brief Access the theme manager.
+        /// \return Theme manager instance.
+        Themes::ThemeManager& getThemeManager() {
+            return m_window.getThemeManager();
+        }
+
     protected:
         WindowInterface& m_window; ///< Controlled window instance.
     };

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -30,6 +30,8 @@
 
 namespace ImGuiX {
 
+    class Controller;
+
     /// \brief Abstract base class for a window instance.
     ///
     /// Combines event handling, rendering, and controller orchestration.
@@ -184,6 +186,10 @@ namespace ImGuiX {
         /// \return Font manager control interface.
         ImGuiX::Fonts::FontManager::Control& fontsControl() noexcept { return m_font_manager.control(); }
 
+        /// \brief Access the theme manager.
+        /// \return Theme manager.
+        ImGuiX::Themes::ThemeManager& getThemeManager() noexcept override { return m_theme_manager; }
+
         // ---
 
         /// \brief Compute file path for storing ImGui ini settings.
@@ -296,6 +302,7 @@ namespace ImGuiX {
         bool m_in_init_phase = false;       ///< Guard flag for onInit phase operations.
         bool m_is_fonts_init = false;       ///< Indicates whether fonts have been built.
         ImGuiX::Fonts::FontManager m_font_manager; ///< Manages ImGui font atlas.
+        ImGuiX::Themes::ThemeManager m_theme_manager; ///< Manages ImGui style themes.
         ImGuiX::I18N::LangStore    m_lang_store{}; ///< Localization storage for this window.
         std::string                m_pending_lang; ///< Language code pending to apply.
 

--- a/include/imguix/core/window/WindowInstance.ipp
+++ b/include/imguix/core/window/WindowInstance.ipp
@@ -1,5 +1,6 @@
 #include <imgui.h>
 #include <imguix/utils/path_utils.hpp>
+#include <imguix/themes/themes.hpp>
 
 namespace ImGuiX {
 
@@ -8,6 +9,9 @@ namespace ImGuiX {
           m_window_id(id),
           m_window_name(std::move(name)),
           m_application(app) {
+        m_theme_manager.registerTheme("light", std::make_unique<Themes::LightTheme>());
+        m_theme_manager.registerTheme("dark", std::make_unique<Themes::DarkTheme>());
+        m_theme_manager.setTheme("dark");
     }
 
     void WindowInstance::drawContent() {

--- a/include/imguix/core/window/WindowInterface.hpp
+++ b/include/imguix/core/window/WindowInterface.hpp
@@ -120,6 +120,10 @@ namespace ImGuiX {
         /// \return Language store.
         virtual const ImGuiX::I18N::LangStore& langStore() const = 0;
 
+        /// \brief Access the theme manager.
+        /// \return Theme manager.
+        virtual Themes::ThemeManager& getThemeManager() = 0;
+
     };
 
 } // namespace ImGuiX

--- a/include/imguix/core/window/WindowManager.ipp
+++ b/include/imguix/core/window/WindowManager.ipp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <imgui.h>
+#include <imguix/themes/ThemeManager.hpp>
 
 namespace ImGuiX {
 
@@ -111,6 +113,7 @@ namespace ImGuiX {
 #       endif
 
         for (auto& window : m_windows) {
+            window->getThemeManager().updateCurrentTheme(ImGui::GetStyle());
             window->tick();
         }
     }

--- a/include/imguix/themes/Theme.hpp
+++ b/include/imguix/themes/Theme.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#ifndef _IMGUIX_THEMES_THEME_HPP_INCLUDED
+#define _IMGUIX_THEMES_THEME_HPP_INCLUDED
+
+/// \file Theme.hpp
+/// \brief Theme definitions and helpers.
+
+#include <imgui.h>
+
+namespace ImGuiX::Themes {
+
+    class Theme {
+    public:
+        virtual ~Theme() = default;
+        virtual void apply(ImGuiStyle& style) const = 0;
+    };
+
+    class LightTheme final : public Theme {
+    public:
+        void apply(ImGuiStyle& style) const override {
+            ImGui::StyleColorsLight(&style);
+        }
+    };
+
+    class DarkTheme final : public Theme {
+    public:
+        void apply(ImGuiStyle& style) const override {
+            ImGui::StyleColorsDark(&style);
+        }
+    };
+
+    inline void applyLightTheme(ImGuiStyle& style) {
+        LightTheme{}.apply(style);
+    }
+
+    inline void applyDarkTheme(ImGuiStyle& style) {
+        DarkTheme{}.apply(style);
+    }
+
+} // namespace ImGuiX::Themes
+
+#endif // _IMGUIX_THEMES_THEME_HPP_INCLUDED

--- a/include/imguix/themes/ThemeManager.hpp
+++ b/include/imguix/themes/ThemeManager.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#ifndef _IMGUIX_THEMES_THEME_MANAGER_HPP_INCLUDED
+#define _IMGUIX_THEMES_THEME_MANAGER_HPP_INCLUDED
+
+/// \file ThemeManager.hpp
+/// \brief Manages ImGui style themes.
+
+#include <imgui.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "Theme.hpp"
+
+namespace ImGuiX::Themes {
+
+    class ThemeManager {
+    public:
+        /// \brief Register theme under identifier.
+        /// \param id Theme identifier.
+        /// \param theme Theme instance.
+        void registerTheme(std::string id, std::unique_ptr<Theme> theme) {
+            m_themes.emplace(std::move(id), std::move(theme));
+        }
+
+        /// \brief Set active theme identifier.
+        /// \param id Identifier of registered theme.
+        void setTheme(std::string_view id) {
+            m_current.assign(id.begin(), id.end());
+        }
+
+        /// \brief Apply currently selected theme to style.
+        /// \param style Target ImGui style.
+        void updateCurrentTheme(ImGuiStyle& style) {
+            auto it = m_themes.find(m_current);
+            if (it != m_themes.end() && it->second) {
+                it->second->apply(style);
+            }
+        }
+
+    private:
+        std::unordered_map<std::string, std::unique_ptr<Theme>> m_themes;
+        std::string m_current;
+    };
+
+} // namespace ImGuiX::Themes
+
+#endif // _IMGUIX_THEMES_THEME_MANAGER_HPP_INCLUDED

--- a/include/imguix/themes/themes.hpp
+++ b/include/imguix/themes/themes.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#ifndef _IMGUIX_THEMES_THEMES_HPP_INCLUDED
+#define _IMGUIX_THEMES_THEMES_HPP_INCLUDED
+
+/// \file themes.hpp
+/// \brief Public header aggregating theme facilities.
+///
+/// Example usage:
+/// \code
+/// struct MyTheme : ImGuiX::Themes::Theme {
+///     void apply(ImGuiStyle& style) const override {
+///         style.FrameRounding = 0.0f;
+///     }
+/// };
+///
+/// class MyController : public ImGuiX::Controller {
+/// public:
+///     using Controller::Controller;
+///
+///     void onInit() {
+///         auto& tm = getThemeManager();
+///         tm.registerTheme("custom", std::make_unique<MyTheme>());
+///         tm.setTheme("custom");
+///     }
+/// };
+/// \endcode
+///
+/// A controller can register a custom theme and switch to it.
+
+#include <memory>
+
+#include "Theme.hpp"
+#include "ThemeManager.hpp"
+
+namespace ImGuiX::Themes {
+
+    inline void registerLightTheme(ThemeManager& mgr) {
+        mgr.registerTheme("light", std::make_unique<LightTheme>());
+    }
+
+    inline void registerDarkTheme(ThemeManager& mgr) {
+        mgr.registerTheme("dark", std::make_unique<DarkTheme>());
+    }
+
+    inline void setLightTheme(ThemeManager& mgr) {
+        mgr.setTheme("light");
+    }
+
+    inline void setDarkTheme(ThemeManager& mgr) {
+        mgr.setTheme("dark");
+    }
+
+} // namespace ImGuiX::Themes
+
+#endif // _IMGUIX_THEMES_THEMES_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- add base Theme interface and light/dark themes
- implement ThemeManager for registering and switching themes
- integrate theme manager with windows, controllers, and window manager loop
- expose theme manager via WindowInterface and restore window include order to avoid cycles

## Testing
- `git submodule update --init --recursive`
- `apt-get install -y libxrandr-dev libxcursor-dev libxi-dev`
- `apt-get install -y libgl1-mesa-dev libudev-dev`
- `cmake -S . -B build`
- `cmake --build build` *(fails: windowsx.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5bc8b2a8832cbc1960583cc68f23