### PR TITLE
feat(plot): add OHLC chart widget

### DIFF
--- a/include/imguix/config/colors.hpp
+++ b/include/imguix/config/colors.hpp
@@ -19,4 +19,10 @@
 /// \brief RGBA color for success markers.
 #define IMGUIX_COLOR_SUCCESS ImVec4(0.0f, 0.60f, 0.0f, 1.0f)
 
+/// \brief Default bull candle color for PlotOHLCChart.
+#define IMGUIX_COLOR_OHLC_BULL ImVec4(0.0f, 1.0f, 0.441f, 1.0f)
+
+/// \brief Default bear candle color for PlotOHLCChart.
+#define IMGUIX_COLOR_OHLC_BEAR ImVec4(0.853f, 0.05f, 0.31f, 1.0f)
+
 #endif // _IMGUIX_CONFIG_COLORS_HPP_INCLUDED

--- a/include/imguix/widgets.hpp
+++ b/include/imguix/widgets.hpp
@@ -33,4 +33,8 @@
 #include <imguix/widgets/time/hours_selector.hpp>
 #include <imguix/widgets/time/time_picker.hpp>
 
+#ifdef IMGUI_ENABLE_IMPLOT
+#   include <imguix/widgets/plot/PlotOHLCChart.hpp>
+#endif
+
 #endif // IMGUIX_WIDGETS_HPP_INCLUDED

--- a/include/imguix/widgets/plot/BarAdapter.hpp
+++ b/include/imguix/widgets/plot/BarAdapter.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_PLOT_BARADAPTER_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_PLOT_BARADAPTER_HPP_INCLUDED
+
+/// \file BarAdapter.hpp
+/// \brief Generic adapters for OHLC bar data access.
+
+#include <functional>
+#include <utility>
+
+namespace ImGuiX::Widgets {
+
+    inline constexpr double kMillisecondsInSecond = 1000.0; ///< Milliseconds in one second.
+
+    /// \brief Adapter accessing bar fields through member pointers or callables.
+    /// \tparam T Bar type.
+    /// \tparam Open   Member pointer or callable returning open price.
+    /// \tparam High   Member pointer or callable returning high price.
+    /// \tparam Low    Member pointer or callable returning low price.
+    /// \tparam Close  Member pointer or callable returning close price.
+    /// \tparam Time   Member pointer or callable returning time value.
+    /// \tparam Volume Member pointer or callable returning volume.
+    /// \tparam TimeScale Divisor applied to time to convert to seconds.
+    template<typename T,
+             auto Open,
+             auto High,
+             auto Low,
+             auto Close,
+             auto Time,
+             auto Volume = nullptr,
+             double TimeScale = kMillisecondsInSecond>
+    struct MemberBarAdapter {
+        static double getOpen(const T& bar) {
+            return static_cast<double>(std::invoke(Open, bar));
+        }
+        static double getHigh(const T& bar) {
+            return static_cast<double>(std::invoke(High, bar));
+        }
+        static double getLow(const T& bar) {
+            return static_cast<double>(std::invoke(Low, bar));
+        }
+        static double getClose(const T& bar) {
+            return static_cast<double>(std::invoke(Close, bar));
+        }
+        static double getTime(const T& bar) {
+            return static_cast<double>(std::invoke(Time, bar)) / TimeScale;
+        }
+        static double getVolume(const T& bar) {
+            if constexpr (Volume != nullptr) {
+                return static_cast<double>(std::invoke(Volume, bar));
+            }
+            return 0.0;
+        }
+    };
+
+    /// \brief Default adapter for bars with members: open, high, low, close, time (ms).
+    template<typename T>
+    using DefaultBarAdapter = MemberBarAdapter<T,
+                                              &T::open,
+                                              &T::high,
+                                              &T::low,
+                                              &T::close,
+                                              &T::time>;
+
+} // namespace ImGuiX::Widgets
+
+#endif // _IMGUIX_WIDGETS_PLOT_BARADAPTER_HPP_INCLUDED

