### PR TITLE
docs: improve Doxygen coverage for utilities

### DIFF
--- a/include/imguix/utils/time_utils.hpp
+++ b/include/imguix/utils/time_utils.hpp
@@ -14,20 +14,33 @@ namespace ImGuiX::Utils {
 
     // ---------- civil date algorithms (Howard Hinnant) ----------
 
-    /// @brief Leap year check for civil year.
+    /// \brief Check if the year is leap.
+    /// \param y Civil year.
+    /// \return True if \p y is leap.
     inline bool is_leap_year_date(int64_t y) noexcept {
         return (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
     }
 
-    /// @brief Days since 1970-01-01 for civil y-m-d.
+    /// \brief Compute days since 1970-01-01 for civil date.
+    /// \param y Civil year.
+    /// \param m Month [1,12].
+    /// \param d Day [1,31].
+    /// \return Days since Unix epoch.
     int64_t days_from_civil(int64_t y, unsigned m, unsigned d) noexcept;
 
-    /// @brief Civil y-m-d from days since 1970-01-01.
+    /// \brief Convert days since 1970-01-01 to civil date.
+    /// \param z Days since Unix epoch.
+    /// \param y Output civil year.
+    /// \param m Output month.
+    /// \param d Output day.
     void civil_from_days(int64_t z, int64_t& y, unsigned& m, unsigned& d) noexcept;
 
     // ---------- timestamp <-> ymdhms ----------
 
-    /// @brief num days in month for civil y-m.
+    /// \brief Number of days in month for civil year and month.
+    /// \param year Civil year.
+    /// \param month Month [1,12].
+    /// \return Days in month.
     inline int num_days_in_month(int64_t year, int month) {
         static const int k_days[12] = {31,28,31,30,31,30,31,31,30,31,30,31};
         int d = k_days[month - 1];
@@ -35,7 +48,15 @@ namespace ImGuiX::Utils {
         return d;
     }
 
-    /// @brief Clamp Y/M/D/h/m/s into sane ranges (with year bounds).
+    /// \brief Clamp Y/M/D/h/m/s into ranges with year bounds.
+    /// \param y Year value to clamp.
+    /// \param m Month value to clamp.
+    /// \param d Day value to clamp.
+    /// \param hh Hour value to clamp.
+    /// \param mm Minute value to clamp.
+    /// \param ss Second value to clamp.
+    /// \param min_year Minimum year inclusive.
+    /// \param max_year Maximum year inclusive.
     void clamp_ymdhms(
             int64_t& y,
             int& m,
@@ -45,14 +66,26 @@ namespace ImGuiX::Utils {
             int& ss,
             int min_year,
             int max_year);
-    
-    /// \brief Clamp Y/M/D to sane ranges using Utils::clamp_ymdhms.
+
+    /// \brief Clamp year, month, and day using clamp_ymdhms.
+    /// \param y Year value to clamp.
+    /// \param m Month value to clamp.
+    /// \param d Day value to clamp.
+    /// \param min_y Minimum year inclusive.
+    /// \param max_y Maximum year inclusive.
     inline void clamp_ymd(int64_t& y, int& m, int& d, int min_y, int max_y) {
-        int hh=0, mm=0, ss=0;
+        int hh = 0, mm = 0, ss = 0;
         clamp_ymdhms(y, m, d, hh, mm, ss, min_y, max_y);
     }
 
-    /// @brief Split POSIX seconds into Y/M/D/h/m/s.
+    /// \brief Split POSIX seconds into date-time components.
+    /// \param ts Seconds since Unix epoch.
+    /// \param year Output year.
+    /// \param month Output month.
+    /// \param day Output day.
+    /// \param hour Output hour.
+    /// \param minute Output minute.
+    /// \param second Output second.
     void timestamp_to_ymdhms(
             int64_t ts,
             int64_t& year,
@@ -62,7 +95,14 @@ namespace ImGuiX::Utils {
             int& minute,
             int& second);
 
-    /// @brief Compose POSIX seconds from Y/M/D/h/m/s.
+    /// \brief Compose POSIX seconds from date-time components.
+    /// \param year Civil year.
+    /// \param month Month.
+    /// \param day Day.
+    /// \param hour Hour.
+    /// \param minute Minute.
+    /// \param second Second.
+    /// \return Seconds since Unix epoch.
     int64_t ymdhms_to_timestamp(
             int64_t year,
             int month,
@@ -73,12 +113,20 @@ namespace ImGuiX::Utils {
 
     // ---------- H:M:S helpers ----------
 
+    /// \brief Clamp seconds to the range [0, 86399].
+    /// \param sec Seconds to clamp.
+    /// \return Clamped seconds.
     inline int clamp_time_sec(int sec) {
         if (sec < 0)   return 0;
         if (sec > 86399) return 86399;
         return sec;
     }
 
+    /// \brief Convert seconds to hours, minutes, and seconds.
+    /// \param sec Seconds to convert.
+    /// \param h Output hours.
+    /// \param m Output minutes.
+    /// \param s Output seconds.
     inline void seconds_to_hms(int sec, int& h, int& m, int& s) {
         sec = clamp_time_sec(sec);
         h = sec / 3600;
@@ -86,6 +134,11 @@ namespace ImGuiX::Utils {
         s = sec % 60;
     }
 
+    /// \brief Compose seconds from hours, minutes, and seconds.
+    /// \param h Hours component.
+    /// \param m Minutes component.
+    /// \param s Seconds component.
+    /// \return Seconds in range [0, 86399].
     inline int hms_to_seconds(int h, int m, int s) {
         h = std::clamp(h, 0, 23);
         m = std::clamp(m, 0, 59);
@@ -95,13 +148,21 @@ namespace ImGuiX::Utils {
     
     // ---------- weekdays ----------
 
-    /// @brief Weekday 0=Sun..6=Sat for civil date.
+    /// \brief Weekday index where 0=Sun and 6=Sat.
+    /// \param y Civil year.
+    /// \param m Month [1,12].
+    /// \param d Day [1,31].
+    /// \return Weekday index.
     int weekday_sun0_from_ymd(int64_t y, int m, int d);
 
-    /// @brief Convert Sunday-based index (Sun=0..Sat=6) to Monday-based (Mon=0..Sun=6).
+    /// \brief Convert Sunday-based index (Sun=0..Sat=6) to Monday-based.
+    /// \param sun0 Sunday-based weekday index.
+    /// \return Monday-based weekday index.
     inline int to_monday0(int sun0) { return (sun0 + 6) % 7; }
 
-    /// \brief Format month by mode.
+    /// \brief Short English month name.
+    /// \param m Month [1,12].
+    /// \return Pointer to static month name or "???".
     inline const char* month_short_name(int m) {
         static const char* k[12] = {"Jan","Feb","Mar","Apr","May","Jun",
                                     "Jul","Aug","Sep","Oct","Nov","Dec"};
@@ -110,20 +171,42 @@ namespace ImGuiX::Utils {
     
     // ---------- format ----------
 
+    /// \brief Format seconds as "HH:MM:SS".
+    /// \param sec Seconds to format.
+    /// \return Formatted string.
     std::string format_hms(int sec);
 
+    /// \brief Format signed offset seconds as "+HH:MM:SS".
+    /// \param off_sec Offset seconds.
+    /// \return Formatted string.
     std::string format_signed_hms(int64_t off_sec);
 
-    /// \brief Format YYYY-MM-DD.
+    /// \brief Format date as "YYYY-MM-DD".
+    /// \param y Civil year.
+    /// \param m Month.
+    /// \param d Day.
+    /// \return Formatted string.
     std::string format_ymd(int64_t y, int m, int d);
 
-    /// \brief Optional human hint like "Mon 2025-08-25" based on Utils weekday.
+    /// \brief Format date with weekday prefix like "Mon 2025-08-25".
+    /// \param y Civil year.
+    /// \param m Month.
+    /// \param d Day.
+    /// \return Formatted string.
     std::string format_with_weekday(int64_t y, int m, int d);
 
-    /// @brief Parse "+03:00", "-05:30:15", "3:00", "0300" into signed seconds.
+    /// \brief Parse signed offset like "+03:00" or "-05:30:15".
+    /// \param txt Input text.
+    /// \param out_sec Output seconds.
+    /// \return True on success.
     bool parse_signed_hms(const char* txt, int64_t& out_sec);
 
     /// \brief Parse "YYYY-MM-DD", "YYYY/MM/DD", "YYYY.MM.DD", or "YYYYMMDD".
+    /// \param txt Input text.
+    /// \param y Output year.
+    /// \param m Output month.
+    /// \param d Output day.
+    /// \return True on success.
     /// Accepts optional spaces; rejects invalid ranges.
     bool parse_ymd(const char* txt, int64_t& y, int& m, int& d);
 

--- a/include/imguix/utils/vformat.hpp
+++ b/include/imguix/utils/vformat.hpp
@@ -2,8 +2,8 @@
 #ifndef _IMGUIX_UTILS_VFORMAT_HPP_INCLUDED
 #define _IMGUIX_UTILS_VFORMAT_HPP_INCLUDED
 
-/// \file format.hpp
-/// \brief Function for formatting strings according to a specified format.
+/// \file vformat.hpp
+/// \brief String formatting helpers using printf semantics.
 
 #include <cstdarg>
 #include <vector>
@@ -11,18 +11,9 @@
 
 namespace ImGuiX::Utils {
 
-    /// \brief vsnprintf-based formatter using a va_list (robust, resizes buffer).
-    ///
-    /// This function formats a string using either the custom implementation based on `vsnprintf`).
-    ///
-    /// \param fmt The format string (similar to printf format).
-    /// \param ... A variable number of arguments matching the format string.
-    /// \see https://habr.com/ru/articles/318962/
-    /// \return A formatted std::string.
-    
-    /// \brief vsnprintf-based formatter using a va_list (robust, resizes buffer).
+    /// \brief Format string using a va_list.
     /// \param fmt printf-like format string.
-    /// \param args argument list (will be copied internally).
+    /// \param args Argument list copied internally.
     /// \return Formatted string.
     inline std::string vformat_va(const char *fmt, va_list args) {
         if (!fmt) return {};
@@ -44,7 +35,9 @@ namespace ImGuiX::Utils {
         }
     }
     
-    /// \brief printf-style formatter (varargs) built on top of vformat_va.
+    /// \brief Format string using variable arguments.
+    /// \param fmt printf-like format string.
+    /// \return Formatted string.
     inline std::string vformat(const char* fmt, ...) {
         if (!fmt) return {};
         va_list args; va_start(args, fmt);

--- a/tests/test_widgets.cpp
+++ b/tests/test_widgets.cpp
@@ -38,7 +38,13 @@
 //namespace i18n = ImGuiX::I18N;
 
 #ifdef IMGUI_ENABLE_IMPLOT
-// Генератор OHLCV-баров с шагом времени tf_sec (сек) и временем в миллисекундах
+/// \brief Generate synthetic OHLCV bars.
+/// \param out Output bar container.
+/// \param count Number of bars to produce.
+/// \param tf_sec Timeframe in seconds.
+/// \param start_time Starting timestamp.
+/// \param start_price Starting price.
+/// \param seed Random seed.
 inline static void GenerateBars(
         std::vector<ImGuiX::Widgets::OhlcvBar>& out,
         int count, int tf_sec, std::uint64_t start_time,


### PR DESCRIPTION
## Summary
- clarify formatting helpers in vformat.hpp
- document date and time utilities
- comment test bar generator

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b29b86140c832cb6b2c9d9687195a2