### PR TITLE
docs(core): normalize Doxygen comments

### DIFF
--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -51,7 +51,14 @@ namespace ImGuiX {
         const std::string& name() const override;
 
     protected:
+        /// \brief Create window via factory.
+        /// \param factory Factory producing window instance.
+        /// \return Reference to created window.
         WindowInstance& createWindowImpl(WindowFactory factory) override;
+
+        /// \brief Create model via factory.
+        /// \param factory Factory producing model instance.
+        /// \return Reference to created model.
         Model& createModelImpl(ModelFactory factory) override;
 
     private:
@@ -93,6 +100,7 @@ namespace ImGuiX {
 
 #ifdef __EMSCRIPTEN__
         /// \brief Called when asynchronous filesystem mounting finishes.
+        /// \param arg User data pointer.
         static void filesystemReady(void* arg);
 #endif
     };

--- a/include/imguix/core/events/ApplicationExitEvent.hpp
+++ b/include/imguix/core/events/ApplicationExitEvent.hpp
@@ -10,12 +10,15 @@ namespace ImGuiX::Events {
     /// \brief Emitted when the application requests a full shutdown.
     class ApplicationExitEvent : public Pubsub::Event {
     public:
+        /// \brief Construct event.
         ApplicationExitEvent() = default;
 
+        /// \copydoc Pubsub::Event::type
         std::type_index type() const override {
             return typeid(ApplicationExitEvent);
         }
 
+        /// \copydoc Pubsub::Event::name
         const char* name() const override {
             return u8"ApplicationExitEvent";
         }

--- a/include/imguix/core/events/LangChangeEvent.hpp
+++ b/include/imguix/core/events/LangChangeEvent.hpp
@@ -26,6 +26,8 @@ namespace ImGuiX::Events {
             , window_id(target_window_id) {}
 
         /// \brief Factory helper that targets all windows.
+        /// \param language Language code to set.
+        /// \return Configured event.
         static LangChangeEvent ForAll(std::string language) {
             return LangChangeEvent(std::move(language), /*to_all=*/true, /*target_window_id=*/-1);
         }
@@ -33,14 +35,17 @@ namespace ImGuiX::Events {
         /// \brief Factory helper that targets a single window.
         /// \param language Language code to set.
         /// \param target_window_id ID of the window that should change its language.
+        /// \return Configured event.
         static LangChangeEvent ForWindow(std::string language, int target_window_id) {
             return LangChangeEvent(std::move(language), /*to_all=*/false, target_window_id);
         }
 
+        /// \copydoc Pubsub::Event::type
         std::type_index type() const override {
             return typeid(LangChangeEvent);
         }
 
+        /// \copydoc Pubsub::Event::name
         const char* name() const override {
             return u8"LangChangeEvent";
         }

--- a/include/imguix/core/events/LogEvent.hpp
+++ b/include/imguix/core/events/LogEvent.hpp
@@ -13,7 +13,9 @@
 #define IMGUIX_FUNCTION __func__
 #endif
 
-/// \brief Helper macro to emit a LogEvent.
+/// \brief Emit a LogEvent with source metadata.
+/// \param LVL Log level.
+/// \param MSG Log message.
 #define IMGUIX_LOG_EVENT(LVL, MSG)                                             \
   ImGuiX::Events::LogEvent((LVL), (MSG), __FILE__, __LINE__, IMGUIX_FUNCTION)
 
@@ -24,6 +26,8 @@ namespace ImGuiX::Events {
     enum class LogLevel { Trace, Debug, Info, Warn, Error, Fatal };
 
     /// \brief Convert level to short string.
+    /// \param level Severity level.
+    /// \return Null-terminated level string.
     inline const char *levelToCStr(LogLevel level) noexcept {
       switch (level) {
       case LogLevel::Trace:
@@ -45,19 +49,27 @@ namespace ImGuiX::Events {
     /// \brief Event containing log message and source metadata.
     class LogEvent : public Pubsub::Event {
     public:
-      LogLevel level;       ///< Severity level
-      std::string message;  ///< Log text
-      const char *file;     ///< Source file
-      int line;             ///< Source line
-      const char *function; ///< Function signature
+      LogLevel level;       ///< Severity level.
+      std::string message;  ///< Log text.
+      const char *file;     ///< Source file.
+      int line;             ///< Source line.
+      const char *function; ///< Function signature.
 
+      /// \brief Construct log event.
+      /// \param lvl Severity level.
+      /// \param msg Log text.
+      /// \param file Source file.
+      /// \param line Source line.
+      /// \param func Function signature.
       LogEvent(LogLevel lvl, std::string msg, const char *file, int line,
                const char *func)
           : level(lvl), message(std::move(msg)), file(file), line(line),
             function(func) {}
 
+      /// \copydoc Pubsub::Event::type
       std::type_index type() const override { return typeid(LogEvent); }
 
+      /// \copydoc Pubsub::Event::name
       const char *name() const override { return u8"LogEvent"; }
     };
 

--- a/include/imguix/core/events/WindowClosedEvent.hpp
+++ b/include/imguix/core/events/WindowClosedEvent.hpp
@@ -13,13 +13,18 @@ namespace ImGuiX::Events {
         int id; ///< ID of the closed window.
         std::string window_name; ///< Name of the closed window (for debugging).
 
+        /// \brief Construct event.
+        /// \param id ID of the closed window.
+        /// \param name Window name for debugging.
         WindowClosedEvent(int id, std::string name)
             : id(id), window_name(std::move(name)) {}
 
+        /// \copydoc Pubsub::Event::type
         std::type_index type() const override {
             return typeid(WindowClosedEvent);
         }
 
+        /// \copydoc Pubsub::Event::name
         const char* name() const override {
             return u8"WindowClosedEvent";
         }

--- a/include/imguix/core/options/OptionsStore.hpp
+++ b/include/imguix/core/options/OptionsStore.hpp
@@ -19,7 +19,8 @@ namespace ImGuiX {
 
     /// \class OptionsStore
     /// \brief Durable JSON-backed key-value options storage.
-    /// \note Thread-safe. Call update() periodically to perform debounced saves.
+    /// \thread_safety Thread-safe.
+    /// \note Call update() periodically to perform debounced saves.
     class OptionsStore :
         private OptionsStoreViewCRTP<OptionsStore>,
         private OptionsStoreControlCRTP<OptionsStore> {
@@ -34,8 +35,10 @@ namespace ImGuiX {
                 std::string path,
                 double save_delay_sec = IMGUIX_OPTIONS_SAVE_DELAY_SEC);
         
+        /// \brief Construct store using default path from configuration.
         explicit OptionsStore();
 
+        /// \brief Destroy store.
         ~OptionsStore();
 
         /// \brief Load from disk (best-effort). Keeps existing values on failure.

--- a/include/imguix/core/resource/ResourceRegistry.hpp
+++ b/include/imguix/core/resource/ResourceRegistry.hpp
@@ -22,6 +22,7 @@ namespace ImGuiX {
 
     /// \class ResourceRegistry
     /// \brief Manage registration and access to shared resources in a threadsafe manner.
+    /// \thread_safety Thread-safe.
     /// \note Stores type-erased shared resources and ensures only one instance per type.
     /// \note Access during registration throws or returns `nullopt`.
     class ResourceRegistry {

--- a/include/imguix/core/themes/Theme.hpp
+++ b/include/imguix/core/themes/Theme.hpp
@@ -14,21 +14,26 @@
 
 namespace ImGuiX::Themes {
 
-    /// \berif
+    /// \brief Interface for style themes.
     class Theme {
     public:
         virtual ~Theme() = default;
 
+        /// \brief Apply theme to ImGui style.
+        /// \param style Style to modify.
         virtual void apply(ImGuiStyle& style) const = 0;
 
 #       ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme to ImPlot style.
+        /// \param style Style to modify.
         virtual void apply(ImPlotStyle& style) const = 0;
 #       endif
 
     };
-    
-    /// \brief Устанавливает базовые параметры оформления для ImGui.
-    /// \details Применяется всеми темами как стартовое состояние перед наложением цветовой схемы.
+
+    /// \brief Set baseline ImGui style parameters.
+    /// \param style Style to modify.
+    /// \details Used by all themes before applying color scheme.
     inline void applyDefaultImGuiStyle(ImGuiStyle& style) {
         using namespace ImGuiX::Config;
 
@@ -51,46 +56,52 @@ namespace ImGuiX::Themes {
         style.GrabRounding      = GRAB_ROUNDING;
     }
     
-    /// \berif
+    /// \brief Classic ImGui theme.
     class ClassicTheme final : public Theme {
     public:
+        /// \copydoc Theme::apply
         void apply(ImGuiStyle& style) const override {
             ImGui::StyleColorsClassic(&style);
             applyDefaultImGuiStyle(style);
         }
-    
+
 #       ifdef IMGUI_ENABLE_IMPLOT
+        /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsClassic(&style);
         }
 #       endif
     };
-    
-    /// \berif
+
+    /// \brief Light color theme.
     class LightTheme final : public Theme {
     public:
+        /// \copydoc Theme::apply
         void apply(ImGuiStyle& style) const override {
             ImGui::StyleColorsLight(&style);
             applyDefaultImGuiStyle(style);
         }
-    
+
 #       ifdef IMGUI_ENABLE_IMPLOT
+        /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsLight(&style);
         }
 #       endif
     };
 
-    /// \berif
+    /// \brief Dark color theme.
     class DarkTheme final : public Theme {
     public:
 
+        /// \copydoc Theme::apply
         void apply(ImGuiStyle& style) const override {
             ImGui::StyleColorsDark(&style);
             applyDefaultImGuiStyle(style);
         }
-        
+
 #       ifdef IMGUI_ENABLE_IMPLOT
+        /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsDark(&style);
         }

--- a/include/imguix/core/themes/ThemeManager.hpp
+++ b/include/imguix/core/themes/ThemeManager.hpp
@@ -19,12 +19,21 @@
 
 namespace ImGuiX::Themes {
 
+    /// \brief Manage registration and application of themes.
     class ThemeManager {
     public:
-        
-        /// \brief Register theme under identifier. 
-        /// \param id Theme identifier. 
+
+        /// \brief Construct manager with built-in themes.
+        ThemeManager() {
+            registerTheme("classic", std::make_unique<ClassicTheme>());
+            registerTheme("light",   std::make_unique<LightTheme>());
+            registerTheme("dark",    std::make_unique<DarkTheme>());
+        }
+
+        /// \brief Register theme under identifier.
+        /// \param id Theme identifier.
         /// \param theme Theme instance.
+        /// \return True if existing theme was replaced.
         bool registerTheme(std::string id, std::unique_ptr<Theme> theme) {
             bool replaced = (m_themes.find(id) != m_themes.end());
             m_themes.insert_or_assign(id, std::move(theme));
@@ -32,10 +41,16 @@ namespace ImGuiX::Themes {
             return replaced;
         }
 
+        /// \brief Check whether theme is registered.
+        /// \param id Theme identifier.
+        /// \return True if theme exists.
         bool hasTheme(const std::string& id) const {
             return m_themes.find(id) != m_themes.end();
         }
 
+        /// \brief Remove theme by identifier.
+        /// \param id Theme identifier.
+        /// \return Removed theme or null.
         std::unique_ptr<Theme> unregisterTheme(const std::string& id) {
             auto it = m_themes.find(id);
             if (it == m_themes.end()) return {};
@@ -45,7 +60,7 @@ namespace ImGuiX::Themes {
             return old;
         }
 
-        /// \brief Set active theme identifier. 
+        /// \brief Set active theme identifier.
         /// \param id Identifier of registered theme.
         void setTheme(std::string id) {
             m_current = std::move(id);
@@ -62,12 +77,6 @@ namespace ImGuiX::Themes {
 #               endif
             }
             m_dirty = false;
-        }
-
-        ThemeManager() {
-            registerTheme("classic", std::make_unique<ClassicTheme>());
-            registerTheme("light",   std::make_unique<LightTheme>());
-            registerTheme("dark",    std::make_unique<DarkTheme>());
         }
 
     private:


### PR DESCRIPTION
## Summary
- refine OptionsStore docs with thread-safety tag and default construction notes
- expand event helpers and logging macros with complete parameter documentation
- clarify theme interfaces and manager behaviour in Doxygen

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afb62b55a8832cb116ddbfc60e11b3