--- a/include/imguix/widgets/plot/Bars.hpp
+++ b/include/imguix/widgets/plot/Bars.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_PLOT_BARS_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_PLOT_BARS_HPP_INCLUDED
+
+/// \file Bars.hpp
+/// \brief Simple OHLC bar data structures.
+
+namespace ImGuiX::Widgets {
+
+    /// \brief Bar with OHLC prices and time in milliseconds.
+    struct Bar {
+        double open{};  ///< Open price.
+        double high{};  ///< High price.
+        double low{};   ///< Low price.
+        double close{}; ///< Close price.
+        double time{};  ///< Time in milliseconds.
+    };
+
+    /// \brief Bar with OHLC prices, volume and time in milliseconds.
+    struct BarWithVolume {
+        double open{};   ///< Open price.
+        double high{};   ///< High price.
+        double low{};    ///< Low price.
+        double close{};  ///< Close price.
+        double volume{}; ///< Traded volume.
+        double time{};   ///< Time in milliseconds.
+    };
+
+} // namespace ImGuiX::Widgets
+
+#endif // _IMGUIX_WIDGETS_PLOT_BARS_HPP_INCLUDED

--- a/include/imguix/widgets/plot/PlotOHLCChart.hpp
+++ b/include/imguix/widgets/plot/PlotOHLCChart.hpp
@@ -1,0 +1,77 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_PLOT_PLOTOHLCCHART_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_PLOT_PLOTOHLCCHART_HPP_INCLUDED
+
+/// \file PlotOHLCChart.hpp
+/// \brief OHLC price chart widget built on ImPlot.
+
+#include <imgui.h>
+#include <implot.h>
+#include <string>
+#include <vector>
+#include <functional>
+
+#include <imguix/config/colors.hpp>
+#include <imguix/widgets/plot/BarAdapter.hpp>
+
+namespace ImGuiX::Widgets {
+
+    inline constexpr int kSecondsPerMinute = 60;                ///< Seconds in one minute.
+    inline constexpr int kSecondsPerHour   = 60 * kSecondsPerMinute; ///< Seconds in one hour.
+    inline constexpr int kSecondsPerDay    = 24 * kSecondsPerHour;   ///< Seconds in one day.
+
+    /// \brief Configuration for PlotOHLCChart.
+    struct OHLCChartConfig {
+        ImVec4 bull_color = IMGUIX_COLOR_OHLC_BULL; ///< Color for bullish candles.
+        ImVec4 bear_color = IMGUIX_COLOR_OHLC_BEAR; ///< Color for bearish candles.
+        ImVec2 plot_size  = ImVec2(-1, 0);          ///< Plot size; (-1,0) uses full width.
+
+        bool enable_timeframes = true; ///< Show timeframe combo.
+        std::vector<int> timeframes_seconds = {
+            kSecondsPerMinute,
+            5 * kSecondsPerMinute,
+            15 * kSecondsPerMinute,
+            kSecondsPerHour,
+            kSecondsPerDay
+        }; ///< Available timeframe options in seconds.
+        int initial_timeframe = kSecondsPerMinute; ///< Default timeframe value.
+        std::function<void(int)> on_timeframe_changed; ///< Callback on timeframe change.
+
+        std::vector<std::string> symbols{}; ///< Available trading symbols.
+        std::string initial_symbol{"AAPL"}; ///< Initially selected symbol.
+        std::function<void(const std::string&)> on_symbol_changed; ///< Callback on symbol change.
+
+        bool enable_lines = true; ///< Render user-defined lines.
+        struct Line {
+            double x1; ///< Line start X (time).
+            double y1; ///< Line start Y (price).
+            double x2; ///< Line end X (time).
+            double y2; ///< Line end Y (price).
+            ImVec4 color; ///< Line color.
+        };
+        std::vector<Line> user_lines; ///< User lines to draw over chart.
+
+        bool show_tooltip = true; ///< Display tooltip on bar hover.
+        const char* no_data_text = "No data available"; ///< Text shown when no bars.
+    };
+
+    /// \brief Render an OHLC chart.
+    /// \tparam T Bar data type.
+    /// \tparam Adapter Adapter providing accessors for bar fields.
+    /// \param id Unique plot identifier.
+    /// \param bars Bars ordered by ascending time.
+    /// \param config Chart rendering configuration.
+    template<typename T, typename Adapter = DefaultBarAdapter<T>>
+    void PlotOHLCChart(
+            const char* id,
+            const std::vector<T>& bars,
+            OHLCChartConfig& config
+    );
+
+} // namespace ImGuiX::Widgets
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "PlotOHLCChart.ipp"
+#endif
+
+#endif // _IMGUIX_WIDGETS_PLOT_PLOTOHLCCHART_HPP_INCLUDED

