### PR TITLE
docs(cmake): clarify build scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.18)
 project(ImGuiX LANGUAGES CXX VERSION 0.1.0)
 
-# Normalize REAL_PATH behaviour (MSYS/Windows paths → native first)
+# ===== Root CMakeLists.txt =====
+# Purpose: Configure and build the ImGuiX library and optional SDK.
+# Inputs:  IMGUIX_* options and IMGUIX_DEPS_* modes, IMGUI_DIR
+# Outputs: target imguix and export ImGuiXTargets
+# Notes:   Select backend via IMGUIX_USE_*_BACKEND options.
+
+# Normalize REAL_PATH behavior so MSYS/Windows paths resolve to native form first
 if(POLICY CMP0152)
     cmake_policy(SET CMP0152 NEW)
 endif()
@@ -22,15 +28,17 @@ option(IMGUIX_IMGUI_FREETYPE   "Enable ImGui FreeType rasterizer" ON)
 # ImGui / ImPlot
 option(IMGUIX_USE_IMPLOT       "Build ImPlot and link it in" ON)
 
-# JSON vendoring (A by default = OFF -> искать внешнюю зависимость)
+# JSON vendoring (default OFF to prefer system package)
 option(IMGUIX_VENDOR_JSON      "Install vendored nlohmann_json headers with ImGuiX" OFF)
 
 option(IMGUIX_SDK_FLATTEN_MISC_HEADERS
-       "Also copy imgui_stdlib.h and imgui_freetype.h into include/ root" ON)
- 
-# SDK 
+    "Also copy imgui_stdlib.h and imgui_freetype.h into include/ root" ON)
+
+# SDK
+# Install SDK extras (quickstart, templates, assets)
 option(IMGUIX_SDK_INSTALL      "Устанавливать SDK-«добавки» (quickstart, шаблоны, ассеты)" ON)
 option(IMGUIX_SDK_BUNDLE_DEPS  "Install 3rd-party deps into SDK stage" ON)
+# Place quickstart template into SDK
 option(IMGUIX_SDK_INSTALL_QUICKSTART "Класть quickstart-шаблон в SDK" ON)
 
 # ===== Deps mode =====
@@ -55,9 +63,9 @@ set(IMGUIX_USER_CONFIG_NAME "imguix/config/imconfig-imguix.hpp")
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # --- std::string helpers for ImGui (imgui_stdlib) ---
-# Если пользователь не задал, выбираем дефолт:
-# - при SFML backend: OFF (ImGui-SFML уже тянет imgui_stdlib.cpp)
-# - иначе: ON
+# If user does not set the option, choose default:
+# - with SFML backend: OFF (ImGui-SFML already provides imgui_stdlib.cpp)
+# - otherwise: ON
 if(NOT DEFINED IMGUIX_IMGUI_STDLIB)
     set(_imgui_stdlib_default ON)
     if(IMGUIX_USE_SFML_BACKEND)
@@ -85,8 +93,8 @@ include(cmake/deps/app_icon.cmake)
 include(cmake/ImGuiXDemos.cmake)
 
 # ===== Resolve core deps =====
-imguix_use_or_fetch_fmt(FMT_TARGET)                 # ожидается fmt::fmt
-imguix_use_or_fetch_nlohmann_json(JSON_TARGET)      # всегда nlohmann_json::nlohmann_json (или алиас)
+imguix_use_or_fetch_fmt(FMT_TARGET)                 # Expect fmt::fmt
+imguix_use_or_fetch_nlohmann_json(JSON_TARGET)      # Always nlohmann_json::nlohmann_json or alias
 
 # ===== Resolve GUI/backend deps =====
 set(BACKEND_LIBS "")
@@ -107,7 +115,7 @@ else()
     set(IMGUI_LIB "${IMGUI_TARGET}")
 endif()
 
-# --- какой макрос бэкенда объявлять ---
+# --- Select backend define ---
 set(_IMGUIX_BACKEND_DEFINE "")
 if(IMGUIX_USE_SFML_BACKEND)
     set(_IMGUIX_BACKEND_DEFINE IMGUIX_USE_SFML_BACKEND)
@@ -127,15 +135,18 @@ if(IMGUIX_HEADER_ONLY)
     add_library(imguix INTERFACE)
     add_library(ImGuiX::imguix ALIAS imguix)
 
+    # BUILD_INTERFACE: headers from source tree during build
+    # INSTALL_INTERFACE: headers exposed after installation
     target_include_directories(imguix INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
         $<INSTALL_INTERFACE:include>
     )
-    
+
+    # Allow user configuration overrides via IMGUI_USER_CONFIG
     target_include_directories(imguix INTERFACE "${IMGUIX_USER_CONFIG_DIR}")
     target_compile_definitions(imguix INTERFACE IMGUI_USER_CONFIG="${IMGUIX_USER_CONFIG_NAME}")
 
