### PR TITLE
feat(app): async IDBFS mount and load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if(EMSCRIPTEN)
+    add_link_options(-sASYNCIFY)
+    add_compile_definitions(IMGUIX_ASYNCIFY)
+endif()
+
 set(IMGUIX_USER_CONFIG_DIR  "${PROJECT_SOURCE_DIR}/include")
 set(IMGUIX_USER_CONFIG_NAME "imguix/config/imconfig-imguix.hpp")
 

--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -61,6 +61,7 @@ namespace ImGuiX {
         std::thread m_main_thread;                     ///< Thread running the main loop when async.
         std::atomic<bool> m_is_closing{false};         ///< Indicates shutdown in progress.
         std::atomic<bool> m_is_ini_once{false};        ///< Ensures imgui ini is saved only once.
+        std::atomic<bool> m_is_fs_ready{true};         ///< Set when filesystem mount completes.
 
         std::atomic<int> m_next_window_id{0};          ///< Incremental ID for new windows.
         std::string m_app_name = u8"ImGuiX Application"; ///< Application name string.
@@ -86,6 +87,14 @@ namespace ImGuiX {
 
         /// \brief Initializes all pending models.
         void initializePendingModels();
+
+        /// \brief Initialize persistent filesystem (no-op on native builds).
+        void initFilesystem();
+
+#ifdef __EMSCRIPTEN__
+        /// \brief Called when asynchronous filesystem mounting finishes.
+        static void filesystemReady(void* arg);
+#endif
     };
 
 } // namespace ImGuiX


### PR DESCRIPTION
## Summary
- mount persistent filesystem in Application constructor and wait for readiness before registering OptionsStore
- add initFilesystem helper and callback to handle IDBFS setup
- expose IMGUIX_ASYNCIFY flag when linking with Asyncify

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68afae99eba0832cb701579406e19d63