### PR TITLE
feat: add exponential moving average helper

### DIFF
--- a/include/imguix/extensions.hpp
+++ b/include/imguix/extensions.hpp
@@ -6,6 +6,7 @@
 /// \brief Unified include for all ImGuiX extensions.
 /// \note Includes style patches, scoped overrides, and rendering helpers.
 
+#include "extensions/ema.hpp"
 #include "extensions/force_opaque_style.hpp"
 
 #endif // _IMGUIX_EXTENSIONS_EXTENSIONS_HPP_INCLUDED

--- a/include/imguix/extensions/ema.hpp
+++ b/include/imguix/extensions/ema.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#ifndef _IMGUIX_EXTENSIONS_EMA_HPP_INCLUDED
+#define _IMGUIX_EXTENSIONS_EMA_HPP_INCLUDED
+
+/// \file ema.hpp
+/// \brief Exponential moving average helper with per-ID state in ImGui storage.
+
+#include <imgui.h>
+
+namespace ImGuiX::Extensions {
+
+    /// \brief Exponential moving average stored in ImGui storage.
+    class Ema {
+    public:
+        static constexpr float kDefaultAlpha = 0.1f;
+
+        /// \brief Reset stored value.
+        /// \param id Storage identifier.
+        /// \param value Value to set as current EMA.
+        static void reset(ImGuiID id, float value);
+
+        /// \brief Update EMA with new sample.
+        /// \param id Storage identifier.
+        /// \param sample New data point.
+        /// \param alpha Smoothing factor [0,1].
+        /// \return Updated EMA value.
+        static float update(
+                ImGuiID id,
+                float sample,
+                float alpha = kDefaultAlpha);
+
+        /// \brief Get current EMA value.
+        /// \param id Storage identifier.
+        /// \param default_value Fallback if EMA not yet initialized.
+        /// \return Stored EMA value or default_value if unset.
+        static float value(ImGuiID id, float default_value = 0.0f);
+    };
+
+} // namespace ImGuiX::Extensions
+
+#ifdef IMGUIX_HEADER_ONLY
+#include "ema.ipp"
+#endif
+
+#endif // _IMGUIX_EXTENSIONS_EMA_HPP_INCLUDED

--- a/include/imguix/extensions/ema.ipp
+++ b/include/imguix/extensions/ema.ipp
@@ -1,0 +1,19 @@
+namespace ImGuiX::Extensions {
+
+    inline void Ema::reset(ImGuiID id, float value) {
+        ImGui::GetStateStorage()->SetFloat(id, value);
+    }
+
+    inline float Ema::update(ImGuiID id, float sample, float alpha) {
+        ImGuiStorage* st = ImGui::GetStateStorage();
+        float current = st->GetFloat(id, sample);
+        current += alpha * (sample - current);
+        st->SetFloat(id, current);
+        return current;
+    }
+
+    inline float Ema::value(ImGuiID id, float default_value) {
+        return ImGui::GetStateStorage()->GetFloat(id, default_value);
+    }
+
+} // namespace ImGuiX::Extensions

--- a/tests/test_ema.cpp
+++ b/tests/test_ema.cpp
@@ -1,0 +1,38 @@
+#include <imgui.h>
+#include <imguix/extensions/ema.hpp>
+#include <iostream>
+
+int main() {
+    ImGuiContext* ctx = ImGui::CreateContext();
+    ImGui::SetCurrentContext(ctx);
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(100, 100);
+    io.Fonts->AddFontDefault();
+    io.Fonts->Build();
+
+    ImGui::NewFrame();
+    ImGui::Begin("test");
+
+    ImGuiID id = ImGui::GetID("ema");
+    ImGuiX::Extensions::Ema::reset(id, 0.0f);
+    ImGuiX::Extensions::Ema::update(id, 1.0f);
+
+    float v = ImGuiX::Extensions::Ema::value(id);
+    if (!(v > 0.0f && v < 1.0f)) {
+        std::cerr << "EMA not between 0 and 1\n";
+        return 1;
+    }
+
+    ImGuiX::Extensions::Ema::reset(id, 5.0f);
+    ImGuiX::Extensions::Ema::update(id, 5.0f);
+    if (ImGuiX::Extensions::Ema::value(id) != 5.0f) {
+        std::cerr << "EMA reset failed\n";
+        return 1;
+    }
+
+    ImGui::End();
+    ImGui::Render();
+    ImGui::DestroyContext(ctx);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `Ema` extension to smooth parameter changes with per-id state
- expose the new helper via `extensions.hpp`
- cover EMA behavior with a minimal unit test

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF`
- `cmake --build build --target test_ema`
- `cd build && ctest -R test_ema`


------
https://chatgpt.com/codex/tasks/task_e_68b238677590832cb9f7455eda4be4d6