### PR TITLE
feat(core): add controller onInit lifecycle

### DIFF
--- a/include/imguix/core/controller/Controller.hpp
+++ b/include/imguix/core/controller/Controller.hpp
@@ -27,6 +27,9 @@ namespace ImGuiX {
 
         virtual ~Controller() = default;
 
+        /// \brief Optional initialization callback invoked once.
+        virtual void onInit() {}
+
         /// \brief Renders frame content (background, world, etc.).
         virtual void drawContent() = 0;
 

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -95,6 +95,9 @@ namespace ImGuiX {
         template <typename ControllerType, typename... Args>
         ControllerType& createController(Args&&... args);
 
+        /// \brief Call onInit() on controllers pending initialization.
+        void initializePendingControllers();
+
         // --- WindowInterface interface ---
 
         /// \brief Returns the unique ID of this window.
@@ -307,6 +310,7 @@ namespace ImGuiX {
 
         ApplicationContext& m_application;  ///< Reference to the owning application.
         std::vector<std::unique_ptr<Controller>> m_controllers; ///< Attached controllers.
+        std::vector<Controller*> m_pending_controllers; ///< Controllers awaiting onInit.
         std::string m_ini_path;             ///< Path to the window-specific ImGui ini file.
         bool m_is_ini_once = false;         ///< Ensures imgui ini is saved only once.
         bool m_is_ini_loaded = false;       ///< Indicates whether ini settings have been loaded.

--- a/include/imguix/core/window/WindowInstance.ipp
+++ b/include/imguix/core/window/WindowInstance.ipp
@@ -34,9 +34,18 @@ namespace ImGuiX {
         auto ctrl = std::make_unique<ControllerType>(
             static_cast<WindowInterface&>(*this),
             std::forward<Args>(args)...);
-        ControllerType& ref = *ctrl;
+        ControllerType* ptr = ctrl.get();
+        ControllerType& ref = *ptr;
+        m_pending_controllers.push_back(ptr);
         m_controllers.push_back(std::move(ctrl));
         return ref;
+    }
+
+    void WindowInstance::initializePendingControllers() {
+        for (auto* ctrl : m_pending_controllers) {
+            if (ctrl) ctrl->onInit();
+        }
+        m_pending_controllers.clear();
     }
 
 // --- WindowInterface interface ---

--- a/include/imguix/core/window/WindowManager.hpp
+++ b/include/imguix/core/window/WindowManager.hpp
@@ -86,6 +86,9 @@ namespace ImGuiX {
         /// \brief Remove windows that are no longer open.
         void removeClosed();
 
+        /// \brief Call onInit() on pending controllers in all windows.
+        void initializeControllers();
+
     protected:
         std::vector<std::unique_ptr<WindowInstance>> m_windows;      ///< Managed windows.
         std::vector<std::unique_ptr<WindowInstance>> m_pending_add;  ///< Newly created windows waiting to be added.

--- a/include/imguix/core/window/WindowManager.ipp
+++ b/include/imguix/core/window/WindowManager.ipp
@@ -28,6 +28,7 @@ namespace ImGuiX {
         flushPending();        // move pending windows into the active list
         initializePending();   // run onInit on newly added windows
         removeClosed();        // purge windows that have been closed
+        initializeControllers(); // run onInit on controllers
     }
     
     void WindowManager::flushPending() {
@@ -45,6 +46,12 @@ namespace ImGuiX {
             window->buildFonts();
         }
         m_pending_init.clear();
+    }
+
+    void WindowManager::initializeControllers() {
+        for (auto& window : m_windows) {
+            window->initializePendingControllers();
+        }
     }
 
     void WindowManager::closeAll() {


### PR DESCRIPTION
## Summary
- add optional onInit hook to Controller
- initialize controllers once when windows prepare each frame

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68afb9815af8832ca503bd3dd155793a