### PR TITLE
docs: improve Doxygen comments for misc widgets

### DIFF
--- a/include/imguix/widgets/misc/loading_spinner.hpp
+++ b/include/imguix/widgets/misc/loading_spinner.hpp
@@ -26,6 +26,9 @@ namespace ImGuiX::Widgets {
     /// \param id Unique widget identifier.
     /// \param cfg Spinner parameters.
     /// \return True if the item was submitted (not clipped).
+    /// \code
+    /// LoadingSpinner("busy");
+    /// \endcode
     bool LoadingSpinner(const char* id, const LoadingSpinnerConfig& cfg = {});
 
     /// \brief Convenience overload with basic parameters.

--- a/include/imguix/widgets/misc/markers.hpp
+++ b/include/imguix/widgets/misc/markers.hpp
@@ -12,14 +12,24 @@
 #include <imguix/config/colors.hpp>
 
 namespace ImGuiX::Widgets {
-    
+
+    /// \brief Marker display mode.
     enum class MarkerMode : int {
         TooltipOnly = 0,  ///< icon/label + tooltip on hover
         InlineText  = 1   ///< icon/label + inline wrapped text
     };
 
+    /// \brief Show tooltip text with word wrapping.
+    /// \param desc Tooltip text.
+    /// \param wrap_cols Column width for wrapping.
     void TooltipWrapped(const char* desc, float wrap_cols = 35.0f);
-    
+
+    /// \brief Draw icon marker with tooltip or inline text.
+    /// \param icon_utf8 Icon UTF-8 string.
+    /// \param color Icon color.
+    /// \param desc Tooltip or inline text.
+    /// \param mode Display mode.
+    /// \param wrap_cols Column width for wrapping.
     void IconMarker(
             const char* icon_utf8,
             const ImVec4& color,
@@ -45,6 +55,8 @@ namespace ImGuiX::Widgets {
 
     /// \brief Help marker using a question icon with tooltip.
     /// \param desc Help text.
+    /// \param mode Display mode.
+    /// \param icon_utf8 Icon glyph.
     void HelpMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,
@@ -53,6 +65,9 @@ namespace ImGuiX::Widgets {
 
     /// \brief Warning marker with yellow icon and text.
     /// \param desc Warning message.
+    /// \param mode Display mode.
+    /// \param color Icon and text color.
+    /// \param icon_utf8 Icon glyph.
     void WarningMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,
@@ -62,6 +77,9 @@ namespace ImGuiX::Widgets {
 
     /// \brief Info marker with blue icon and text.
     /// \param desc Information message.
+    /// \param mode Display mode.
+    /// \param color Icon and text color.
+    /// \param icon_utf8 Icon glyph.
     void InfoMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,
@@ -71,6 +89,9 @@ namespace ImGuiX::Widgets {
 
     /// \brief Success marker with green icon and text.
     /// \param desc Success message.
+    /// \param mode Display mode.
+    /// \param color Icon and text color.
+    /// \param icon_utf8 Icon glyph.
     void SuccessMarker(
             const char* desc,
             MarkerMode mode = MarkerMode::TooltipOnly,

--- a/include/imguix/widgets/misc/text_center.hpp
+++ b/include/imguix/widgets/misc/text_center.hpp
@@ -14,6 +14,7 @@ namespace ImGuiX::Widgets {
 
     /// \brief Center a single-line formatted text using ImGui::Text.
     /// \param fmt Format string for std::vsnprintf.
+    /// \param ... printf-style arguments.
     /// \note If text width exceeds available width, falls back to left alignment.
     void TextCenteredFmt(const char* fmt, ...);
 
@@ -28,11 +29,14 @@ namespace ImGuiX::Widgets {
     void TextWrappedCentered(const char* text, float wrap_width = 0.0f);
     
     /// \brief Overload for std::string (unformatted).
+    /// \param s UTF-8 string to render.
     inline void TextUnformattedCentered(const std::string& s) {
         TextUnformattedCentered(s.c_str());
     }
 
     /// \brief Overload for std::string (wrapped).
+    /// \param s Text to render.
+    /// \param wrap_width Desired wrap width in pixels.
     inline void TextWrappedCentered(const std::string& s, float wrap_width = 0.0f) {
         TextWrappedCentered(s.c_str(), wrap_width);
     }


### PR DESCRIPTION
## Summary
- document marker modes and helpers in misc marker headers
- clarify text-centering helpers and variadic arguments
- add usage snippet for loading spinner widget

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afba11185c832ca145ce4e9bcdbdd1