### PR TITLE
docs: refine notification Doxygen comments

### DIFF
--- a/include/imguix/core/notify/NotificationManager.hpp
+++ b/include/imguix/core/notify/NotificationManager.hpp
@@ -20,24 +20,41 @@ namespace ImGuiX::Notify {
         NotificationManager() = default;
 
         /// \brief Access mutable config.
+        /// \return Reference to configuration.
         Config&       config()       { return m_cfg; }
         /// \brief Access const config.
+        /// \return Reference to configuration.
         const Config& config() const { return m_cfg; }
 
         /// \brief Fonts configuration.
+        /// \return Reference to font config.
         FontConfig&       fonts()       { return m_fonts; }
+        /// \brief Fonts configuration (const).
+        /// \return Reference to font config.
         const FontConfig& fonts() const { return m_fonts; }
-        
+
+        /// \brief Icon configuration.
+        /// \return Reference to icon config.
         IconConfig&       icons()       { return m_icons; }
+        /// \brief Icon configuration (const).
+        /// \return Reference to icon config.
         const IconConfig& icons() const { return m_icons; }
 
+        /// \brief Queue notification.
+        /// \param toast Notification to push.
         void push(Notification toast) { m_notifications.push_back(std::move(toast)); }
+        /// \brief Remove all queued notifications.
         void clear() { m_notifications.clear(); }
 
         /// \brief Render all active notifications.
         void render();
 
-        /// \brief Post notification using fmt with compile-time checked format (string literal).
+        /// \brief Post notification using fmt with compile-time checked format.
+        /// \tparam Args Format argument types.
+        /// \param type Notification type.
+        /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+        /// \param fmt_s Format string.
+        /// \param args Format arguments.
         template<class... Args>
         void postFmt(Notify::Type type, int dismiss_ms,
                      fmt::format_string<Args...> fmt_s, Args&&... args) {
@@ -48,6 +65,11 @@ namespace ImGuiX::Notify {
         }
 
         /// \brief Post notification using fmt for a runtime format string.
+        /// \tparam Args Format argument types.
+        /// \param type Notification type.
+        /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+        /// \param fmt_rt Runtime format string.
+        /// \param args Format arguments.
         template<class... Args>
         void postFmtRuntime(Notify::Type type, int dismiss_ms,
                             fmt::string_view fmt_rt, Args&&... args) {
@@ -58,7 +80,15 @@ namespace ImGuiX::Notify {
             push(std::move(n));
         }
 
-        /// \brief Post notification with title/content via fmt (both literals).
+        /// \brief Post notification with title and content via fmt.
+        /// \tparam ArgsT Title argument types.
+        /// \tparam ArgsC Content argument types.
+        /// \param type Notification type.
+        /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+        /// \param title_fmt Title format string.
+        /// \param title_args Title format arguments.
+        /// \param content_fmt Content format string.
+        /// \param content_args Content format arguments.
         template<class... ArgsT, class... ArgsC>
         void postWithTitleFmt(Notify::Type type, int dismiss_ms,
                               fmt::format_string<ArgsT...> title_fmt,   ArgsT&&... title_args,
@@ -71,7 +101,17 @@ namespace ImGuiX::Notify {
             push(std::move(n));
         }
 
-        /// \brief Post notification with a button via fmt (all literals).
+        /// \brief Post notification with a button via fmt.
+        /// \tparam ArgsT Title argument types.
+        /// \tparam ArgsC Content argument types.
+        /// \param type Notification type.
+        /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+        /// \param button_label Button label.
+        /// \param on_click Callback executed on button click.
+        /// \param title_fmt Title format string.
+        /// \param title_args Title format arguments.
+        /// \param content_fmt Content format string.
+        /// \param content_args Content format arguments.
         template<class... ArgsT, class... ArgsC>
         void postWithButtonFmt(Notify::Type type, int dismiss_ms,
                                const char* button_label, std::function<void()> on_click,
@@ -87,7 +127,11 @@ namespace ImGuiX::Notify {
             push(std::move(n));
         }
 
-        /// \brief Post notification using classic printf-style format (always available).
+        /// \brief Post notification using classic printf-style format.
+        /// \param type Notification type.
+        /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+        /// \param fmt_s printf-like format string.
+        /// \param ... Format arguments.
         inline void postf(Notify::Type type, int dismiss_ms, const char* fmt_s, ...) {
             if (!fmt_s) return;
             va_list args; va_start(args, fmt_s);
@@ -99,16 +143,23 @@ namespace ImGuiX::Notify {
         }
 
     private:
+        /// \brief Remove notification at index.
+        /// \param index Position in queue.
         void remove(std::size_t index) {
             m_notifications.erase(m_notifications.begin() + static_cast<std::ptrdiff_t>(index));
         }
 		
-		/// \brief Посчитать эффективный dismiss с учётом политики и wrap.
-		int computeEffectiveDismissMs(
-			const Notification& n,
-			const Config& cfg,
-			float wrap_width,
-			int wrapped_lines /*>=1*/) const;
+        /// \brief Compute dismiss time with policy and wrapped content.
+        /// \param n Notification instance.
+        /// \param cfg Configuration.
+        /// \param wrap_width Wrap width in pixels.
+        /// \param wrapped_lines Number of wrapped lines (>=1).
+        /// \return Effective dismiss time in milliseconds.
+        int computeEffectiveDismissMs(
+                const Notification& n,
+                const Config& cfg,
+                float wrap_width,
+                int wrapped_lines /*>=1*/) const;
 
         std::vector<Notification> m_notifications;
         Config     m_cfg{};

--- a/include/imguix/core/notify/NotificationTypes.hpp
+++ b/include/imguix/core/notify/NotificationTypes.hpp
@@ -19,7 +19,7 @@ namespace ImGuiX::Notify {
 
     /// \brief Toast lifecycle phase.
     enum class Phase : std::uint8_t { FadeIn, Wait, FadeOut, Expired, COUNT };
-    
+
     /// \brief Auto-duration mode.
     enum class AutoDurationMode : std::uint8_t { Off, PerChar, WPM };
     
@@ -36,7 +36,7 @@ namespace ImGuiX::Notify {
         // Rendering
         float wrap_width_frac     = 1.0f / 3.0f; ///< text wrap as viewport fraction
         float opacity             = 0.8f;        ///< global opacity
-        float close_btn_right_margin = 0.0f;     ///<
+        float close_btn_right_margin = 0.0f;     ///< margin between close button and right edge
         bool  use_separator       = false;       ///< separator between title/content
         bool  use_dismiss_button  = true;        ///< show close button
         int   render_limit        = 5;           ///< 0 = unlimited
@@ -57,38 +57,38 @@ namespace ImGuiX::Notify {
             // ImGuiWindowFlags_NoDocking             |
             ImGuiWindowFlags_NoSavedSettings;
             
-        // --- авто-длительность ---
+        // --- auto duration ---
         AutoDurationMode auto_mode = AutoDurationMode::WPM;
 
-        // PerChar: на сколько миллисекунд продлеваем на символ
-        float ms_per_char = 32.0f; // подбирается по вкусу (20–60мс)
+        // PerChar: milliseconds added per character
+        float ms_per_char = 32.0f; ///< tune between 20 and 60 ms
 
-        // WPM: скорость чтения (слов/мин) и средняя длина слова (символов)
-        float reading_wpm         = 220.0f;
-        float avg_chars_per_word  = 5.0f;
+        // WPM: reading speed and average word length
+        float reading_wpm        = 220.0f; ///< words per minute
+        float avg_chars_per_word = 5.0f;   ///< average characters per word
 
-        // Доп. надбавка за переносы строк (если текст длинный и реально занимает несколько строк)
-        int   extra_per_line_ms = 120;
+        // Extra time per wrapped line when text spans multiple lines
+        int   extra_per_line_ms = 120;     ///< milliseconds per wrapped line
 
-        // Ограничения и поведение
-        int   min_dismiss_ms = 1500;
-        int   max_dismiss_ms = 15000;
-        bool  pause_on_hover = true; // «заморозить таймер» когда тост под курсором
+        // Limits and behaviour
+        int   min_dismiss_ms = 1500;       ///< minimum dismiss time
+        int   max_dismiss_ms = 15000;      ///< maximum dismiss time
+        bool  pause_on_hover = true;       ///< pause timer when hovered
     };
     
     /// \brief Icon config (non-owning pointers to FA6 glyphs).
     struct IconConfig {
-        const char* icon_success = IMGUIX_NOTIFY_ICON_SUCCESS;
-        const char* icon_warning = IMGUIX_NOTIFY_ICON_WARNING;
-        const char* icon_error   = IMGUIX_NOTIFY_ICON_ERROR;
-        const char* icon_info    = IMGUIX_NOTIFY_ICON_INFO;
-        const char* icon_close   = IMGUIX_NOTIFY_ICON_CLOSE;
+        const char* icon_success = IMGUIX_NOTIFY_ICON_SUCCESS; ///< success icon
+        const char* icon_warning = IMGUIX_NOTIFY_ICON_WARNING; ///< warning icon
+        const char* icon_error   = IMGUIX_NOTIFY_ICON_ERROR;   ///< error icon
+        const char* icon_info    = IMGUIX_NOTIFY_ICON_INFO;    ///< info icon
+        const char* icon_close   = IMGUIX_NOTIFY_ICON_CLOSE;   ///< close icon
     };
-    
-    /// \brief Настройка шрифтов (опционально).
+
+    /// \brief Optional font configuration.
     struct FontConfig {
-        ImFont* text  = nullptr; ///< текстовый шрифт (если null — текущий)
-        ImFont* icons = nullptr; ///< шрифт иконок (если null — иконки смержены)
+        ImFont* text  = nullptr; ///< text font; null uses current
+        ImFont* icons = nullptr; ///< icon font; null uses merged icons
     };
 
 } // namespace ImGuiX::Notify

--- a/include/imguix/widgets/notify/notifications.hpp
+++ b/include/imguix/widgets/notify/notifications.hpp
@@ -153,7 +153,13 @@ namespace ImGuiX::Widgets {
 
     // -------------------- fmt-style helpers (optional) --------------------
 
-    /// \brief Post a notification using fmt with compile-time checked format (string literal).
+    /// \brief Post a notification using fmt with compile-time checked format.
+    /// \tparam Args Format argument types.
+    /// \param ctrl Controller with a NotificationManager.
+    /// \param type Notification type.
+    /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+    /// \param fmt_s Format string.
+    /// \param args Format arguments.
     template<class... Args>
     inline void NotifyFmt(
             Controller* ctrl,
@@ -169,6 +175,12 @@ namespace ImGuiX::Widgets {
     }
 
     /// \brief Post a notification using fmt for a runtime format string.
+    /// \tparam Args Format argument types.
+    /// \param ctrl Controller with a NotificationManager.
+    /// \param type Notification type.
+    /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+    /// \param fmt_rt Runtime format string.
+    /// \param args Format arguments.
     template<class... Args>
     inline void NotifyFmtRuntime(
             Controller* ctrl,
@@ -184,7 +196,16 @@ namespace ImGuiX::Widgets {
         InsertNotification(ctrl, std::move(n));
     }
 
-    /// \brief Post a notification with title/content via fmt (both literals).
+    /// \brief Post a notification with title and content via fmt.
+    /// \tparam ArgsT Title argument types.
+    /// \tparam ArgsC Content argument types.
+    /// \param ctrl Controller with a NotificationManager.
+    /// \param type Notification type.
+    /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+    /// \param title_fmt Title format string.
+    /// \param title_args Title format arguments.
+    /// \param content_fmt Content format string.
+    /// \param content_args Content format arguments.
     template<class... ArgsT, class... ArgsC>
     inline void NotifyWithTitleFmt(
             Controller* ctrl,
@@ -202,7 +223,18 @@ namespace ImGuiX::Widgets {
         InsertNotification(ctrl, std::move(n));
     }
 
-    /// \brief Post a notification with a button via fmt (all literals).
+    /// \brief Post a notification with a button via fmt.
+    /// \tparam ArgsT Title argument types.
+    /// \tparam ArgsC Content argument types.
+    /// \param ctrl Controller with a NotificationManager.
+    /// \param type Notification type.
+    /// \param dismiss_ms Auto-dismiss delay in milliseconds.
+    /// \param button_label Button label.
+    /// \param on_click Callback executed on button click.
+    /// \param title_fmt Title format string.
+    /// \param title_args Title format arguments.
+    /// \param content_fmt Content format string.
+    /// \param content_args Content format arguments.
     template<class... ArgsT, class... ArgsC>
     inline void NotifyWithButtonFmt(
             Controller* ctrl,


### PR DESCRIPTION
## Summary
- document notification entity accessors and timing helpers
- clarify NotificationManager API and internal timing logic
- translate notify config comments and add template docs

## Testing
- `cmake -S . -B build` *(fails: SFML component 'System' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b29a1d1a74832c99191df005cc48c8