### PR TITLE
fix(windows): rename WindowFlags None enumerator

### DIFF
--- a/include/imguix/windows/ImGuiFramedWindow.hpp
+++ b/include/imguix/windows/ImGuiFramedWindow.hpp
@@ -70,7 +70,7 @@ namespace ImGuiX::Windows {
 
     protected:
         std::string m_title;                  ///< Text displayed on the title bar.
-        WindowFlags m_flags = WindowFlags::None; ///< Current window flags.
+        WindowFlags m_flags = WindowFlags::NoFlags; ///< Current window flags.
         ImGuiFramedWindowConfig m_config;        ///< Runtime configuration values.
         bool m_disable_background = false;       ///< Skip clearing the background when true.
 #       ifdef IMGUIX_USE_SFML_BACKEND

--- a/include/imguix/windows/window_flags.hpp
+++ b/include/imguix/windows/window_flags.hpp
@@ -12,7 +12,7 @@ namespace ImGuiX::Windows {
 
     /// \brief Flags used to configure window behavior and appearance.
     enum class WindowFlags : uint32_t {
-        None                       = 0,
+        NoFlags                    = 0,      ///< No flags set
         HasMenuBar                 = 1 << 0, ///< Enable ImGui menu bar region
         EnableTransparency         = 1 << 1, ///< Use DWM transparency (Windows only)
         DisableBackground          = 1 << 2, ///< Disable background color in ImGui::Begin


### PR DESCRIPTION
## Summary
- avoid X11 macro conflict by renaming WindowFlags::None to WindowFlags::NoFlags
- adjust ImGuiFramedWindow default flag to use WindowFlags::NoFlags

## Testing
- `cmake --build build` *(fails: no match for operator!= in libs/imgui-sfml/imgui-SFML.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68afbbbb7268832c8e04fbe6a0c5bd5d