### PR TITLE
docs: normalize window doxygen

### DIFF
--- a/include/imguix/core/window/DeltaClockSfml.hpp
+++ b/include/imguix/core/window/DeltaClockSfml.hpp
@@ -3,7 +3,7 @@
 #define _IMGUIX_CORE_TIME_DELTA_CLOCK_SFML_HPP_INCLUDED
 
 /// \file DeltaClockSfml.hpp
-/// \brief Lightweight wrapper around sf::Clock for delta timing.
+/// \brief Wrap sf::Clock for delta timing.
 /// \ingroup Core
 
 #include <SFML/System/Clock.hpp>
@@ -11,15 +11,15 @@
 
 namespace ImGuiX {
 
-    /// \brief SFML-specific delta time clock wrapper.
+    /// \brief Track frame delta time using sf::Clock.
     class DeltaClockSfml {
     public:
-        /// \brief Updates internal delta time by restarting the SFML clock.
+        /// \brief Restart SFML clock and store elapsed time.
         void update() {
             m_delta = m_clock.restart();
         }
 
-        /// \brief Get last delta time value.
+        /// \brief Return elapsed time since last update.
         /// \return Time since last update.
         const sf::Time& delta() const {
             return m_delta;

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -44,7 +44,7 @@ namespace ImGuiX {
         private WindowInterface,
         public Pubsub::EventMediator {
     public:
-        /// \brief Constructs the window with a unique ID and name.
+        /// \brief Construct window with unique ID and name.
         /// \param id Unique window identifier.
         /// \param app Reference to application context interface.
         /// \param name Window name (title).
@@ -61,27 +61,29 @@ namespace ImGuiX {
         /// \brief Optional callback invoked after the window is added to the manager.
         virtual void onInit() {}
 
-        /// \brief Initializes the window (e.g., creates backend resources).
+        /// \brief Initialize window and create backend resources.
+        /// \return True on success.
         virtual bool create();
 
-        /// \brief Initializes the window with explicit dimensions.
+        /// \brief Initialize window with explicit dimensions.
         /// \param w Width in pixels.
         /// \param h Height in pixels.
+        /// \return True on success.
         virtual bool create(int w, int h);
 
-        /// \brief Processes input events and window messages.
+        /// \brief Process input events and window messages.
         virtual void handleEvents();
 
-        /// \brief Updates logic for the current frame.
+        /// \brief Update logic for the current frame.
         virtual void tick();
 
-        /// \brief Renders scene content (e.g., world, game objects).
+        /// \brief Render scene content (e.g., world, game objects).
         virtual void drawContent();
 
-        /// \brief Renders UI overlays, HUDs, debug panels.
+        /// \brief Render UI overlays, HUDs, debug panels.
         virtual void drawUi();
 
-        /// \brief Finalizes frame and presents to screen.
+        /// \brief Finalize frame and present to screen.
         virtual void present();
 
         /// \brief Creates and registers a controller of given type.
@@ -100,22 +102,28 @@ namespace ImGuiX {
 
         // --- WindowInterface interface ---
 
-        /// \brief Returns the unique ID of this window.
+        /// \brief Return unique window ID.
+        /// \return Window identifier.
         int id() const override;
 
-        /// \brief Returns the window name used as title.
+        /// \brief Return window name used as title.
+        /// \return Window name.
         const std::string& name() const override;
 
-        /// \brief Current width of the window in pixels.
+        /// \brief Return current window width in pixels.
+        /// \return Width in pixels.
         int width() const override;
 
-        /// \brief Current height of the window in pixels.
+        /// \brief Return current window height in pixels.
+        /// \return Height in pixels.
         int height() const override;
 
-        /// \brief Sets window dimensions in pixels.
+        /// \brief Set window dimensions in pixels.
+        /// \param w New width in pixels.
+        /// \param h New height in pixels.
         void setSize(int w, int h) override;
         
-        /// \brief Sets the window icon from an image file (currently SFML only).
+        /// \brief Set the window icon from an image file (currently SFML only).
         /// \param path Path to the icon image file (must be .png or .bmp, 32x32 or 64x64 recommended).
         /// \return True if the icon was loaded and applied successfully.
         bool setWindowIcon(const std::string& path) override;
@@ -124,57 +132,67 @@ namespace ImGuiX {
         /// \param id Identifier of registered theme.
         void setTheme(std::string id) override;
         
-        /// \brief Enables or disables clearing the background between frames.
+        /// \brief Enable or disable clearing the background between frames.
         /// \param disable True to disable clearing.
-        void setDisableBackground(bool disable) override {};
+        void setDisableBackground(bool disable) override { (void)disable; }
 
-        /// \brief Requests the window to close.
+        /// \brief Request window to close.
         void close() override;
 
-        /// \brief Minimizes the window.
+        /// \brief Minimize the window.
         void minimize() override;
 
-        /// \brief Maximizes the window.
+        /// \brief Maximize the window.
         void maximize() override;
 
-        /// \brief Restores the window from minimized or maximized state.
+        /// \brief Restore the window from minimized or maximized state.
         void restore() override;
 
-        /// \brief Checks whether the window is maximized.
+        /// \brief Return true if the window is maximized.
+        /// \return True when maximized.
         bool isMaximized() const override;
 
-        /// \brief Toggles between maximized and restored states.
+        /// \brief Toggle between maximized and restored states.
         void toggleMaximizeRestore() override;
 
-        /// \brief Activates or deactivates the window.
+        /// \brief Activate or deactivate the window.
+        /// \param active True to activate.
+        /// \return True on success.
         bool setActive(bool active) override;
 
-        /// \brief Returns true if the window currently has focus.
+        /// \brief Return true if the window has focus.
+        /// \return True when active.
         bool isActive() const override;
 
-        /// \brief Shows or hides the window.
+        /// \brief Show or hide the window.
         void setVisible(bool visible) override;
 
-        /// \brief Returns true if the window is open.
+        /// \brief Return true if the window is open.
+        /// \return True while the window exists.
         bool isOpen() const override;
         
-        /// \brief Makes the window context current for rendering.
-        /// Call only between frames before ImGui::NewFrame().
+        /// \brief Make the window context current for rendering.
+        /// \note Call only between frames before ImGui::NewFrame().
         virtual void setCurrentWindow();
 
-        /// \brief Access to the global event bus.
+        /// \brief Provide access to the global event bus.
+        /// \return Event bus.
         Pubsub::EventBus& eventBus() override;
 
-        /// \brief Access to the shared resource registry.
+        /// \brief Provide access to the shared resource registry.
+        /// \return Resource registry.
         ResourceRegistry& registry() override;
 
-        /// \brief Access to the global options store.
+        /// \brief Provide access to the global options store.
+        /// \return Options store control interface.
         OptionsStore::Control& options() override;
 
-        /// \brief Read-only access to the global options store.
+        /// \brief Provide read-only access to the global options store.
+        /// \return Options store view.
         const OptionsStore::View& options() const override;
 
-        /// \brief Reference to the owning application.
+        /// \brief Return reference to the owning application.
+        /// \return Application context interface.
         ApplicationContext& application() override;
 
 #       ifdef IMGUIX_USE_SFML_BACKEND
@@ -333,9 +351,9 @@ namespace ImGuiX {
         ImGuiX::Notify::NotificationManager m_notification_manager{}; ///< Toast notifications manager.
 
 
-        /// \brief Requests the window to switch its UI language.
+        /// \brief Hook before applying requested language.
         /// \param lang Language code to apply.
-        virtual void onBeforeLanguageApply(const std::string& /*lang*/) {};
+        virtual void onBeforeLanguageApply(const std::string& lang) { (void)lang; }
     };
 
 } // namespace ImGuiX

--- a/include/imguix/core/window/WindowInterface.hpp
+++ b/include/imguix/core/window/WindowInterface.hpp
@@ -12,7 +12,7 @@
 
 namespace ImGuiX {
 
-    /// \brief Interface for controlling and querying a single window instance.
+    /// \brief Control and query a single window instance.
     ///
     /// Provides access to:
     /// - Window identity (ID, name)
@@ -23,23 +23,23 @@ namespace ImGuiX {
     public:
         virtual ~WindowInterface() = default;
 
-        /// \brief Returns unique window ID.
+        /// \brief Return unique window ID.
         /// \return Window identifier.
         virtual int id() const = 0;
 
-        /// \brief Returns window name (title).
+        /// \brief Return window name (title).
         /// \return String with window title.
         virtual const std::string& name() const = 0;
 
-        /// \brief Returns current window width in pixels.
+        /// \brief Return current window width in pixels.
         /// \return Width in pixels.
         virtual int width() const = 0;
 
-        /// \brief Returns current window height in pixels.
+        /// \brief Return current window height in pixels.
         /// \return Height in pixels.
         virtual int height() const = 0;
 
-        /// \brief Sets the window icon from an image file (SFML only).
+        /// \brief Set window icon from an image file (SFML only).
         /// \param path Path to the icon image file (PNG/BMP, 32x32 or 64x64 recommended).
         /// \return True if the icon was loaded and applied successfully.
         virtual bool setWindowIcon(const std::string& path) = 0;
@@ -48,73 +48,73 @@ namespace ImGuiX {
         /// \param id Identifier of registered theme.
         virtual void setTheme(std::string id) = 0;
 
-        /// \brief Enables or disables background clearing between frames.
+        /// \brief Enable or disable background clearing between frames.
         /// \param disable True to disable clearing.
         virtual void setDisableBackground(bool disable) = 0;
 
-        /// \brief Sets window dimensions in pixels.
+        /// \brief Set window dimensions in pixels.
         /// \param w New width.
         /// \param h New height.
         virtual void setSize(int w, int h) = 0;
 
-        /// \brief Closes the window.
+        /// \brief Close the window.
         virtual void close() = 0;
 
-        /// \brief Minimizes the window.
+        /// \brief Minimize the window.
         virtual void minimize() = 0;
 
-        /// \brief Maximizes the window.
+        /// \brief Maximize the window.
         virtual void maximize() = 0;
 
-        /// \brief Restores the window from minimized or maximized state.
+        /// \brief Restore the window from minimized or maximized state.
         virtual void restore() = 0;
         
-        /// \brief Returns true if window is currently maximized.
+        /// \brief Return true if window is maximized.
         /// \return True when maximized.
         virtual bool isMaximized() const = 0;
 
-        /// \brief Toggles between maximized and restored states.
+        /// \brief Toggle between maximized and restored states.
         virtual void toggleMaximizeRestore() = 0;
 
-        /// \brief Set whether the window is active.
+        /// \brief Activate or deactivate the window.
         /// \param active True to activate window.
         /// \return True if operation succeeded.
         virtual bool setActive(bool active) = 0;
 
-        /// \brief Returns true if the window is currently active (focused).
+        /// \brief Return true if the window is active (focused).
         /// \return True when active.
         virtual bool isActive() const = 0;
 
-        /// \brief Set whether the window is visible.
+        /// \brief Show or hide the window.
         /// \param visible True to show window.
         virtual void setVisible(bool visible) = 0;
 
-        /// \brief Returns true if the window is currently open.
+        /// \brief Return true if the window is open.
         /// \return True while the window exists.
         virtual bool isOpen() const = 0;
 
-        /// \brief Provides access to the global event bus.
+        /// \brief Provide access to the global event bus.
         /// \return Reference to the EventBus.
         virtual Pubsub::EventBus& eventBus() = 0;
 
-        /// \brief Provides access to the global resource registry.
+        /// \brief Provide access to the global resource registry.
         /// \return Reference to the ResourceRegistry.
         virtual ResourceRegistry& registry() = 0;
 
-        /// \brief Provides access to the global options store.
+        /// \brief Provide access to the global options store.
         /// \return Reference to the options store control interface.
         virtual OptionsStore::Control& options() = 0;
 
-        /// \brief Provides read-only access to the global options store.
+        /// \brief Provide read-only access to the global options store.
         /// \return Reference to the options store view.
         virtual const OptionsStore::View& options() const = 0;
         
-        /// \brief Returns the owning application interface.
+        /// \brief Return the owning application interface.
         /// \return Reference to ApplicationContext.
         virtual ApplicationContext& application() = 0;
 
 #       ifdef IMGUIX_USE_SFML_BACKEND
-        /// \brief Provides access to the underlying SFML render target.
+        /// \brief Provide access to the underlying SFML render target.
         /// \return Reference to the SFML render window.
         virtual sf::RenderWindow& getRenderTarget() = 0;
 #       endif

--- a/include/imguix/core/window/WindowManager.hpp
+++ b/include/imguix/core/window/WindowManager.hpp
@@ -3,14 +3,14 @@
 #define _IMGUIX_CORE_WINDOW_MANAGER_HPP_INCLUDED
 
 /// \file WindowManager.hpp
-/// \brief WindowManager controls and orchestrates all active windows.
+/// \brief Control and orchestrate all active windows.
 /// \ingroup Core
 
 namespace ImGuiX {
 
     /// \brief Manage all windows in the application.
-    /// \note Delegates lifecycle operations to each registered window instance.
-    /// \note Provides interfaces for ticking, drawing, and shutdown control.
+    /// \note Delegate lifecycle operations to each registered window instance.
+    /// \note Provide interfaces for ticking, drawing, and shutdown control.
     class WindowManager : public Pubsub::EventMediator {
     public:
         /// \brief Construct window manager with access to the application.
@@ -29,7 +29,7 @@ namespace ImGuiX {
         void addWindow(std::unique_ptr<WindowInstance> window);
 
         /// \brief Prepare window state before each frame.
-        /// \note Moves pending windows, initializes them, and removes closed windows.
+        /// \note Move pending windows, initialize them, and remove closed windows.
         void prepareFrame();
 
         /// \brief Close all managed windows.
@@ -53,16 +53,16 @@ namespace ImGuiX {
         void shutdown();
 
     private:
-        /// \brief Forward handle_events to all windows.
+        /// \brief Forward handleEvents to all windows.
         void handleEvents();
 
         /// \brief Forward tick to all windows.
         void tickAll();
 
-        /// \brief Forward draw_ui to all windows.
+        /// \brief Forward drawUi to all windows.
         void drawUiAll();
 
-        /// \brief Forward draw_content to all windows.
+        /// \brief Forward drawContent to all windows.
         void drawContentAll();
 
         /// \brief Forward present to all windows.

--- a/include/imguix/core/window/imgui_glsl_version.hpp
+++ b/include/imguix/core/window/imgui_glsl_version.hpp
@@ -1,4 +1,6 @@
-// imgui_glsl_version.hpp
+/// \file imgui_glsl_version.hpp
+/// \brief Define GLSL version string based on platform.
+#pragma once
 #ifndef IMGUIX_GLSL_VERSION
 #  if defined(__EMSCRIPTEN__)
 #    define IMGUIX_GLSL_VERSION u8"#version 300 es"   // WebGL2


### PR DESCRIPTION
## Summary
- align delta clock wrapper with project doc style
- normalize WindowInstance, WindowInterface, and WindowManager comments
- document GLSL version header

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b29a5196b8832caf6dec770b1fe413