### PR TITLE
feat: add light blue theme

### DIFF
--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -17,6 +17,7 @@ This document lists the color themes bundled with ImGuiX and shows how to create
 - **Deep Dark** – Nearly black theme for high-contrast setups.
 - **Gold & Black** – Black background with gold accents.
 - **Green & Blue** – Dark background with green/blue accents.
+- **Light Blue** – Light background with subtle blue accents.
 - **Light Green** – Light background with subtle green accents.
 - **OSX Light** – macOS-like light appearance.
 - **Pearl Light** – Soft light theme with blue highlights.

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -1,0 +1,207 @@
+#pragma once
+#ifndef _IMGUIX_THEMES_LIGHT_BLUE_THEME_HPP_INCLUDED
+#define _IMGUIX_THEMES_LIGHT_BLUE_THEME_HPP_INCLUDED
+
+/// \file LightBlueTheme.hpp
+/// \brief Light-Blue theme for ImGui/ImPlot, ported to the ImGuiX theme system.
+///
+/// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
+/// Adaptations:
+///  - repeated colors moved to named constants
+///  - unified layout via applyDefaultImGuiStyle
+///  - added matching ImPlot styling (light)
+
+#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+
+namespace ImGuiX::Themes {
+
+    /// \namespace LightBlueConstants
+    /// \brief Color constants for the Light-Blue theme.
+    namespace LightBlueConstants {
+        // Text
+        constexpr ImVec4 Text                   = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+        constexpr ImVec4 TextDisabled           = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
+
+        // Backgrounds
+        constexpr ImVec4 WindowBg               = ImVec4(0.86f, 0.86f, 0.86f, 1.00f);
+        constexpr ImVec4 ChildBg                = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+        constexpr ImVec4 PopupBg                = ImVec4(0.93f, 0.93f, 0.93f, 0.98f);
+
+        // Borders
+        constexpr ImVec4 Border                 = ImVec4(0.71f, 0.71f, 0.71f, 0.08f);
+        constexpr ImVec4 BorderShadow           = ImVec4(0.00f, 0.00f, 0.00f, 0.04f);
+
+        // Frames
+        constexpr ImVec4 FrameBg                = ImVec4(0.71f, 0.71f, 0.71f, 0.55f);
+        constexpr ImVec4 FrameBgHovered         = ImVec4(0.94f, 0.94f, 0.94f, 0.55f);
+        constexpr ImVec4 FrameBgActive          = ImVec4(0.69f, 0.78f, 0.86f, 0.98f);
+
+        // Titles / Menu
+        constexpr ImVec4 TitleBg                = ImVec4(0.85f, 0.85f, 0.85f, 1.00f);
+        constexpr ImVec4 TitleBgCollapsed       = ImVec4(0.82f, 0.78f, 0.78f, 0.51f);
+        constexpr ImVec4 TitleBgActive          = ImVec4(0.78f, 0.78f, 0.78f, 1.00f);
+        constexpr ImVec4 MenuBarBg              = ImVec4(0.86f, 0.86f, 0.86f, 1.00f);
+
+        // Scrollbar
+        constexpr ImVec4 ScrollbarBg            = ImVec4(0.20f, 0.25f, 0.30f, 0.61f);
+        constexpr ImVec4 ScrollbarGrab          = ImVec4(0.90f, 0.90f, 0.90f, 0.30f);
+        constexpr ImVec4 ScrollbarGrabHovered   = ImVec4(0.92f, 0.92f, 0.92f, 0.78f);
+        constexpr ImVec4 ScrollbarGrabActive    = ImVec4(1.00f, 1.00f, 1.00f, 1.00f);
+
+        // Accents
+        constexpr ImVec4 CheckMark              = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+        constexpr ImVec4 BlueSoft               = ImVec4(0.26f, 0.59f, 0.98f, 0.78f);
+        constexpr ImVec4 Blue                   = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+
+        // Buttons / Headers (blue range)
+        constexpr ImVec4 Button                 = ImVec4(0.69f, 0.78f, 0.86f, 0.40f);
+        constexpr ImVec4 ButtonHovered          = ImVec4(0.702f, 0.805f, 0.902f, 1.00f);
+        constexpr ImVec4 ButtonActive           = ImVec4(0.793f, 0.900f, 0.936f, 1.00f);
+
+        constexpr ImVec4 Header                 = ImVec4(0.69f, 0.78f, 0.86f, 0.31f);
+        constexpr ImVec4 HeaderHovered          = ImVec4(0.69f, 0.78f, 0.86f, 0.80f);
+        constexpr ImVec4 HeaderActive           = ImVec4(0.69f, 0.78f, 0.86f, 1.00f);
+
+        // Separators / grips
+        constexpr ImVec4 Separator              = ImVec4(0.39f, 0.39f, 0.39f, 1.00f);
+        constexpr ImVec4 SeparatorHovered       = ImVec4(0.14f, 0.44f, 0.80f, 0.78f);
+        constexpr ImVec4 SeparatorActive        = ImVec4(0.14f, 0.44f, 0.80f, 1.00f);
+
+        constexpr ImVec4 ResizeGrip             = ImVec4(1.00f, 1.00f, 1.00f, 0.00f);
+        constexpr ImVec4 ResizeGripHovered      = ImVec4(0.26f, 0.59f, 0.98f, 0.45f);
+        constexpr ImVec4 ResizeGripActive       = ImVec4(0.26f, 0.59f, 0.98f, 0.78f);
+
+        // Tabs
+        constexpr ImVec4 Tab                    = ImVec4(0.69f, 0.78f, 0.86f, 0.80f);
+        constexpr ImVec4 TabHovered             = ImVec4(0.69f, 0.78f, 0.86f, 0.80f); // close to HeaderHovered
+        constexpr ImVec4 TabActive              = ImVec4(0.69f, 0.78f, 0.86f, 1.00f);
+        constexpr ImVec4 TabUnfocused           = ImVec4(0.18f, 0.18f, 0.18f, 1.00f);
+        constexpr ImVec4 TabUnfocusedActive     = ImVec4(0.36f, 0.36f, 0.36f, 0.54f);
+
+        // Plots
+        constexpr ImVec4 PlotLines              = ImVec4(0.39f, 0.39f, 0.39f, 1.00f);
+        constexpr ImVec4 PlotLinesHovered       = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+        constexpr ImVec4 PlotHistogram          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+        constexpr ImVec4 PlotHistogramHovered   = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+
+        // Misc / Navigation
+        constexpr ImVec4 TextSelectedBg         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+        constexpr ImVec4 DragDropTarget         = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+        constexpr ImVec4 NavHighlight           = HeaderHovered; // as in the original snippet
+        constexpr ImVec4 NavWindowingHighlight  = ImVec4(0.70f, 0.70f, 0.70f, 0.70f);
+    }
+
+    /// \class LightBlueTheme
+    /// \brief Light theme with soft blue accents, unified with default layout config.
+    class LightBlueTheme final : public Theme {
+    public:
+        void apply(ImGuiStyle& style) const override {
+            using namespace LightBlueConstants;
+            ImVec4* colors = style.Colors;
+
+            colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextDisabled]          = TextDisabled;
+
+            colors[ImGuiCol_WindowBg]              = WindowBg;
+            colors[ImGuiCol_ChildBg]               = ChildBg;
+            colors[ImGuiCol_PopupBg]               = PopupBg;
+
+            colors[ImGuiCol_Border]                = Border;
+            colors[ImGuiCol_BorderShadow]          = BorderShadow;
+
+            colors[ImGuiCol_FrameBg]               = FrameBg;
+            colors[ImGuiCol_FrameBgHovered]        = FrameBgHovered;
+            colors[ImGuiCol_FrameBgActive]         = FrameBgActive;
+
+            colors[ImGuiCol_TitleBg]               = TitleBg;
+            colors[ImGuiCol_TitleBgCollapsed]      = TitleBgCollapsed;
+            colors[ImGuiCol_TitleBgActive]         = TitleBgActive;
+            colors[ImGuiCol_MenuBarBg]             = MenuBarBg;
+
+            colors[ImGuiCol_ScrollbarBg]           = ScrollbarBg;
+            colors[ImGuiCol_ScrollbarGrab]         = ScrollbarGrab;
+            colors[ImGuiCol_ScrollbarGrabHovered]  = ScrollbarGrabHovered;
+            colors[ImGuiCol_ScrollbarGrabActive]   = ScrollbarGrabActive;
+
+            colors[ImGuiCol_CheckMark]             = CheckMark;
+            colors[ImGuiCol_SliderGrab]            = BlueSoft;
+            colors[ImGuiCol_SliderGrabActive]      = Blue;
+
+            colors[ImGuiCol_Button]                = Button;
+            colors[ImGuiCol_ButtonHovered]         = ButtonHovered;
+            colors[ImGuiCol_ButtonActive]          = ButtonActive;
+
+            colors[ImGuiCol_Header]                = Header;
+            colors[ImGuiCol_HeaderHovered]         = HeaderHovered;
+            colors[ImGuiCol_HeaderActive]          = HeaderActive;
+
+            colors[ImGuiCol_Separator]             = Separator;
+            colors[ImGuiCol_SeparatorHovered]      = SeparatorHovered;
+            colors[ImGuiCol_SeparatorActive]       = SeparatorActive;
+
+            colors[ImGuiCol_ResizeGrip]            = ResizeGrip;
+            colors[ImGuiCol_ResizeGripHovered]     = ResizeGripHovered;
+            colors[ImGuiCol_ResizeGripActive]      = ResizeGripActive;
+
+            colors[ImGuiCol_Tab]                   = Tab;
+            colors[ImGuiCol_TabHovered]            = TabHovered;
+            colors[ImGuiCol_TabActive]             = TabActive;
+            colors[ImGuiCol_TabUnfocused]          = TabUnfocused;
+            colors[ImGuiCol_TabUnfocusedActive]    = TabUnfocusedActive;
+
+            colors[ImGuiCol_PlotLines]             = PlotLines;
+            colors[ImGuiCol_PlotLinesHovered]      = PlotLinesHovered;
+            colors[ImGuiCol_PlotHistogram]         = PlotHistogram;
+            colors[ImGuiCol_PlotHistogramHovered]  = PlotHistogramHovered;
+
+            colors[ImGuiCol_TextSelectedBg]        = TextSelectedBg;
+            colors[ImGuiCol_DragDropTarget]        = DragDropTarget;
+
+            colors[ImGuiCol_NavHighlight]          = NavHighlight;
+            colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
+            // Note: NavWindowingDimBg / ModalWindowDimBg not set in the original snippet.
+
+            // Unify sizes/roundings/paddings/borders from config
+            applyDefaultImGuiStyle(style);
+        }
+
+#ifdef IMGUI_ENABLE_IMPLOT
+        void apply(ImPlotStyle& style) const override {
+            using namespace LightBlueConstants;
+
+            ImPlot::StyleColorsLight(&style);
+
+            style.Colors[ImPlotCol_PlotBg]        = WindowBg;
+            style.Colors[ImPlotCol_PlotBorder]    = Border;
+            style.Colors[ImPlotCol_LegendBg]      = PopupBg;
+            style.Colors[ImPlotCol_LegendBorder]  = Border;
+            style.Colors[ImPlotCol_LegendText]    = Text;
+
+            style.Colors[ImPlotCol_TitleText]     = Text;
+            style.Colors[ImPlotCol_InlayText]     = Text;
+            style.Colors[ImPlotCol_AxisText]      = Text;
+
+            // Light-ish grid/ticks over bright bg
+            style.Colors[ImPlotCol_AxisGrid]      = ImVec4(0.75f, 0.75f, 0.75f, 0.60f);
+            style.Colors[ImPlotCol_AxisTick]      = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
+
+            // Use the blue accent for selection/crosshairs
+            style.Colors[ImPlotCol_Selection]     = ImVec4(0.26f, 0.59f, 0.98f, 0.55f);
+            style.Colors[ImPlotCol_Crosshairs]    = Blue;
+
+            applyDefaultImPlotStyle(style);
+        }
+#endif
+    };
+
+    /// \brief Registers the Light-Blue theme in ThemeManager.
+    /// \param tm Theme manager where the theme will be registered.
+    /// \param id Unique theme identifier (defaults to "light-blue").
+    inline void registerLightBlueTheme(ThemeManager& tm, std::string id = "light-blue") {
+        tm.registerTheme(std::move(id), std::make_unique<LightBlueTheme>());
+    }
+
+} // namespace ImGuiX::Themes
+
+#endif // _IMGUIX_THEMES_LIGHT_BLUE_THEME_HPP_INCLUDED
+