-    # (Вариант B) — при вендоринге кладём json-хедеры и даём build-include на сабмодуль
+    # Variant B: when vendoring, add json headers to build include path
     if(IMGUIX_VENDOR_JSON)
         target_include_directories(imguix INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/libs/json/include>
@@ -150,14 +161,14 @@ if(IMGUIX_HEADER_ONLY)
 
     if(IMGUIX_IMGUI_FREETYPE)
         target_compile_definitions(imguix INTERFACE IMGUI_ENABLE_FREETYPE)
-        # НЕ линкуем freetype/SFML/ImGui-SFML в INTERFACE — их добавляет потребитель.
+        # Do not link freetype/SFML/ImGui-SFML in INTERFACE; consumers link them
     endif()
-    
+
     if(IMGUIX_USE_IMPLOT)
         target_compile_definitions(imguix INTERFACE IMGUI_ENABLE_IMPLOT)
     endif()
 
-    # Санитарная зачистка интерфейса (чтобы install(EXPORT ...) не тянул чужие цели)
+    # Clean interface to avoid exporting foreign targets
     set_property(TARGET imguix PROPERTY INTERFACE_LINK_LIBRARIES "")
 
 else()
@@ -181,13 +192,13 @@ else()
         set_target_properties(imguix PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
     endif()
 
-    # Все внешние зависимости — только PRIVATE (чтобы export не падал)
+    # Link external dependencies as PRIVATE to keep export minimal
     target_link_libraries(imguix
         PRIVATE fmt::fmt nlohmann_json::nlohmann_json
         PRIVATE ${IMGUI_LIB} ${BACKEND_LIBS}
     )
 
-    # Бэкенд-макрос должен участвовать в компиляции самого таргета
+    # Ensure backend define participates in this target's compilation
     if(_IMGUIX_BACKEND_DEFINE)
         target_compile_definitions(imguix PUBLIC ${_IMGUIX_BACKEND_DEFINE})
     endif()
@@ -195,39 +206,39 @@ else()
     if(IMGUIX_IMGUI_FREETYPE)
         target_compile_definitions(imguix PUBLIC IMGUI_ENABLE_FREETYPE)
 
-        # Нужен include-путь для imgui_freetype.h
+        # Require include path for imgui_freetype.h
         set(_IMGUI_DIR_LOCAL "${IMGUI_DIR}")
         if(NOT _IMGUI_DIR_LOCAL)
             set(_IMGUI_DIR_LOCAL "${PROJECT_SOURCE_DIR}/libs/imgui")
         endif()
         target_include_directories(imguix PRIVATE "${_IMGUI_DIR_LOCAL}/misc/freetype")
-        
-        # Путь к корню Dear ImGui (как ты делаешь для freetype)
+
+        # Resolve Dear ImGui root (same approach as for FreeType)
         set(_IMGUI_DIR_LOCAL "${IMGUI_DIR}")
         if(NOT _IMGUI_DIR_LOCAL)
             set(_IMGUI_DIR_LOCAL "${PROJECT_SOURCE_DIR}/libs/imgui")
         endif()
 
-        # Нужен include-путь для imgui_stdlib.h (misc/cpp)
+        # Require include path for imgui_stdlib.h (misc/cpp)
         target_include_directories(imguix PRIVATE "${_IMGUI_DIR_LOCAL}/misc/cpp")
 
         imguix_use_or_find_freetype(FREETYPE_TARGET)
         target_link_libraries(imguix PRIVATE ${FREETYPE_TARGET})
     endif()
 
-    # (Вариант B) — при вендоринге дадим build-include на сабмодуль json (для исходной сборки)
+    # Variant B: when vendoring, add build include for json submodule
     if(IMGUIX_VENDOR_JSON)
         target_include_directories(imguix PRIVATE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/libs/json/include>
         )
     endif()
-    
+
     if(IMGUIX_USE_IMPLOT)
         target_compile_definitions(imguix PUBLIC IMGUI_ENABLE_IMPLOT)
         target_link_libraries(imguix PRIVATE ${IMPLOT_TARGET})
     endif()
 
-    # Санитарная зачистка интерфейса (чтобы install(EXPORT ...) не тянул чужие цели)
+    # Clean interface to avoid exporting foreign targets
     set_property(TARGET imguix PROPERTY INTERFACE_LINK_LIBRARIES "")
 endif()
 
@@ -258,7 +269,7 @@ if(IMGUIX_BUILD_TESTS)
         target_include_directories(${TEST_NAME} PRIVATE
             "${CMAKE_CURRENT_LIST_DIR}/include"
         )
-        # Дать доступ к imgui_stdlib.h
+        # Provide access to imgui_stdlib.h
         target_include_directories(${TEST_NAME} PRIVATE 
             "${_IMGUI_DIR}/misc/cpp"
         )
@@ -280,18 +291,18 @@ if(IMGUIX_BUILD_TESTS)
             target_link_libraries(${TEST_NAME} PRIVATE implot::implot)
             imguix_add_implot_demo(${TEST_NAME})
         endif()
-        
+
         imguix_add_imgui_demo(${TEST_NAME})
 
         if(WIN32)
             target_link_libraries(${TEST_NAME} PRIVATE gdi32 user32 comctl32 dwmapi)
         endif()
 
-        # Копирование ассетов (POST_BUILD)
+        # Copy assets after build
         imguix_add_assets(${TEST_NAME}
             DEST_RUNTIME data
             DIRS ${PROJECT_SOURCE_DIR}/assets/data
-            EXCLUDE_DIRS web  # выкинет assets/data/web
+            EXCLUDE_DIRS web  # exclude assets/data/web
         )
 
         imguix_copy_and_embed_app_icon(${TEST_NAME})
@@ -316,13 +327,13 @@ install(TARGETS imguix
     INCLUDES DESTINATION include
 )
 
-# Публичные хедеры самой ImGuiX
+# Public headers of ImGuiX
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/imguix
         DESTINATION include)
 
-# (Вариант B) — вендорим json-хедеры по переключателю
+# Variant B: vendor json headers when enabled
 if(IMGUIX_VENDOR_JSON)
-    # Кладём в стандартный инклюд-путь, чтобы <nlohmann/json.hpp> работал из коробки
+    # Place headers so <nlohmann/json.hpp> works out of the box
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/libs/json/include/nlohmann
             DESTINATION include/nlohmann)
 endif()
