### PR TITLE
feat: add linux support for sfml framed window

### DIFF
--- a/include/imguix/windows/ImGuiFramedWindow.hpp
+++ b/include/imguix/windows/ImGuiFramedWindow.hpp
@@ -76,19 +76,19 @@ namespace ImGuiX::Windows {
 #       ifdef IMGUIX_USE_SFML_BACKEND
         int m_prev_width = -1;   ///< Width before entering fullscreen.
         int m_prev_height = -1;  ///< Height before entering fullscreen.
+        bool applyCommonWindowSetup();
 #       ifdef _WIN32
         RECT m_minimize_btn_rect = {0}; ///< Rectangle of the minimize button.
         RECT m_maximize_btn_rect = {0}; ///< Rectangle of the maximize button.
         RECT m_close_btn_rect = {0};    ///< Rectangle of the close button.
         bool m_in_manual_sizing = false; ///< True while resizing manually.
         void setupWindowEffects(HWND hwnd);
-        bool applyCommonWindowSetup();
         void applyRoundedRegion(HWND hwnd, int width, int height, int radius);
         static LRESULT CALLBACK SubclassProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
                                      UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
-#       endif
     public:
         LRESULT WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+#       endif
 #       endif
     
     protected:


### PR DESCRIPTION
## Summary
- guard Windows-only APIs and include a Linux path for `ImGuiFramedWindow`
- add Linux implementation of `applyCommonWindowSetup` for SFML backend

## Testing
- `cmake -S . -B build -GNinja` *(passes)*
- `cmake --build build` *(fails: imgui-SFML.cpp operator!=)*


------
https://chatgpt.com/codex/tasks/task_e_68afb52b6d00832ca7576bd39c6b7d0f