### PR TITLE
docs(auth): normalize widget Doxygen comments

### DIFF
--- a/include/imguix/widgets/auth/auth_js_panel.hpp
+++ b/include/imguix/widgets/auth/auth_js_panel.hpp
@@ -23,7 +23,7 @@ namespace ImGuiX::Widgets {
         // Panel
         ImVec2      panel_size = ImVec2(0.0f, 0.0f); ///< x<=0: fill available width; y<=0: auto-computed
         bool        inputs_fill_width = true;        ///< make input fields fill panel width
-        bool        border            = true;
+        bool        border            = true;       ///< draw panel border
 
         // Labels / hints
         std::string header               = u8"JS Config";

--- a/include/imguix/widgets/auth/auth_panel.hpp
+++ b/include/imguix/widgets/auth/auth_panel.hpp
@@ -31,21 +31,40 @@ namespace ImGuiX::Widgets {
         ConnectClicked   = 1u << 6
     };
 
+    /// \brief Combine two result masks.
+    /// \param a Left operand.
+    /// \param b Right operand.
+    /// \return Bitwise OR of a and b.
     inline AuthPanelResult operator|(AuthPanelResult a, AuthPanelResult b) {
         return static_cast<AuthPanelResult>(static_cast<unsigned>(a) | static_cast<unsigned>(b));
     }
-    
+
+    /// \brief Intersect two result masks.
+    /// \param a Left operand.
+    /// \param b Right operand.
+    /// \return Bitwise AND of a and b.
     inline AuthPanelResult operator&(AuthPanelResult a, AuthPanelResult b) {
         return static_cast<AuthPanelResult>(static_cast<unsigned>(a) & static_cast<unsigned>(b));
     }
-    
+
+    /// \brief Add flags from b to a.
+    /// \param a Mask to modify.
+    /// \param b Flags to add.
+    /// \return Reference to a after modification.
     inline AuthPanelResult& operator|=(AuthPanelResult& a, AuthPanelResult b) { a = a | b; return a; }
 
+    /// \brief Check if any flag is set.
+    /// \param r Result mask.
+    /// \return True if r is non-zero.
     inline bool Any(ImGuiX::Widgets::AuthPanelResult r) noexcept {
         using U = std::underlying_type_t<ImGuiX::Widgets::AuthPanelResult>;
         return static_cast<U>(r) != 0u;
     }
 
+    /// \brief Check if r contains flag f.
+    /// \param r Result mask.
+    /// \param f Flag mask to test.
+    /// \return True if r has all bits from f.
     inline bool Has(ImGuiX::Widgets::AuthPanelResult r,
                     ImGuiX::Widgets::AuthPanelResult f) noexcept {
         using U = std::underlying_type_t<ImGuiX::Widgets::AuthPanelResult>;

--- a/include/imguix/widgets/auth/domain_selector.hpp
+++ b/include/imguix/widgets/auth/domain_selector.hpp
@@ -16,14 +16,14 @@ namespace ImGuiX::Widgets {
         // Panel
         ImVec2      panel_size = ImVec2(0.0f, 0.0f); ///< x<=0: fill available width; y<=0: auto-computed
         bool        inputs_fill_width = true;        ///< make input fields fill panel width
-        bool        border            = true;
+        bool        border            = true;       ///< draw panel border
         
         std::string header       = u8"Domain";
         std::string hint_domain  = u8"domain";
         std::string custom_text  = u8"Custom";
         std::string default_domain;
         std::string help_text;
-        bool        show_help    = false;
+        bool        show_help    = false;           ///< show help marker
 
         /// \brief List of predefined domains. If empty, InputTextWithVKValidated is used directly.
         std::vector<std::string> domains;

--- a/include/imguix/widgets/auth/proxy_panel.hpp
+++ b/include/imguix/widgets/auth/proxy_panel.hpp
@@ -21,12 +21,12 @@ namespace ImGuiX::Widgets {
 
     /// \brief Mutable model of proxy settings.
     struct ProxySettings {
-        bool        use_proxy      = false;
+        bool        use_proxy      = false;            ///< use proxy
         std::string ip;            ///< host or IPv4 string
-        int         port           = 0;        ///< 0..65535
-        ProxyType   type           = ProxyType::HTTP;
-        std::string username;
-        std::string password;
+        int         port           = 0;                ///< 0..65535
+        ProxyType   type           = ProxyType::HTTP;  ///< proxy protocol type
+        std::string username;                         ///< authentication username
+        std::string password;                         ///< authentication password
         
         bool ip_valid        = true; ///< out (set by widget if cfg.validate_ip)
         bool port_valid      = true; ///< out
@@ -38,7 +38,7 @@ namespace ImGuiX::Widgets {
     struct ProxyPanelConfig {
         ImVec2 panel_size             = ImVec2(0, 0); ///< 0→auto width/height
         bool   inputs_fill_width      = true;         ///< make input fields fill panel width
-        bool   border                 = true;
+        bool   border                 = true;         ///< draw panel border
 
         // Labels
         const char* header            = u8"Proxy settings";


### PR DESCRIPTION
## Summary
- clarify AuthPanelResult flag helpers with full Doxygen
- document optional border toggles and proxy fields across auth widgets

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68afb9e10fa0832c882f2f63ec16e50a