### PR TITLE
docs: add theme guide references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,7 @@ Format: `type(scope): short description` where the scope is optional. Keep messa
 | Path                     | Role                                                   |
 | ------------------------ | ------------------------------------------------------ |
 | `docs/FONTS-GUIDE.md` | FontManager usage; preset tokens including `MiscSymbols`, `Dingbats`, `Arrows`, `PUA` |
+| `docs/THEMES.md`        | Theme guide for built-in styles and creating custom themes |
 
 ### Dependency Map
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An object-oriented wrapper around [Dear ImGui](https://github.com/ocornut/imgui)
 - [Architecture](#architecture)
 - [Web/Emscripten](#webemscripten)
 - [CMake Options (Summary)](#cmake-options-summary)
+- [Themes](#themes)
 - [Fonts and Licensing](#fonts-and-licensing)
 - [License](#license)
 
@@ -223,6 +224,11 @@ After building, open `http://localhost:8081/index.html` in your browser.
 * JSON: `IMGUIX_VENDOR_JSON` — place `nlohmann_json` headers in the SDK.
 * Dependency modes:
   `IMGUIX_DEPS_MODE= AUTO|SYSTEM|BUNDLED` plus per-package `IMGUIX_DEPS_*_MODE` (`fmt`, `SFML`, `ImGui`, `ImGui-SFML`, `freetype`, `json`, `mdbx`).
+
+## Themes
+
+ImGuiX provides several built-in color themes and supports creating custom ones.
+See [docs/THEMES.md](docs/THEMES.md) for details.
 
 ## Fonts and Licensing
 


### PR DESCRIPTION
## Summary
- link theme guide from README and AGENTS

## Testing
- `cmake -S . -B build -DIMGUIX_HEADER_ONLY=ON` (fails: nlohmann_json missing)
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b2feb88788832c91642264ff250b4d