### PR TITLE
fix(pubsub,widgets): correct cached event pointer access and format string

### DIFF
--- a/include/imguix/core/pubsub/EventMediator.hpp
+++ b/include/imguix/core/pubsub/EventMediator.hpp
@@ -386,9 +386,9 @@ namespace ImGuiX::Pubsub {
         void handleCachedEvent(const EventType& e) {
             std::lock_guard<std::mutex> lk(m_cache_mutex);
             for (auto& [id, slot] : m_cached_events) {
-                if (slot.type != std::type_index(typeid(EventType))) continue;
-                if (slot.predicate(&e)) {
-                    slot.event = std::make_unique<EventType>(e);
+                if (slot->type != std::type_index(typeid(EventType))) continue;
+                if (slot->predicate(&e)) {
+                    slot->event = std::make_unique<EventType>(e);
                 }
             }
         }

--- a/include/imguix/widgets/misc/markers.ipp
+++ b/include/imguix/widgets/misc/markers.ipp
@@ -54,7 +54,7 @@ void HelpMarker(
         const char* desc,
         MarkerMode mode,
         const char* icon_utf8) {
-    ImGui::TextDisabled(icon_utf8);
+    ImGui::TextDisabled("%s", icon_utf8);
     if (mode == MarkerMode::InlineText) {
         ImGui::SameLine();
         ImGui::TextWrapped("%s", desc);


### PR DESCRIPTION
## Summary
- fix cached event slot access to use pointer in EventMediator
- avoid format-security warning in HelpMarker by using explicit format string

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_DEPS_IMGUI_MODE=SYSTEM` *(fails: Cannot find source file: libs/imgui/imgui.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68b24fade680832c88ba09d5aa4fe457