### PR TITLE
docs(widgets): normalize Doxygen in control headers

### DIFF
--- a/include/imguix/widgets/controls/circle_button.hpp
+++ b/include/imguix/widgets/controls/circle_button.hpp
@@ -8,12 +8,17 @@
 
 namespace ImGuiX::Widgets {
 
-    /// \brief Draw simple circular button with solid fill.
+    /// \brief Draw circular button with solid fill.
     /// \param id Unique string ID.
     /// \param diameter Button diameter in pixels.
     /// \param color Base color.
     /// \return True if button was clicked.
     /// \note Button changes color on hover or active using style.
+    /// \code
+    /// if (CircleButton("play", 24.0f, ImVec4{1, 0, 0, 1})) {
+    ///     // clicked
+    /// }
+    /// \endcode
     bool CircleButton(const char* id, float diameter, const ImVec4& color);
 
 } // namespace ImGuiX::Widgets

--- a/include/imguix/widgets/controls/icon_button.hpp
+++ b/include/imguix/widgets/controls/icon_button.hpp
@@ -4,6 +4,9 @@
 
 #include <imgui.h>
 
+/// \file icon_button.hpp
+/// \brief Centered icon or text button widget.
+
 namespace ImGuiX::Widgets {
 
     /// \brief Configuration for IconButtonCentered.
@@ -22,6 +25,11 @@ namespace ImGuiX::Widgets {
     /// \param text UTF-8 text or icon string.
     /// \param cfg Button appearance options.
     /// \return True if clicked with left mouse button.
+    /// \code
+    /// if (IconButtonCentered("ok", "OK")) {
+    ///     // clicked
+    /// }
+    /// \endcode
     bool IconButtonCentered(
             const char* id,
             const char* text,

--- a/include/imguix/widgets/controls/system_button.hpp
+++ b/include/imguix/widgets/controls/system_button.hpp
@@ -26,17 +26,22 @@ namespace ImGuiX::Widgets {
 
     /// \brief Type of the system-style button.
     enum class SystemButtonType {
-        Close,
-        Minimize,
-        Maximize
+        Close,    ///< Close window
+        Minimize, ///< Minimize window
+        Maximize  ///< Maximize window
     };
 
-    /// \brief Draw system-style button with icon based on type.
+    /// \brief Draw system-style button.
     /// \param id Unique ID string.
     /// \param type Button type.
     /// \param size Button size in pixels.
     /// \return True if button was clicked.
     /// \note Button is highlighted on hover or active using style colors.
+    /// \code
+    /// if (SystemButton("close", SystemButtonType::Close, ImVec2{16, 16})) {
+    ///     // clicked
+    /// }
+    /// \endcode
     bool SystemButton(const char* id, SystemButtonType type, ImVec2 size);
 
 } // namespace ImGuiX::Widgets

--- a/include/imguix/widgets/controls/toggle_button.hpp
+++ b/include/imguix/widgets/controls/toggle_button.hpp
@@ -9,9 +9,13 @@
 
 namespace ImGuiX::Widgets {
 
-    /// \brief Draw an animated toggle switch (no imgui_internal.h).
+    /// \brief Draw animated toggle switch.
     /// \param id Unique string identifier.
     /// \param state Pointer to boolean storing current state.
+    /// \code
+    /// bool enabled = false;
+    /// ToggleButton("enabled", &enabled);
+    /// \endcode
     void ToggleButton(const char* id, bool* state);
 
 } // namespace ImGuiX::Widgets


### PR DESCRIPTION
## Summary
- document CircleButton with example
- add file header and example for IconButtonCentered
- document SystemButton and enum values
- clarify ToggleButton usage with example

## Testing
- `cmake -S . -B build` *(fails: SFML component 'System' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afb9f1901c832c8cf5b0c4db0e762e