### PR TITLE
fix(window): undef X11 macros causing conflicts

### DIFF
--- a/include/imguix/core/window/SfmlWindowInstance.ipp
+++ b/include/imguix/core/window/SfmlWindowInstance.ipp
@@ -5,6 +5,15 @@
 #ifdef __linux__
 #   include <X11/Xlib.h>
 #   include <X11/Xutil.h>
+#   ifdef None
+#       undef None // prevents conflicts with enums and sf::Style::None
+#   endif
+#   ifdef Bool
+#       undef Bool
+#   endif
+#   ifdef Status
+#       undef Status
+#   endif
 #endif
 
 #include <imguix/utils/path_utils.hpp>


### PR DESCRIPTION
## Summary
- undefine X11 macros like None, Bool, and Status in the SFML window implementation to avoid enum conflicts

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afc049ad20832cb9899b63fd9eef55