### PR TITLE
fix(utils): centralize dependent_false_v

### DIFF
--- a/include/imguix/utils/detail/common.hpp
+++ b/include/imguix/utils/detail/common.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#ifndef _IMGUIX_UTILS_DETAIL_COMMON_HPP_INCLUDED
+#define _IMGUIX_UTILS_DETAIL_COMMON_HPP_INCLUDED
+
+namespace ImGuiX::Utils::detail {
+
+    template<class T>
+    inline constexpr bool dependent_false_v = false;
+
+} // namespace ImGuiX::Utils::detail
+
+#endif // _IMGUIX_UTILS_DETAIL_COMMON_HPP_INCLUDED

--- a/include/imguix/utils/encoding_utils.hpp
+++ b/include/imguix/utils/encoding_utils.hpp
@@ -49,12 +49,12 @@ namespace ImGuiX::Utils {
 
 } // namespace ImGuiX::Utils
 #else
+
 #include <string>
+
+#include "detail/common.hpp"
+
 namespace ImGuiX::Utils {
-    namespace detail {
-        template<typename T>
-        inline constexpr bool dependent_false_v = false;
-    }
 
     template<typename Dummy = void>
     std::string Utf8ToAnsi(const std::string&) {
@@ -97,6 +97,7 @@ namespace ImGuiX::Utils {
         static_assert(detail::dependent_false_v<Dummy>, u8"Utf8ToUtf16 is not supported on this platform");
         return {};
     }
+
 } // namespace ImGuiX::Utils
 
 #endif // ifdef _WIN32

--- a/include/imguix/utils/path_utils.hpp
+++ b/include/imguix/utils/path_utils.hpp
@@ -23,12 +23,10 @@
 #    include <unistd.h>
 #endif
 
+#include "detail/common.hpp"
+
 namespace ImGuiX::Utils {
     namespace fs = std::filesystem;
-    namespace detail {
-        template<typename T>
-        inline constexpr bool dependent_false_v = false;
-    }
 
     /// \brief Get full path to current executable.
     /// \tparam Dummy Dummy template parameter for SFINAE.


### PR DESCRIPTION
## Summary
- add shared `dependent_false_v` helper
- include helper in encoding and path utilities to avoid redefinition

## Testing
- `cmake -S . -B build` *(fails: Could not find SFML package)*

------
https://chatgpt.com/codex/tasks/task_e_68afbbb83898832c853d0f4963b4499e