@@ -340,14 +351,21 @@ configure_package_config_file(
 install(FILES ${CMAKE_BINARY_DIR}/ImGuiXConfig.cmake
         DESTINATION lib/cmake/ImGuiX)
 
-# Экспорт из build-дерева (для локальной проверки find_package)
+# Export from build tree for local find_package()
 export(EXPORT ImGuiXTargets
     NAMESPACE ImGuiX::
     FILE "${CMAKE_BINARY_DIR}/ImGuiXTargets.cmake")
-    
+
 # ===== SDK bundle of 3rd-party deps =====
 
-# Установка таргета с учётом PUBLIC_HEADER
+# Install target and optionally its PUBLIC_HEADER files
+# Params:
+# - tgt: target name to install
+# Behavior:
+# - Installs library and headers if PUBLIC_HEADER is defined
+# Usage:
+#   imguix_install_target_with_headers(imgui)
+# Idempotent: no-op if target is missing
 function(imguix_install_target_with_headers tgt)
     if(NOT TARGET ${tgt})
         return()
@@ -371,7 +389,7 @@ endfunction()
 
 
 if(IMGUIX_SDK_BUNDLE_DEPS)
-    # --- Dear ImGui: кладём только нужные .h, без служебных папок ---
+    # --- Dear ImGui: install only required headers, skip aux folders ---
     set(_IMGUI_DIR "${IMGUI_DIR}")
     if(NOT _IMGUI_DIR)
         set(_IMGUI_DIR "${PROJECT_SOURCE_DIR}/libs/imgui")
@@ -382,12 +400,12 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
             DIRECTORY "${_IMGUI_DIR}/"
             DESTINATION "include"
             FILES_MATCHING
-                # включаем только заголовки
+                # Include headers only
                 PATTERN "*.h"
-                # дополнительно берем хедеры из misc/cpp и misc/freetype
+                # Also take headers from misc/cpp and misc/freetype
                 PATTERN "misc/cpp/*.h"
                 PATTERN "misc/freetype/*.h"
-            # исключаем ненужные каталоги целиком
+            # Exclude irrelevant directories
             PATTERN ".git*"     EXCLUDE
             PATTERN ".github*"  EXCLUDE
             PATTERN "backends"  EXCLUDE
@@ -396,9 +414,9 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
             PATTERN "scripts"   EXCLUDE
             PATTERN "bindings"  EXCLUDE
         )
-        
+
         if(IMGUIX_SDK_FLATTEN_MISC_HEADERS)
-            # Дубли в корень include/ для простых инклюдов
+            # Duplicate misc headers into root include for simple includes
             if(EXISTS "${_IMGUI_DIR}/misc/cpp/imgui_stdlib.h")
                 install(FILES "${_IMGUI_DIR}/misc/cpp/imgui_stdlib.h"
                         DESTINATION "include")
@@ -411,7 +429,7 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
     endif()
 
 
-    # --- ImGui-SFML: статическая либa + заголовки ---
+    # --- ImGui-SFML: static library and headers ---
     if(TARGET ImGui-SFML)
         imguix_install_target_with_headers(ImGui-SFML)
         if(NOT DEFINED IMGUI_SFML_DIR OR IMGUI_SFML_DIR STREQUAL "")
@@ -425,7 +443,7 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
         endif()
     endif()
 
-    # --- fmt: либa + (на всякий) хедеры, если это сабмодуль ---
+    # --- fmt: library and headers if submodule ---
     if(TARGET fmt)
         if(DEFINED FMT_INSTALL AND FMT_INSTALL)
             message(STATUS "SDK: fmt installs itself (FMT_INSTALL=ON) — skipping manual header install")
@@ -438,15 +456,15 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
         endif()
     endif()
 
-    # --- nlohmann-json (header-only) — если вендорим ---
+    # --- nlohmann-json (header-only) when vendored ---
     if(IMGUIX_VENDOR_JSON)
         if(EXISTS "${PROJECT_SOURCE_DIR}/libs/json/include/nlohmann")
             install(DIRECTORY "${PROJECT_SOURCE_DIR}/libs/json/include/nlohmann"
                     DESTINATION include)
         endif()
     endif()
-    
-    # --- ImPlot: заголовки ---
+
+    # --- ImPlot: headers ---
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/implot/implot.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/implot/implot.h"
@@ -457,15 +475,15 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
 
 endif()
 
-# --- Quickstart и ресурсы quickstart (всегда под флагом IMGUIX_SDK_INSTALL) ---
+# --- Quickstart and resources (guarded by IMGUIX_SDK_INSTALL) ---
 if(IMGUIX_SDK_INSTALL AND IMGUIX_SDK_INSTALL_QUICKSTART)