--- a/include/imguix/widgets/plot/PlotOHLCChart.ipp
+++ b/include/imguix/widgets/plot/PlotOHLCChart.ipp
@@ -1,0 +1,186 @@
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+namespace ImGuiX::Widgets {
+
+    namespace detail {
+        inline constexpr double kBarHalfWidthFactor = 0.25; ///< Half-width factor for bar bodies.
+        inline constexpr double kTooltipTolerance   = 0.1;  ///< Max time diff to show tooltip.
+        inline constexpr float  kUserLineThickness  = 1.5f; ///< Thickness of user lines.
+        inline constexpr int    kTooltipBufferSize  = 64;   ///< Tooltip buffer size.
+        const ImVec4 kNoDataColor{1.0f, 0.3f, 0.3f, 1.0f};  ///< Color for no-data message.
+    } // namespace detail
+
+    template<typename T, typename Adapter>
+    void PlotOHLCChart(
+            const char* id,
+            const std::vector<T>& bars,
+            OHLCChartConfig& config
+    ) {
+        static int selected_tf = config.initial_timeframe;
+        static std::string selected_symbol = config.initial_symbol;
+
+        if (!config.symbols.empty()) {
+            ImGui::TextUnformatted("Symbol:");
+            ImGui::SameLine();
+            if (ImGui::BeginCombo("##symbol", selected_symbol.c_str())) {
+                for (const auto& sym : config.symbols) {
+                    const bool selected = (sym == selected_symbol);
+                    if (ImGui::Selectable(sym.c_str(), selected)) {
+                        selected_symbol = sym;
+                        if (config.on_symbol_changed) {
+                            config.on_symbol_changed(sym);
+                        }
+                    }
+                }
+                ImGui::EndCombo();
+            }
+        } else {
+            ImGui::Text("Symbol: %s", selected_symbol.c_str());
+        }
+
+        if (config.enable_timeframes) {
+            ImGui::SameLine();
+            ImGui::TextUnformatted("Timeframe:");
+            ImGui::SameLine();
+            std::string tf_label = std::to_string(selected_tf);
+            if (selected_tf >= kSecondsPerDay) {
+                tf_label = "D" + std::to_string(selected_tf / kSecondsPerDay);
+            } else if (selected_tf >= kSecondsPerHour) {
+                tf_label = "H" + std::to_string(selected_tf / kSecondsPerHour);
+            } else if (selected_tf >= kSecondsPerMinute) {
+                tf_label = "M" + std::to_string(selected_tf / kSecondsPerMinute);
+            } else {
+                tf_label = "S" + std::to_string(selected_tf);
+            }
+
+            if (ImGui::BeginCombo("##tf", tf_label.c_str())) {
+                for (int tf : config.timeframes_seconds) {
+                    std::string label;
+                    if (tf >= kSecondsPerDay) {
+                        label = "D" + std::to_string(tf / kSecondsPerDay);
+                    } else if (tf >= kSecondsPerHour) {
+                        label = "H" + std::to_string(tf / kSecondsPerHour);
+                    } else if (tf >= kSecondsPerMinute) {
+                        label = "M" + std::to_string(tf / kSecondsPerMinute);
+                    } else {
+                        label = "S" + std::to_string(tf);
+                    }
+
+                    const bool selected = (tf == selected_tf);
+                    if (ImGui::Selectable(label.c_str(), selected)) {
+                        selected_tf = tf;
+                        if (config.on_timeframe_changed) {
+                            config.on_timeframe_changed(tf);
+                        }
+                    }
+                }
+                ImGui::EndCombo();
+            }
+        }
+
+        if (bars.empty()) {
+            ImGui::TextColored(detail::kNoDataColor, "%s", config.no_data_text);
+            return;
+        }
+
+        if (ImPlot::BeginPlot(id, config.plot_size)) {
+            ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+            ImPlot::SetupAxes("Time", "Price");
+            ImPlot::SetupAxesLimits(
+                Adapter::getTime(bars.front()),
+                Adapter::getTime(bars.back()),
+                0,
+                0,
+                ImPlotCond_Once
+            );
+
+            ImDrawList* draw = ImPlot::GetPlotDrawList();
+            const double width = bars.size() > 1
+                ? (Adapter::getTime(bars[1]) - Adapter::getTime(bars[0])) * detail::kBarHalfWidthFactor
+                : selected_tf * detail::kBarHalfWidthFactor;
+
+            if (ImPlot::IsPlotHovered() && config.show_tooltip) {
+                ImPlotPoint mouse = ImPlot::GetPlotMousePos();
+                mouse.x = ImPlot::RoundTime(
+                        ImPlotTime::FromDouble(mouse.x),
+                        ImPlotTimeUnit_S
+                ).ToDouble();
+
+                const auto it = std::find_if(
+                        bars.begin(),
+                        bars.end(),
+                        [&](const T& bar) {
+                            return std::abs(
+                                    Adapter::getTime(bar) - mouse.x
+                                ) < detail::kTooltipTolerance;
+                        }
+                );
+
+                if (it != bars.end()) {
+                    ImGui::BeginTooltip();
+                    ImPlotTime t = ImPlotTime::FromDouble(Adapter::getTime(*it));
+                    char buf[detail::kTooltipBufferSize];
+                    ImPlot::FormatDateTime(
+                            t,
+                            buf,
+                            detail::kTooltipBufferSize,
+                            ImPlotDateTimeFmt_DayMoYrHrMin,
+                            false
+                    );
+                    ImGui::Text("Time:  %s", buf);
+                    ImGui::Text("Open:  %.2f", Adapter::getOpen(*it));
+                    ImGui::Text("High:  %.2f", Adapter::getHigh(*it));
+                    ImGui::Text("Low:   %.2f", Adapter::getLow(*it));
+                    ImGui::Text("Close: %.2f", Adapter::getClose(*it));
+                    ImGui::EndTooltip();
+                }
+            }
+
+            for (const auto& bar : bars) {
+                const double t = Adapter::getTime(bar);
+                const ImVec2 open = ImPlot::PlotToPixels(
+                        t - width,
+                        Adapter::getOpen(bar)
+                );
+                const ImVec2 close = ImPlot::PlotToPixels(
+                        t + width,
+                        Adapter::getClose(bar)
+                );
+                const ImVec2 high = ImPlot::PlotToPixels(
+                        t,
+                        Adapter::getHigh(bar)
+                );
+                const ImVec2 low = ImPlot::PlotToPixels(
+                        t,
+                        Adapter::getLow(bar)
+                );
+                const ImU32 col = ImGui::GetColorU32(
+                        Adapter::getClose(bar) >= Adapter::getOpen(bar)
+                            ? config.bull_color
+                            : config.bear_color
+                );
+                draw->AddLine(low, high, col);
+                draw->AddRectFilled(open, close, col);
+            }
+
+            if (config.enable_lines) {
+                for (const auto& line : config.user_lines) {
+                    const ImVec2 p1 = ImPlot::PlotToPixels(line.x1, line.y1);
+                    const ImVec2 p2 = ImPlot::PlotToPixels(line.x2, line.y2);
+                    draw->AddLine(
+                            p1,
+                            p2,
+                            ImGui::GetColorU32(line.color),
+                            detail::kUserLineThickness
+                    );
+                }
+            }
+
+            ImPlot::EndPlot();
+        }
+    }
+
+} // namespace ImGuiX::Widgets
+


### PR DESCRIPTION
## Summary
- add PlotOHLCChart widget with timeframe, symbol and line overlays
- introduce flexible MemberBarAdapter for custom bar types
- expose default bull/bear colors via config macros
- add volume support and basic bar structs for adapters

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b04f986cd8832c845f85276c3425d8