### PR TITLE
Add theme picker widget with persistent storage

### DIFF
--- a/include/imguix/themes/theme_ids.hpp
+++ b/include/imguix/themes/theme_ids.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef _IMGUIX_THEMES_THEME_IDS_HPP_INCLUDED
+#define _IMGUIX_THEMES_THEME_IDS_HPP_INCLUDED
+
+/// \file theme_ids.hpp
+/// \brief Predefined theme identifiers and storage key.
+
+#define IMGUIX_THEME_CLASSIC        "classic"
+#define IMGUIX_THEME_LIGHT          "light"
+#define IMGUIX_THEME_DARK           "dark"
+#define IMGUIX_THEME_CORPORATE_GREY "corporate-grey"
+#define IMGUIX_THEME_DARK_CHARCOAL  "dark-charcoal"
+#define IMGUIX_THEME_DARK_GRAPHITE  "dark-graphite"
+#define IMGUIX_THEME_DARK_TEAL      "dark-teal"
+#define IMGUIX_THEME_DEEP_DARK      "deep-dark"
+#define IMGUIX_THEME_GOLD_BLACK     "gold-black"
+#define IMGUIX_THEME_GREEN_BLUE     "green-blue"
+#define IMGUIX_THEME_LIGHT_GREEN    "light-green"
+#define IMGUIX_THEME_OSX_LIGHT      "osx-light"
+#define IMGUIX_THEME_PEARL_LIGHT    "pearl-light"
+#define IMGUIX_THEME_SLATE_DARK     "slate-dark"
+#define IMGUIX_THEME_VS_DARK        "vs-dark"
+
+/// \brief Storage key used to persist theme selection.
+#define IMGUIX_THEME_STORAGE_KEY    "imguix.theme"
+
+#endif // _IMGUIX_THEMES_THEME_IDS_HPP_INCLUDED

--- a/include/imguix/widgets/misc/theme_picker.hpp
+++ b/include/imguix/widgets/misc/theme_picker.hpp
@@ -1,0 +1,128 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_MISC_THEME_PICKER_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_MISC_THEME_PICKER_HPP_INCLUDED
+
+/// \file theme_picker.hpp
+/// \brief Combo widget for selecting UI theme with persistent storage.
+
+#include <imgui.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+#include <imguix/core/controller/Controller.hpp>
+#include <imguix/core/window/WindowInterface.hpp>
+#include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcComboWidthForPreview
+#include <imguix/themes/theme_ids.hpp>
+
+namespace ImGuiX::Widgets {
+
+    /// \brief Theme entry for ThemePicker.
+    struct ThemeItem {
+        const char* id;    ///< Theme identifier.
+        const char* label; ///< Display name.
+    };
+
+    /// \brief Default list of themes.
+    /// \return Reference to static theme list.
+    inline const std::vector<ThemeItem>& DefaultThemes() {
+        static const std::vector<ThemeItem> themes = {
+            {IMGUIX_THEME_CLASSIC,        u8"Classic"},
+            {IMGUIX_THEME_LIGHT,          u8"Light"},
+            {IMGUIX_THEME_DARK,           u8"Dark"},
+            {IMGUIX_THEME_CORPORATE_GREY, u8"Corporate Grey"},
+            {IMGUIX_THEME_DARK_CHARCOAL,  u8"Dark Charcoal"},
+            {IMGUIX_THEME_DARK_GRAPHITE,  u8"Dark Graphite"},
+            {IMGUIX_THEME_DARK_TEAL,      u8"Dark Teal"},
+            {IMGUIX_THEME_DEEP_DARK,      u8"Deep Dark"},
+            {IMGUIX_THEME_GOLD_BLACK,     u8"Gold Black"},
+            {IMGUIX_THEME_GREEN_BLUE,     u8"Green Blue"},
+            {IMGUIX_THEME_LIGHT_GREEN,    u8"Light Green"},
+            {IMGUIX_THEME_OSX_LIGHT,      u8"OSX Light"},
+            {IMGUIX_THEME_PEARL_LIGHT,    u8"Pearl Light"},
+            {IMGUIX_THEME_SLATE_DARK,     u8"Slate Dark"},
+            {IMGUIX_THEME_VS_DARK,        u8"Visual Studio Dark"},
+        };
+        return themes;
+    }
+
+    /// \brief Configuration for ThemePicker widget.
+    struct ThemePickerConfig {
+        const char* label = u8"Theme";                   ///< Combo label.
+        float combo_width = 0.0f;                        ///< Forced combo width.
+        const std::vector<ThemeItem>* items = nullptr;   ///< Custom theme list.
+    };
+
+    /// \brief Theme selection combo with persistent storage.
+    /// \param id Unique widget identifier.
+    /// \param ctrl Controller that owns ThemeManager and OptionsStore.
+    /// \param cfg Widget configuration.
+    /// \return True if selection changed.
+    inline bool ThemePicker(const char* id,
+                            Controller* ctrl,
+                            const ThemePickerConfig& cfg = {}) {
+        if (!id || !ctrl) return false;
+
+        const std::vector<ThemeItem>& list =
+            (cfg.items && !cfg.items->empty()) ? *cfg.items : DefaultThemes();
+        if (list.empty()) return false;
+
+        auto& opts = ctrl->options();
+        std::string cur_id = opts.getStrOr(IMGUIX_THEME_STORAGE_KEY, list[0].id);
+
+        int cur_index = 0;
+        for (int i = 0; i < static_cast<int>(list.size()); ++i) {
+            if (cur_id == list[i].id) { cur_index = i; break; }
+        }
+
+        float combo_w = cfg.combo_width;
+        if (combo_w <= 0.0f) {
+            float maxw = 0.0f;
+            for (const auto& t : list) {
+                float w = ImGuiX::Extensions::CalcComboWidthForPreview(t.label);
+                if (w > maxw) maxw = w;
+            }
+            combo_w = maxw;
+        }
+
+        bool changed = false;
+        ImGui::PushID(id);
+        ImGui::SetNextItemWidth(combo_w);
+        const char* preview = list[cur_index].label;
+        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Theme", preview)) {
+            for (int i = 0; i < static_cast<int>(list.size()); ++i) {
+                bool sel = (i == cur_index);
+                if (ImGui::Selectable(list[i].label, sel)) {
+                    cur_index = i;
+                    cur_id = list[i].id;
+                    opts.setStr(IMGUIX_THEME_STORAGE_KEY, cur_id);
+                    ctrl->setTheme(cur_id);
+                    changed = true;
+                }
+                if (sel) ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+        }
+        ImGui::PopID();
+        return changed;
+    }
+
+    /// \brief Apply stored theme to window if present in options.
+    /// \param win Window to update.
+    inline void ApplyStoredTheme(WindowInterface* win) {
+        if (!win) return;
+        const auto id = win->options().getStrOr(IMGUIX_THEME_STORAGE_KEY, "");
+        if (!id.empty()) win->setTheme(id);
+    }
+
+    /// \brief Apply stored theme to controller if present in options.
+    /// \param ctrl Controller to update.
+    inline void ApplyStoredTheme(Controller* ctrl) {
+        if (!ctrl) return;
+        const auto id = ctrl->options().getStrOr(IMGUIX_THEME_STORAGE_KEY, "");
+        if (!id.empty()) ctrl->setTheme(id);
+    }
+
+} // namespace ImGuiX::Widgets
+
+#endif // _IMGUIX_WIDGETS_MISC_THEME_PICKER_HPP_INCLUDED