--- a/include/imguix/themes/theme_ids.hpp
+++ b/include/imguix/themes/theme_ids.hpp
@@ -15,6 +15,7 @@
 #define IMGUIX_THEME_DEEP_DARK      "deep-dark"
 #define IMGUIX_THEME_GOLD_BLACK     "gold-black"
 #define IMGUIX_THEME_GREEN_BLUE     "green-blue"
+#define IMGUIX_THEME_LIGHT_BLUE     "light-blue"
 #define IMGUIX_THEME_LIGHT_GREEN    "light-green"
 #define IMGUIX_THEME_OSX_LIGHT      "osx-light"
 #define IMGUIX_THEME_PEARL_LIGHT    "pearl-light"

--- a/include/imguix/widgets/misc/theme_picker.hpp
+++ b/include/imguix/widgets/misc/theme_picker.hpp
@@ -37,6 +37,7 @@ namespace ImGuiX::Widgets {
             {IMGUIX_THEME_DEEP_DARK,      u8"Deep Dark"},
             {IMGUIX_THEME_GOLD_BLACK,     u8"Gold Black"},
             {IMGUIX_THEME_GREEN_BLUE,     u8"Green Blue"},
+            {IMGUIX_THEME_LIGHT_BLUE,     u8"Light Blue"},
             {IMGUIX_THEME_LIGHT_GREEN,    u8"Light Green"},
             {IMGUIX_THEME_OSX_LIGHT,      u8"OSX Light"},
             {IMGUIX_THEME_PEARL_LIGHT,    u8"Pearl Light"},

--- a/tests/test_widgets.cpp
+++ b/tests/test_widgets.cpp
@@ -39,6 +39,7 @@
 #include <imguix/themes/DeepDarkTheme.hpp>
 #include <imguix/themes/GoldBlackTheme.hpp>
 #include <imguix/themes/GreenBlueTheme.hpp>
+#include <imguix/themes/LightBlueTheme.hpp>
 #include <imguix/themes/LightGreenTheme.hpp>
 #include <imguix/themes/OSXTheme.hpp>
 #include <imguix/themes/PearlLightTheme.hpp>
@@ -770,6 +771,7 @@ public:
         ImGuiX::Themes::registerDeepDarkTheme(tm);
         ImGuiX::Themes::registerGoldBlackTheme(tm);
         ImGuiX::Themes::registerGreenBlueTheme(tm);
+        ImGuiX::Themes::registerLightBlueTheme(tm);
         ImGuiX::Themes::registerLightGreenTheme(tm);
         ImGuiX::Themes::registerOSXTheme(tm);
         ImGuiX::Themes::registerPearlLightTheme(tm);


### PR DESCRIPTION
## Summary
- add LightBlueTheme with blue color palette and registration helper
- expose light-blue id in theme utilities and default picker
- document and register light blue theme in tests

## Testing
- `cmake -S . -B build -DIMGUIX_DEPS_MODE=BUNDLED` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b301a5ef00832c8f216d08e5a6ef2e