### PR TITLE
refactor: move options save delay to config

### DIFF
--- a/include/imguix/config.hpp
+++ b/include/imguix/config.hpp
@@ -10,6 +10,7 @@
 #include "config/i18n.hpp"
 #include "config/icons.hpp"
 #include "config/colors.hpp"
+#include "config/options.hpp"
 #include "config/sizing.hpp"
 #include "config/theme_config.hpp"
 

--- a/include/imguix/config/options.hpp
+++ b/include/imguix/config/options.hpp
@@ -1,0 +1,11 @@
+#ifndef _IMGUIX_CONFIG_OPTIONS_HPP_INCLUDED
+#define _IMGUIX_CONFIG_OPTIONS_HPP_INCLUDED
+
+/// \file options.hpp
+/// \brief Options store configuration values.
+
+#ifndef IMGUIX_OPTIONS_SAVE_DELAY_SEC
+#   define IMGUIX_OPTIONS_SAVE_DELAY_SEC 0.5
+#endif
+
+#endif // _IMGUIX_CONFIG_OPTIONS_HPP_INCLUDED

--- a/include/imguix/core/options/OptionsStore.hpp
+++ b/include/imguix/core/options/OptionsStore.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include <imguix/config/options.hpp>
+
 #include "OptionsStoreViewCRTP.hpp"
 #include "OptionsStoreControlCRTP.hpp"
 
@@ -28,7 +30,9 @@ namespace ImGuiX {
         /// \brief Construct store.
         /// \param path JSON file path.
         /// \param save_delay_sec Debounce window for saving (seconds).
-        explicit OptionsStore(std::string path, double save_delay_sec = 0.5);
+        explicit OptionsStore(
+                std::string path,
+                double save_delay_sec = IMGUIX_OPTIONS_SAVE_DELAY_SEC);
         
         explicit OptionsStore();
 

--- a/include/imguix/core/options/OptionsStore.ipp
+++ b/include/imguix/core/options/OptionsStore.ipp
@@ -8,6 +8,7 @@
 #   include <emscripten.h>
 #endif
 
+#include <imguix/config/options.hpp>
 #include <imguix/config/paths.hpp>
 #include <imguix/utils/path_utils.hpp>
 
@@ -19,7 +20,7 @@ namespace ImGuiX {
     struct OptionsStore::Impl {
         std::string m_path;
         std::string m_tmp_path;
-        double m_save_delay{0.5};
+        double m_save_delay{IMGUIX_OPTIONS_SAVE_DELAY_SEC};
 
         mutable std::mutex m_mutex;
         json m_root = json::object();
@@ -177,7 +178,7 @@ namespace ImGuiX {
     
     inline OptionsStore::OptionsStore()
         : m_impl(std::make_unique<Impl>()) {
-        m_impl->m_save_delay = 0.5;
+        m_impl->m_save_delay = IMGUIX_OPTIONS_SAVE_DELAY_SEC;
 #ifdef __EMSCRIPTEN__
         const auto base_abs = ImGuiX::Utils::joinPaths(
                 "/imguix_fs",


### PR DESCRIPTION
## Summary
- add `IMGUIX_OPTIONS_SAVE_DELAY_SEC` macro
- use macro for OptionsStore save delay
- include new options config in aggregate `config.hpp`

## Testing
- `cmake -S . -B build` *(fails: could not find package configuration file provided by "SFML"; component 'System' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afad2ecb14832ca9262614b467bef9