--- a/tests/test_widgets.cpp
+++ b/tests/test_widgets.cpp
@@ -29,6 +29,21 @@
 #include <imguix/widgets/auth/proxy_panel.hpp>
 #include <imguix/widgets/misc/loading_spinner.hpp>
 #include <imguix/widgets/misc/markers.hpp>
+#include <imguix/widgets/misc/theme_picker.hpp>
+
+// === Themes ===
+#include <imguix/themes/CorporateGreyTheme.hpp>
+#include <imguix/themes/DarkCharcoalTheme.hpp>
+#include <imguix/themes/DarkGraphiteTheme.hpp>
+#include <imguix/themes/DarkTealTheme.hpp>
+#include <imguix/themes/DeepDarkTheme.hpp>
+#include <imguix/themes/GoldBlackTheme.hpp>
+#include <imguix/themes/GreenBlueTheme.hpp>
+#include <imguix/themes/LightGreenTheme.hpp>
+#include <imguix/themes/OSXTheme.hpp>
+#include <imguix/themes/PearlLightTheme.hpp>
+#include <imguix/themes/SlateDarkTheme.hpp>
+#include <imguix/themes/VisualStudioDarkTheme.hpp>
 
 // === Графики ===
 #ifdef IMGUI_ENABLE_IMPLOT
@@ -99,6 +114,7 @@ public:
         m_state.auth_data.host     = options().getStrOr("host", "demo.local");
         m_state.auth_data.email    = options().getStrOr("email", "guest@example.com");
         m_state.auth_data.password = options().getStrOr("password", "");
+        ImGuiX::Widgets::ApplyStoredTheme(this);
     }
 
     void drawContent() override {
@@ -282,6 +298,11 @@ private:
     // Рендер всей демо-витрины виджетов (сгруппировано под спойлеры)
     void drawWidgetsDemo() {
         ImGui::SeparatorText("Widgets Demo");
+
+        // --- Theme Picker ---
+        if (ImGui::CollapsingHeader("Theme", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGuiX::Widgets::ThemePicker("demo.theme", this);
+        }
 
         // --- Authorization block ---
         if (ImGui::CollapsingHeader("Authorization", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -740,6 +761,21 @@ public:
         createController<WidgetsController>();
         create(id() == 0 ? 800 : 640, id() == 0 ? 600 : 480);
         setWindowIcon("data/resources/icons/icon.png");
+
+        auto& tm = themeManager();
+        ImGuiX::Themes::registerCorporateGreyTheme(tm);
+        ImGuiX::Themes::registerDarkCharcoalTheme(tm);
+        ImGuiX::Themes::registerDarkGraphiteTheme(tm);
+        ImGuiX::Themes::registerDarkTealTheme(tm);
+        ImGuiX::Themes::registerDeepDarkTheme(tm);
+        ImGuiX::Themes::registerGoldBlackTheme(tm);
+        ImGuiX::Themes::registerGreenBlueTheme(tm);
+        ImGuiX::Themes::registerLightGreenTheme(tm);
+        ImGuiX::Themes::registerOSXTheme(tm);
+        ImGuiX::Themes::registerPearlLightTheme(tm);
+        ImGuiX::Themes::registerSlateDarkTheme(tm);
+        ImGuiX::Themes::registerVisualStudioDarkTheme(tm);
+        ImGuiX::Widgets::ApplyStoredTheme(this);
 
         // Шрифты (ручная сборка)
         fontsBeginManual();


### PR DESCRIPTION
## Summary
- add predefined theme ID macros and storage key
- implement ThemePicker combo widget and helpers to apply stored theme
- showcase theme selector in widgets demo and register available themes

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f63b1cac832caba3f4cea0aedc7e