### PR TITLE
Add default ImPlot style and update themes

### DIFF
--- a/include/imguix/core/themes/Theme.hpp
+++ b/include/imguix/core/themes/Theme.hpp
@@ -55,6 +55,28 @@ namespace ImGuiX::Themes {
         style.PopupBorderSize   = POPUP_BORDER_SIZE;
         style.GrabRounding      = GRAB_ROUNDING;
     }
+
+#   ifdef IMGUI_ENABLE_IMPLOT
+    /// \brief Set baseline ImPlot style parameters.
+    /// \param style Style to modify.
+    /// \details Used by all themes before applying color scheme.
+    inline void applyDefaultImPlotStyle(ImPlotStyle& style) {
+        using namespace ImGuiX::Config;
+
+        style.UseISO8601     = true;
+        style.Use24HourClock = true;
+
+        style.PlotBorderSize = FRAME_BORDER_SIZE;
+        style.PlotPadding    = WINDOW_PADDING;
+        style.LabelPadding   = ITEM_SPACING;
+
+        style.LegendPadding        = WINDOW_PADDING;
+        style.LegendInnerPadding   = WINDOW_PADDING;
+        style.LegendSpacing        = ITEM_SPACING;
+        style.MousePosPadding      = WINDOW_PADDING;
+        style.AnnotationPadding    = ITEM_SPACING;
+    }
+#   endif
     
     /// \brief Classic ImGui theme.
     class ClassicTheme final : public Theme {
@@ -69,6 +91,7 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsClassic(&style);
+            applyDefaultImPlotStyle(style);
         }
 #       endif
     };
@@ -86,6 +109,7 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsLight(&style);
+            applyDefaultImPlotStyle(style);
         }
 #       endif
     };
@@ -104,6 +128,7 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsDark(&style);
+            applyDefaultImPlotStyle(style);
         }
 #       endif
     };

--- a/include/imguix/themes/CorporateGreyTheme.hpp
+++ b/include/imguix/themes/CorporateGreyTheme.hpp
@@ -127,6 +127,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = ImVec4(0.15f, 0.15f, 0.15f, 1.0f);
             style.Colors[ImPlotCol_LegendBg]      = DarkGrey25;
             style.Colors[ImPlotCol_LegendBorder]  = ImVec4(0.12f, 0.12f, 0.12f, 0.71f);
+            style.Colors[ImPlotCol_LegendText]    = White;
             style.Colors[ImPlotCol_TitleText]     = White;
             style.Colors[ImPlotCol_InlayText]     = White;
             style.Colors[ImPlotCol_AxisText]      = White;
@@ -134,6 +135,8 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_AxisTick]      = ImVec4(0.45f, 0.45f, 0.45f, 0.70f);
             style.Colors[ImPlotCol_Selection]     = Highlight;
             style.Colors[ImPlotCol_Crosshairs]    = Highlight;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -197,6 +197,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
             style.Colors[ImPlotCol_AxisText]      = Text;
