### PR TITLE
docs: standardize Doxygen in extension headers

### DIFF
--- a/include/imguix/extensions/color_gradient.hpp
+++ b/include/imguix/extensions/color_gradient.hpp
@@ -10,16 +10,26 @@
 
 namespace ImGuiX::Extensions {
 
+    /// \brief HSV color components.
     struct Hsv {
-        double h; /// angle in degrees
-        double s; /// fraction between 0 and 1
-        double v; /// fraction between 0 and 1
+        /// \brief Hue angle in degrees.
+        double h;
+        /// \brief Saturation as fraction [0,1].
+        double s;
+        /// \brief Value as fraction [0,1].
+        double v;
     };
 
+    /// \brief Convert HSV color to RGBA vector.
+    /// \param in HSV color.
+    /// \return Corresponding RGBA color with alpha = 1.
     ImVec4 hsvToRgb(const Hsv& in);
 
+    /// \brief Generates sequential colors from HSV spectrum.
     class ColorGradient {
     public:
+        /// \brief Construct gradient for given number of colors.
+        /// \param count Number of colors to cycle through.
         explicit ColorGradient(std::size_t count);
 
         /// \brief Retrieve next color from gradient.

--- a/include/imguix/extensions/ema.hpp
+++ b/include/imguix/extensions/ema.hpp
@@ -12,6 +12,7 @@ namespace ImGuiX::Extensions {
     /// \brief Exponential moving average stored in ImGui storage.
     class Ema {
     public:
+        /// \brief Default smoothing factor.
         static constexpr float kDefaultAlpha = 0.1f;
 
         /// \brief Reset stored value.

--- a/include/imguix/extensions/sizing.hpp
+++ b/include/imguix/extensions/sizing.hpp
@@ -10,7 +10,8 @@
 
 namespace ImGuiX::Extensions {
 
-    /// \brief Width of the combo arrow button (square) for the current style.
+    /// \brief Width of the combo arrow button for the current style.
+    /// \return Arrow width in pixels.
     inline float ComboArrowWidth() {
         return ImGui::GetFrameHeight();
     }
@@ -19,6 +20,7 @@ namespace ImGuiX::Extensions {
     /// \param combo_width  Total width of the combo item (SetNextItemWidth / CalcItemWidth).
     /// \param flags        Combo flags (respects NoArrowButton/NoPreview).
     /// \param extra_slack  Small safety padding to avoid clipping on fractional pixels.
+    /// \return Maximum preview text width.
     inline float CalcComboPreviewTextMax(
         float combo_width,
         ImGuiComboFlags flags = 0,
@@ -40,6 +42,7 @@ namespace ImGuiX::Extensions {
     /// \param preview_text  Text to fit (UTF-8).
     /// \param flags         Combo flags (respects NoArrowButton/NoPreview).
     /// \param extra_slack   Additional safety space (usually small, e.g. ItemSpacing.x * 0.5).
+    /// \return Combo width in pixels.
     inline float CalcComboWidthForPreview(
             const char* preview_text,
             ImGuiComboFlags flags = 0,
@@ -60,6 +63,7 @@ namespace ImGuiX::Extensions {
     /// \brief Compute width for a fixed-width numeric field (e.g., HH/MM/SS).
     /// \param sample_text  Text sample to fit (e.g., "+88" or "88").
     /// \param extra_slack  Small safety space (default: ItemSpacing.x * 0.25).
+    /// \return Field width in pixels.
     inline float CalcFieldWidthForSample(const char* sample_text, float extra_slack = -1.0f) {
         const ImGuiStyle& st = ImGui::GetStyle();
         if (extra_slack < 0.0f) extra_slack = st.ItemSpacing.x * 0.25f;
@@ -69,6 +73,7 @@ namespace ImGuiX::Extensions {
     /// \brief Recommended combo width for time-of-day preview ("23:59:59").
     /// \param signed_preview If true, includes '+' (use for offsets like "+23:59:59").
     /// \param flags          Combo flags (respects NoArrowButton/NoPreview).
+    /// \return Combo width in pixels.
     inline float CalcTimeComboWidth(
             bool signed_preview = true,
             ImGuiComboFlags flags = 0
@@ -78,12 +83,14 @@ namespace ImGuiX::Extensions {
     }
 
     /// \brief Recommended field width for HH/MM/SS steppers (fits "+88").
+    /// \return Field width in pixels.
     inline float CalcHMSFieldWidth() {
         return CalcFieldWidthForSample(IMGUIX_SIZING_HMS, ImGui::GetStyle().ItemSpacing.x * 0.25f);
     }
 
     /// \brief Recommended combo width for date preview like "Mon +8888-88-88".
-    /// \param flags       Combo flags (уважает NoArrowButton/NoPreview).
+    /// \param flags Combo flags (respects NoArrowButton/NoPreview).
+    /// \return Combo width in pixels.
     inline float CalcDateComboWidth(
             ImGuiComboFlags flags = 0
         ) {
@@ -93,7 +100,8 @@ namespace ImGuiX::Extensions {
 	}
 
     /// \brief Recommended field width for a year edit (fits "+8888" or "8888").
-    /// \param signed_year If true, reserves '+' for signed years (смещения/офсеты).
+    /// \param signed_year If true, reserves '+' for signed years (offsets).
+    /// \return Field width in pixels.
     inline float CalcYearFieldWidth(bool signed_year = true) {
         return CalcFieldWidthForSample(
                         signed_year ? IMGUIX_SIZING_YEAR_SIGNED : IMGUIX_SIZING_YEAR_UNSIGNED,
@@ -101,10 +109,15 @@ namespace ImGuiX::Extensions {
                 );
     }
 	
-	inline float CalcWeekdayComboWidth(ImGuiComboFlags flags = 0) {
-                return CalcComboWidthForPreview(IMGUIX_SIZING_WEEKDAYS,
-                                                                                flags, ImGui::GetStyle().ItemSpacing.x * 0.5f);
-	}
+    /// \brief Recommended combo width for weekday name preview.
+    /// \param flags Combo flags (respects NoArrowButton/NoPreview).
+    /// \return Combo width in pixels.
+    inline float CalcWeekdayComboWidth(ImGuiComboFlags flags = 0) {
+        return CalcComboWidthForPreview(
+                IMGUIX_SIZING_WEEKDAYS,
+                flags,
+                ImGui::GetStyle().ItemSpacing.x * 0.5f);
+    }
 
 } // namespace ImGuiX::Extensions
 

--- a/include/imguix/extensions/validation.hpp
+++ b/include/imguix/extensions/validation.hpp
@@ -12,7 +12,8 @@ namespace ImGuiX::Extensions {
 
     /// \brief Safe regex match. Returns true if matches or if regex is invalid (fail-open).
     /// \param s       Input string to validate.
-    /// \param pattern Regex pattern (std::string). If empty or invalid, returns true.
+    /// \param pattern Regex pattern. If empty or invalid, returns true.
+    /// \return True if pattern matches or validation is skipped.
     inline bool RegexMatchSafe(const std::string& s, const std::string& pattern);
 
     /// \brief Begin invalid styling if condition is true.


### PR DESCRIPTION
## Summary
- document HSV color structs and gradient helpers
- clarify default EMA alpha and return semantics
- document validation helpers and sizing width utilities

## Testing
- `cmake -S . -B build` *(fails: SFML component 'System' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b29c4fcf80832c8492adf2e4cd7fb6