### PR TITLE
docs(utils): clarify varargs and UTF-8 validation

### DIFF
--- a/include/imguix/utils/encoding_utils.hpp
+++ b/include/imguix/utils/encoding_utils.hpp
@@ -29,7 +29,7 @@ namespace ImGuiX::Utils {
 
     /// \brief Validate UTF-8 string.
     /// \param message String to validate.
-    /// \return `true` if string is valid UTF-8, `false` otherwise.
+    /// \return True if string is valid UTF-8.
     bool IsValidUtf8(const char* message);
 
     /// \brief Convert CP1251 string to UTF-8.

--- a/include/imguix/utils/vformat.hpp
+++ b/include/imguix/utils/vformat.hpp
@@ -37,6 +37,7 @@ namespace ImGuiX::Utils {
     
     /// \brief Format string using variable arguments.
     /// \param fmt printf-like format string.
+    /// \param ... Arguments to format.
     /// \return Formatted string.
     inline std::string vformat(const char* fmt, ...) {
         if (!fmt) return {};


### PR DESCRIPTION
## Summary
- document variadic arguments for `vformat`
- clarify UTF-8 validation return description

## Testing
- `cmake -S . -B build -DIMGUIX_HEADER_ONLY=ON -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF` *(fails: Target "imguix" INTERFACE_INCLUDE_DIRECTORIES property contains path ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b29cd80308832ca26188042fdf004b