@@ -208,6 +209,8 @@ namespace ImGuiX::Themes {
             // Selection/crosshair in signature orange
             style.Colors[ImPlotCol_Selection]     = ImVec4(1.000f, 0.391f, 0.000f, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.000f, 0.391f, 0.000f, 1.00f);
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -191,6 +191,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -201,6 +202,8 @@ namespace ImGuiX::Themes {
 
             style.Colors[ImPlotCol_Selection]     = AccentBlue;
             style.Colors[ImPlotCol_Crosshairs]    = AccentBlue;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -197,6 +197,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -209,6 +210,8 @@ namespace ImGuiX::Themes {
             // Selection/crosshair use the same accent
             style.Colors[ImPlotCol_Selection]     = ImVec4(0.26f, 0.59f, 0.98f, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = AccentBase;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -207,6 +207,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -219,6 +220,8 @@ namespace ImGuiX::Themes {
             // Selection/crosshair use the red accent to match plot colors
             style.Colors[ImPlotCol_Selection]     = ImVec4(1.00f, 0.00f, 0.00f, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.00f, 0.00f, 0.00f, 1.00f);
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/GoldBlackTheme.hpp
+++ b/include/imguix/themes/GoldBlackTheme.hpp
@@ -192,6 +192,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = GoldBorder;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = GoldBorder;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -204,6 +205,8 @@ namespace ImGuiX::Themes {
             // Selection/crosshair in golden accent
             style.Colors[ImPlotCol_Selection]     = ImVec4(GoldBright.x, GoldBright.y, GoldBright.z, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = GoldBright;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -208,6 +208,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -220,6 +221,8 @@ namespace ImGuiX::Themes {
             // Match selection/crosshair to green-blue accents
             style.Colors[ImPlotCol_Selection]     = ImVec4(0.13f, 0.75f, 1.00f, 0.65f); // cyan, semi-opaque
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(0.13f, 0.75f, 0.75f, 1.00f); // teal
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -175,6 +175,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -187,6 +188,8 @@ namespace ImGuiX::Themes {
             // Use the blue accent for selection/crosshairs to contrast green elements
             style.Colors[ImPlotCol_Selection]     = ImVec4(0.26f, 0.59f, 0.98f, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -175,6 +175,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = PopupBg;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -187,6 +188,8 @@ namespace ImGuiX::Themes {
             // Blue selection/crosshair to match controls
             style.Colors[ImPlotCol_Selection]     = ImVec4(Blue.x, Blue.y, Blue.z, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/PearlLightTheme.hpp
+++ b/include/imguix/themes/PearlLightTheme.hpp
@@ -165,6 +165,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]   = Border;
             style.Colors[ImPlotCol_LegendBg]     = PopupBg;
             style.Colors[ImPlotCol_LegendBorder] = Border;
+            style.Colors[ImPlotCol_LegendText]   = Text;
             style.Colors[ImPlotCol_TitleText]    = Text;
             style.Colors[ImPlotCol_InlayText]    = Text;
             style.Colors[ImPlotCol_AxisText]     = Text;
@@ -172,6 +173,8 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_AxisTick]     = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
             style.Colors[ImPlotCol_Selection]    = AccentBase;
             style.Colors[ImPlotCol_Crosshairs]   = AccentBase;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -165,6 +165,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]   = Border;
             style.Colors[ImPlotCol_LegendBg]     = PopupBg;
             style.Colors[ImPlotCol_LegendBorder] = Border;
+            style.Colors[ImPlotCol_LegendText]   = Text;
             style.Colors[ImPlotCol_TitleText]    = Text;
             style.Colors[ImPlotCol_InlayText]    = Text;
             style.Colors[ImPlotCol_AxisText]     = Text;
@@ -172,6 +173,8 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_AxisTick]     = ImVec4(0.55f, 0.55f, 0.55f, 0.80f);
             style.Colors[ImPlotCol_Selection]    = AccentBase;
             style.Colors[ImPlotCol_Crosshairs]   = AccentBase;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -174,6 +174,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_PlotBorder]    = Border;
             style.Colors[ImPlotCol_LegendBg]      = Panel;
             style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
 
             style.Colors[ImPlotCol_TitleText]     = Text;
             style.Colors[ImPlotCol_InlayText]     = Text;
@@ -185,6 +186,8 @@ namespace ImGuiX::Themes {
 
             style.Colors[ImPlotCol_Selection]     = ImVec4(PanelActive.x, PanelActive.y, PanelActive.z, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = PanelActive;
+
+            applyDefaultImPlotStyle(style);
         }
 #endif
     };


### PR DESCRIPTION
## Summary
- provide `applyDefaultImPlotStyle` to unify ImPlot styling and enable ISO8601/24h time
- ensure built-in and custom themes set legend text color and use the default ImPlot style

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b24f26a76c832cac5cf4c94b9779f4