-    # ресурсы, если нужны квикстарту
+    # Copy resources required by quickstart
     if(EXISTS "${PROJECT_SOURCE_DIR}/assets/data/resources")
         install(DIRECTORY "${PROJECT_SOURCE_DIR}/assets/data/resources/"
                 DESTINATION quickstart/data/resources)
     endif()
 
-    # сам quickstart-код, если он у тебя есть в репозитории
+    # Install quickstart code if present in repository
     if(EXISTS "${PROJECT_SOURCE_DIR}/quickstart/CMakeLists.txt")
         install(DIRECTORY "${PROJECT_SOURCE_DIR}/quickstart/"
                 DESTINATION quickstart

--- a/cmake/ImGuiXDemos.cmake
+++ b/cmake/ImGuiXDemos.cmake
@@ -1,5 +1,16 @@
-# cmake/ImGuiXDemos.cmake
+# ===== ImGuiXDemos.cmake =====
+# Purpose: Add Dear ImGui and ImPlot demo sources to a target.
+# Inputs:  IMGUI_DIR, IMPLOT_DIR
+# Outputs: none; modifies provided target
+# Notes:   Include after targets are declared.
 
+# Add Dear ImGui demo source to a target
+# Params:
+# - tgt: target to extend
+# Behavior:
+# - Adds imgui_demo.cpp if present, otherwise warns
+# Usage:
+#   imguix_add_imgui_demo(my_app)
 function(imguix_add_imgui_demo tgt)
     if(NOT TARGET ${tgt})
         message(FATAL_ERROR "Target ${tgt} not found")
@@ -14,6 +25,13 @@ function(imguix_add_imgui_demo tgt)
     endif()
 endfunction()
 
+# Add ImPlot demo source to a target
+# Params:
+# - tgt: target to extend
+# Behavior:
+# - Adds implot_demo.cpp if present, otherwise warns
+# Usage:
+#   imguix_add_implot_demo(my_app)
 function(imguix_add_implot_demo tgt)
     if(NOT TARGET ${tgt})
         message(FATAL_ERROR "Target ${tgt} not found")
@@ -27,3 +45,4 @@ function(imguix_add_implot_demo tgt)
         message(WARNING "implot_demo.cpp not found at ${IMPLOT_DIR}")
     endif()
 endfunction()
+

--- a/cmake/deps/app_icon.cmake
+++ b/cmake/deps/app_icon.cmake
@@ -1,11 +1,19 @@
-# cmake/deps/app_icon.cmake
+# ===== deps/app_icon.cmake =====
+# Purpose: Copy application icon resources and embed them on Windows.
+# Inputs:  SRC_DIR, RC, ICO, PNG
+# Outputs: modifies given target by adding resource and copying PNG
+# Notes:   No-op on non-Windows platforms.
+
+# Copy and embed application icon for a target
+# Params:
+# - target: target to augment
+# - SRC_DIR: directory with resources (default assets/data/resources/icons)
+# - RC: resource script path
+# - ICO: icon file path
+# - PNG: runtime PNG path
 # Usage:
-#   imguix_copy_and_embed_app_icon(<target>
-#       SRC_DIR <dir-with-rc-and-ico>   # default: ${PROJECT_SOURCE_DIR}/assets/data/resources/icons
-#       RC  <path-to-rc>                # optional
-#       ICO <path-to-ico>               # optional
-#       PNG <path-to-png>               # optional (copied to runtime)
-#   )
+#   imguix_copy_and_embed_app_icon(my_app SRC_DIR my/icons)
+# Idempotent: warns if resources are missing
 function(imguix_copy_and_embed_app_icon target)
     if(NOT WIN32)
         return()

--- a/cmake/deps/assets.cmake
+++ b/cmake/deps/assets.cmake
@@ -1,13 +1,18 @@
-# cmake/deps/assets.cmake
+# ===== deps/assets.cmake =====
+# Purpose: Copy asset directories to runtime or install locations.
+# Inputs:  DIRS, DEST_RUNTIME, EXCLUDE_DIRS, EXCLUDE_PATTERNS
+# Outputs: modifies given target or creates staging target
+# Notes:   EXCLUDE_PATTERNS are reserved for future use.
 
-# Copy arbitrary asset dirs to a target's runtime dir and/or install tree.
+# Copy asset directories to a target's runtime directory
+# Params:
+# - target: target to receive post-build asset copy
+# - DEST_RUNTIME: subdirectory under target runtime dir
+# - DIRS: list of source directories
+# - EXCLUDE_DIRS: subdirectories to remove after copy
 # Usage:
-# imguix_add_assets(<TARGET>
-#     DEST_RUNTIME <subdir-under-runtime>
-#     DIRS <dir1> [<dir2> ...]
-#     [EXCLUDE_DIRS <d1> <d2> ...]
-#     [EXCLUDE_PATTERNS <p1> <p2> ...]  # на будущее, ниже удаляем только EXCLUDE_DIRS
-# )
+#   imguix_add_assets(my_app DIRS data EXCLUDE_DIRS web)
+# Idempotent: no-op if target is missing
 function(imguix_add_assets target)
     set(options)
     set(oneValueArgs DEST_RUNTIME)
@@ -35,7 +40,7 @@ function(imguix_add_assets target)
             VERBATIM
         )
 
-        # Удаляем исключённые подпапки уже в runtime-папке
+        # Remove excluded subdirectories in runtime directory
         foreach(_ex IN LISTS IMGA_EXCLUDE_DIRS)
             add_custom_command(TARGET ${target} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E rm -rf "${_dst}/${_ex}"
@@ -47,12 +52,13 @@ function(imguix_add_assets target)
 endfunction()
 
 
-# One global copy for tests (avoids N copies per test)
+# Stage assets once for tests to avoid per-test copies
+# Params:
+# - SRC: source directory (default assets/data/resources)
+# - DEST: destination directory (default build/tests/data/resources)
 # Usage:
-#   imguix_stage_test_assets(
-#       SRC  <source-dir>   # default: ${PROJECT_SOURCE_DIR}/assets/data/resources
-#       DEST <dest-dir>     # default: ${CMAKE_BINARY_DIR}/tests/data/resources
-#   )
+#   imguix_stage_test_assets(SRC my/assets)
+# Idempotent: recreates staging target each run
 function(imguix_stage_test_assets)
     set(oneValueArgs SRC DEST)
     cmake_parse_arguments(AA "" "${oneValueArgs}" "" ${ARGN})

--- a/cmake/deps/fmt.cmake
+++ b/cmake/deps/fmt.cmake
@@ -1,5 +1,17 @@
-# cmake/deps/fmt.cmake
-# imguix_use_or_fetch_fmt(<out_target>)
+# ===== deps/fmt.cmake =====
+# Purpose: Provide fmt::fmt target from system, submodule, or FetchContent.
+# Inputs:  IMGUIX_DEPS_MODE, IMGUIX_DEPS_FMT_MODE, IMGUIX_SDK_BUNDLE_DEPS
+# Outputs: out_target receives fmt::fmt
+# Notes:   Prefers system package before bundled sources.
+
+# Resolve fmt dependency and return fmt::fmt
+# Params:
+# - out_target: variable to receive target name
+# Behavior:
+# - Reuses existing fmt::fmt, finds system package, or builds from source
+# Usage:
+#   imguix_use_or_fetch_fmt(FMT_TARGET)
+# Idempotent: reuse target if already available
 function(imguix_use_or_fetch_fmt out_target)
     # Resolve effective mode
     set(mode "${IMGUIX_DEPS_FMT_MODE}")

--- a/cmake/deps/freetype.cmake
+++ b/cmake/deps/freetype.cmake
@@ -1,7 +1,19 @@
-# cmake/deps/freetype.cmake
-# Выдаёт: out_target = freetype (или Freetype::Freetype)
+# ===== deps/freetype.cmake =====
+# Purpose: Provide Freetype target from system, submodule, or FetchContent.
+# Inputs:  IMGUIX_DEPS_MODE, IMGUIX_DEPS_FREETYPE_MODE, IMGUIX_FREETYPE_GIT_TAG
+# Outputs: out_target receives Freetype::Freetype or freetype
+# Notes:   Uses system package when available.
+
+# Resolve Freetype dependency
+# Params:
+# - out_target: variable to receive target name
+# Behavior:
+# - Reuses existing target, finds system package, or fetches from source
+# Usage:
+#   imguix_use_or_find_freetype(FREETYPE_TARGET)
+# Idempotent: reuse target if already created
 function(imguix_use_or_find_freetype out_target)
-  # 0) Уже есть цель (например, её собрал SFML)
+  # 0) Existing target (e.g., provided by SFML)
   if(TARGET Freetype::Freetype)
     set(${out_target} Freetype::Freetype PARENT_SCOPE)
     return()
@@ -11,14 +23,14 @@ function(imguix_use_or_find_freetype out_target)
     return()
   endif()
 
-  # 1) Попробуем пакет из системы
+  # 1) Try system package
   find_package(Freetype QUIET)
   if(Freetype_FOUND OR TARGET Freetype::Freetype)
     set(${out_target} Freetype::Freetype PARENT_SCOPE)
     return()
   endif()
 
-  # 2) Режимы (INHERIT => глобальный)
+  # 2) Modes (INHERIT uses global mode)
   set(mode "${IMGUIX_DEPS_FREETYPE_MODE}")
   if(mode STREQUAL "INHERIT" OR mode STREQUAL "")
     set(mode "${IMGUIX_DEPS_MODE}")
@@ -27,11 +39,11 @@ function(imguix_use_or_find_freetype out_target)
     message(FATAL_ERROR "Freetype not found in SYSTEM mode")
   endif()
 
-  # 3) Сабмодуль?
+  # 3) Submodule
   if(EXISTS "${CMAKE_SOURCE_DIR}/libs/freetype/CMakeLists.txt")
     add_subdirectory("${CMAKE_SOURCE_DIR}/libs/freetype"
                      "${CMAKE_BINARY_DIR}/libs/freetype" EXCLUDE_FROM_ALL)
-    # Официальные цели фритайпа:
+    # Official Freetype targets
     if(TARGET Freetype::Freetype)
       set(${out_target} Freetype::Freetype PARENT_SCOPE)
     elseif(TARGET freetype)
@@ -42,11 +54,11 @@ function(imguix_use_or_find_freetype out_target)
     return()
   endif()
 
-  # 4) FetchContent (как последний шанс)
+  # 4) FetchContent as last resort
   include(FetchContent)
   set(_ft_tag "${IMGUIX_FREETYPE_GIT_TAG}")
   if(NOT _ft_tag)
-    set(_ft_tag "VER-2-13-2")  # актуальную метку при необходимости поменять
+    set(_ft_tag "VER-2-13-2")  # update tag if needed
   endif()
   FetchContent_Declare(
     freetype_ext

--- a/cmake/deps/imgui_sfml.cmake
+++ b/cmake/deps/imgui_sfml.cmake
@@ -1,10 +1,18 @@
-# cmake/deps/imgui_sfml.cmake
-# Provide ImGui-SFML target and return it as both SFML-wrapper and IMGUI target.
+# ===== deps/imgui_sfml.cmake =====
+# Purpose: Build ImGui-SFML and expose it as both backend and ImGui target.
+# Inputs:  IMGUI_DIR, IMGUI_SFML_DIR, IMGUIX_IMGUI_FREETYPE
+# Outputs: out_sfml receives ImGui-SFML, out_imgui receives ImGui-SFML
+# Notes:   Links SFML and OpenGL; adds FreeType when enabled.
+
+# Build or reuse ImGui-SFML and return target names
+# Params:
+# - out_sfml: variable to receive ImGui-SFML target
+# - out_imgui: variable to receive ImGui target name
+# Behavior:
+# - Creates static ImGui-SFML library if missing
 # Usage:
-#   imguix_use_or_fetch_imgui_sfml(IMGUI_SFML_TARGET OUT_IMGUI_TARGET)
-# Output:
-#   IMGUI_SFML_TARGET = ImGui-SFML
-#   OUT_IMGUI_TARGET  = ImGui-SFML
+#   imguix_use_or_fetch_imgui_sfml(IMGUI_SFML_TARGET OUT_IMGUI)
+# Idempotent: reuses existing target
 function(imguix_use_or_fetch_imgui_sfml out_sfml out_imgui)
     # Resolve dirs
     if(NOT DEFINED IMGUI_DIR OR IMGUI_DIR STREQUAL "")
@@ -28,7 +36,7 @@ function(imguix_use_or_fetch_imgui_sfml out_sfml out_imgui)
         )
         add_library(ImGui-SFML::ImGui-SFML ALIAS ImGui-SFML)
 
-        # Public includes for consumers
+        # BUILD_INTERFACE: headers during build; INSTALL_INTERFACE: headers after install
         target_include_directories(ImGui-SFML PUBLIC
             $<BUILD_INTERFACE:${IMGUI_SFML_DIR}>
             $<INSTALL_INTERFACE:include>

--- a/cmake/deps/implot.cmake
+++ b/cmake/deps/implot.cmake
@@ -1,14 +1,24 @@
-# cmake/deps/implot.cmake
-# Собирает ImPlot из исходников (без демо), создаёт цель implot::implot
-# Зависит от imgui::imgui
+# ===== deps/implot.cmake =====
+# Purpose: Build ImPlot from sources and expose implot::implot target.
+# Inputs:  IMPLOT_DIR
+# Outputs: out_implot receives implot::implot
+# Notes:   Depends on imgui::imgui.
 
+# Build or reuse ImPlot and expose it as implot::implot
+# Params:
+# - out_implot: variable to receive target name
+# Behavior:
+# - Uses existing target or compiles from ${IMPLOT_DIR} without demo
+# Usage:
+#   imguix_use_or_fetch_implot(IMPLOT_TARGET)
+# Idempotent: reuse target if already created
 function(imguix_use_or_fetch_implot out_implot)
-    # Где лежит ImPlot (по умолчанию сабмодуль)
+    # Locate ImPlot directory (default to submodule)
     if(NOT DEFINED IMPLOT_DIR OR IMPLOT_DIR STREQUAL "")
         set(IMPLOT_DIR "${PROJECT_SOURCE_DIR}/libs/implot")
     endif()
 
-    # Если цель уже есть — вернуть её
+    # If target already exists, return it
     if(TARGET implot::implot)
         set(${out_implot} implot::implot PARENT_SCOPE)
         return()
@@ -18,7 +28,7 @@ function(imguix_use_or_fetch_implot out_implot)
         return()
     endif()
 
-    # Убедимся, что есть imgui::imgui (создаём, если нет)
+    # Ensure imgui::imgui exists (create if missing)
     if(NOT TARGET imgui::imgui)
         if(COMMAND imguix_use_or_fetch_imgui)
             imguix_use_or_fetch_imgui(_IMGUI_TGT)
@@ -29,7 +39,7 @@ function(imguix_use_or_fetch_implot out_implot)
         set(_IMGUI_TGT imgui::imgui)
     endif()
 
-    # Исходники ImPlot (демо-файл не включаем)
+    # ImPlot sources (exclude demo file)
     set(_src
         "${IMPLOT_DIR}/implot.cpp"
         "${IMPLOT_DIR}/implot_items.cpp"
@@ -38,16 +48,17 @@ function(imguix_use_or_fetch_implot out_implot)
     add_library(implot STATIC ${_src})
     add_library(implot::implot ALIAS implot)
 
+    # BUILD_INTERFACE: headers during build; INSTALL_INTERFACE: after install
     target_include_directories(implot
         PUBLIC
             $<BUILD_INTERFACE:${IMPLOT_DIR}>
             $<INSTALL_INTERFACE:include>
     )
 
-    # ImPlot зависит от Dear ImGui
+    # ImPlot depends on Dear ImGui
     target_link_libraries(implot PUBLIC ${_IMGUI_TGT})
 
-    # Опциональные предупреждения
+    # Optional warnings
     if(MSVC)
         target_compile_options(implot PRIVATE /W3)
     else()

--- a/cmake/deps/mdbx.cmake
+++ b/cmake/deps/mdbx.cmake
@@ -1,5 +1,17 @@
-# cmake/deps/mdbx.cmake
-# imguix_use_or_fetch_mdbx(<out_target>)
+# ===== deps/mdbx.cmake =====
+# Purpose: Provide libmdbx target via system package, submodule, or FetchContent.
+# Inputs:  IMGUIX_DEPS_MODE, IMGUIX_DEPS_MDBX_MODE, IMGUIX_SDK_BUNDLE_DEPS
+# Outputs: out_target receives mdbx::mdbx
+# Notes:   Prefers existing targets or system packages before bundling.
+
+# Resolve libmdbx dependency and return mdbx::mdbx
+# Params:
+# - out_target: variable to receive target name
+# Behavior:
+# - Uses existing target, system package, submodule, or FetchContent
+# Usage:
+#   imguix_use_or_fetch_mdbx(MDBX_TARGET)
+# Idempotent: reuse target if already created
 function(imguix_use_or_fetch_mdbx out_target)
     # ---- Effective mode ----
     set(mode "${IMGUIX_DEPS_MDBX_MODE}")
@@ -51,22 +63,22 @@ function(imguix_use_or_fetch_mdbx out_target)
     # ---- BUNDLED/AUTO: submodule? ----
     set(_MDBX_SRC "${PROJECT_SOURCE_DIR}/libs/libmdbx")
     if(EXISTS "${_MDBX_SRC}/CMakeLists.txt")
-        # Нормализуем путь до абсолютного Windows-стиля (D:/...) — важно для MSYS/MinGW
+        # Normalize path to absolute Windows style for MSYS/MinGW
         if(WIN32)
             get_filename_component(_MDBX_SRC_REAL "${_MDBX_SRC}" REALPATH)
         else()
             set(_MDBX_SRC_REAL "${_MDBX_SRC}")
         endif()
         
-        # Build options BEFORE add_subdirectory
+        # Build options before add_subdirectory
         set(MDBX_BUILD_SHARED_LIBRARY OFF CACHE BOOL "" FORCE)
         set(MDBX_BUILD_TOOLS          OFF CACHE BOOL "" FORCE)
         if(IMGUIX_SDK_BUNDLE_DEPS)
-            # чтобы install() сабпроекта поставил статическую либу (+заголовки у них тоже инсталлятся)
+            # Let subproject install static library and headers
             set(MDBX_INSTALL_STATIC ON CACHE BOOL "" FORCE)
         endif()
         
-        # Если в дереве случайно лежит VERSION.json — удаляем, чтобы источником был git
+        # Remove stray VERSION.json so git metadata defines version
         if(EXISTS "${_MDBX_SRC_REAL}/VERSION.json")
             file(REMOVE "${_MDBX_SRC_REAL}/VERSION.json")
             message(STATUS "libmdbx: removed stray VERSION.json (using git metadata)")
@@ -89,7 +101,7 @@ function(imguix_use_or_fetch_mdbx out_target)
 
     # ---- Fallback: FetchContent ----
     include(FetchContent)
-    # Options must be set BEFORE MakeAvailable
+    # Options must be set before MakeAvailable
     set(MDBX_BUILD_SHARED_LIBRARY OFF CACHE BOOL "" FORCE)
     set(MDBX_BUILD_TOOLS          OFF CACHE BOOL "" FORCE)
     if(IMGUIX_SDK_BUNDLE_DEPS)

--- a/cmake/deps/nlohmann_json.cmake
+++ b/cmake/deps/nlohmann_json.cmake
@@ -1,13 +1,26 @@
-# cmake/deps/nlohmann_json.cmake
+# ===== deps/nlohmann_json.cmake =====
+# Purpose: Provide nlohmann_json target from system or submodule.
+# Inputs:  IMGUIX_DEPS_MODE, IMGUIX_DEPS_JSON_MODE
+# Outputs: out_target receives nlohmann_json::nlohmann_json
+# Notes:   FetchContent block is commented out and requires network.
+
+# Resolve nlohmann_json dependency
+# Params:
+# - out_target: variable to receive target name
+# Behavior:
+# - Uses system package or project submodule
+# Usage:
+#   imguix_use_or_fetch_nlohmann_json(JSON_TARGET)
+# Idempotent: reuse target if already available
 function(imguix_use_or_fetch_nlohmann_json out_target)
-  # 0) Система
+  # 0) System package
   find_package(nlohmann_json CONFIG QUIET)
   if(TARGET nlohmann_json::nlohmann_json)
     set(${out_target} nlohmann_json::nlohmann_json PARENT_SCOPE)
     return()
   endif()
 
-  # 1) Режимы
+  # 1) Resolve mode
   set(mode "${IMGUIX_DEPS_JSON_MODE}")
   if(mode STREQUAL "INHERIT" OR mode STREQUAL "")
     set(mode "${IMGUIX_DEPS_MODE}")
@@ -16,12 +29,12 @@ function(imguix_use_or_fetch_nlohmann_json out_target)
     message(FATAL_ERROR "nlohmann_json not found in SYSTEM mode")
   endif()
 
-  # 2) Сабмодуль
+  # 2) Submodule
   if(EXISTS "${CMAKE_SOURCE_DIR}/libs/json/CMakeLists.txt")
     add_subdirectory("${CMAKE_SOURCE_DIR}/libs/json"
                      "${CMAKE_BINARY_DIR}/libs/json" EXCLUDE_FROM_ALL)
   else()
-    # 3) (опционально) FetchContent — если разрешишь сеть
+    # 3) Optional FetchContent (uncomment to enable network fetch)
     # include(FetchContent)
     # FetchContent_Declare(nlohmann_json
     #   GIT_REPOSITORY https://github.com/nlohmann/json.git
@@ -31,7 +44,7 @@ function(imguix_use_or_fetch_nlohmann_json out_target)
     message(FATAL_ERROR "nlohmann_json: no system package and no submodule at libs/json")
   endif()
 
-  # 4) Нормализуем имя цели → импортное
+  # 4) Normalize target name to imported style
   if(TARGET nlohmann_json::nlohmann_json)
     set(${out_target} nlohmann_json::nlohmann_json PARENT_SCOPE)
   elseif(TARGET nlohmann_json)

--- a/cmake/deps/sfml.cmake
+++ b/cmake/deps/sfml.cmake
@@ -1,9 +1,17 @@
-# cmake/deps/sfml.cmake
-# Idempotent helper to provide SFML targets (Graphics, Window, System).
+# ===== deps/sfml.cmake =====
+# Purpose: Provide SFML targets (Graphics, Window, System) from submodule or system.
+# Inputs:  IMGUIX_SFML_SRC_DIR
+# Outputs: out_targets receives "SFML::Graphics;SFML::Window;SFML::System"
+# Notes:   Ensures idempotent addition.
+
+# Resolve SFML dependency
+# Params:
+# - out_targets: variable to receive semicolon-separated target list
+# Behavior:
+# - Reuses existing targets, adds submodule, or finds system package
 # Usage:
-#   imguix_use_or_fetch_sfml(SFML_TARGETS_VAR)
-# Output:
-#   SFML_TARGETS_VAR = "SFML::Graphics;SFML::Window;SFML::System"
+#   imguix_use_or_fetch_sfml(SFML_TARGETS)
+# Idempotent: guarded by global property
 function(imguix_use_or_fetch_sfml out_targets)
     # Already available?
     if(TARGET SFML::Graphics AND TARGET SFML::Window AND TARGET SFML::System)

--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -3,29 +3,35 @@ project(imguix_quickstart LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Укажи SDK префикс через CMAKE_PREFIX_PATH:
+# ===== examples/quickstart/CMakeLists.txt =====
+# Purpose: Build the quickstart sample using the ImGuiX SDK.
+# Inputs:  IMGUIX_SDK_DIR, CMAKE_PREFIX_PATH
+# Outputs: executable imguix_quickstart
+# Notes:   Serves as a template for SDK consumers.
+
+# Specify SDK prefix via CMAKE_PREFIX_PATH:
 #   cmake -S . -B build -DCMAKE_PREFIX_PATH=".../sdk"
 find_package(ImGuiX REQUIRED)
 
 add_executable(imguix_quickstart main.cpp)
 target_link_libraries(imguix_quickstart PRIVATE ImGuiX::imguix)
 
-# Так как ImGuiX линкует SFML/ImGui-SFML приватно, подтянем инклюды/библиотеки SDK в потребителе:
-# Вариант 1: передать путь явно переменной при конфиге:
+# ImGuiX links SFML/ImGui-SFML privately; add SDK includes/libs here.
+# Option 1: pass path explicitly at configure time:
 #   cmake -S . -B build -DIMGUIX_SDK_DIR=".../sdk"
 if(DEFINED IMGUIX_SDK_DIR)
     target_include_directories(imguix_quickstart PRIVATE "${IMGUIX_SDK_DIR}/include")
     target_link_directories(imguix_quickstart PRIVATE "${IMGUIX_SDK_DIR}/lib")
 endif()
 
-# Вариант 2: вывести префикс из найденного пакета (работает, если структура стандартная)
+# Option 2: derive prefix from found package (works with standard layout)
 if(NOT DEFINED IMGUIX_SDK_DIR AND DEFINED ImGuiX_DIR)
     get_filename_component(_imx_prefix "${ImGuiX_DIR}/../.." ABSOLUTE)
     target_include_directories(imguix_quickstart PRIVATE "${_imx_prefix}/include")
     target_link_directories(imguix_quickstart PRIVATE "${_imx_prefix}/lib")
 endif()
 
-# MinGW/Windows: статический SFML + зависимости линковки
+# MinGW/Windows: link static SFML and system dependencies
 if(MINGW)
     target_link_libraries(imguix_quickstart PRIVATE
         sfml-graphics-s sfml-window-s sfml-system-s ImGui-SFML freetype


### PR DESCRIPTION
## Summary
- document top-level CMake options and backend selection
- translate and clarify dependency helper modules
- add explanatory comment headers and function docblocks
- normalize indentation in root build script and ImGui helper
- fix header-only section indentation
- align backend define comment with global scope

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68afaf43bd14832cb3f70b3e5012ec39