### PR TITLE
test: guard ImPlot usage with macros

### DIFF
--- a/tests/demo_backend.cpp
+++ b/tests/demo_backend.cpp
@@ -1,8 +1,12 @@
 #if defined(IMGUIX_USE_SFML_BACKEND)
 
 #include <imgui.h> // necessary for ImGui::*, imgui-SFML.h doesn't include imgui.h
+#ifdef IMGUI_ENABLE_IMPLOT
 #include <implot.h>
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
 #include <implot3d.h>
+#endif
 #include <imgui-SFML.h> // for ImGui::SFML::* functions and SFML-specific overloads
 #include <imgui_freetype.h>
 #include <SFML/Graphics.hpp>
@@ -60,8 +64,12 @@ int main() {
     window.setFramerateLimit(60);
     
     if (!ImGui::SFML::Init(window)) return -1;
+#ifdef IMGUI_ENABLE_IMPLOT
     ImPlot::CreateContext();
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
     ImPlot3D::CreateContext();
+#endif
     
     ImGuiIO& io = ImGui::GetIO();
     io.Fonts->FontLoader = ImGuiFreeType::GetFontLoader();
@@ -94,11 +102,14 @@ int main() {
         ImGui::SFML::Update(window, deltaClock.restart());
 
         ImGui::ShowDemoWindow();
+#ifdef IMGUI_ENABLE_IMPLOT
         static bool show_implot_demo = true;
         if (show_implot_demo) ImPlot::ShowDemoWindow(&show_implot_demo);
-        
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
         static bool show_implot3d_demo = true;
         if (show_implot3d_demo) ImPlot3D::ShowDemoWindow(&show_implot3d_demo);
+#endif
         
         static bool show_implot_checker = true;
         ShowBackendCheckerWindow(&show_implot_checker);
@@ -113,8 +124,12 @@ int main() {
         window.display();
     }
 
+#ifdef IMGUI_ENABLE_IMPLOT
     ImPlot::DestroyContext();
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
     ImPlot3D::DestroyContext();
+#endif
     ImGui::SFML::Shutdown();
 }
 


### PR DESCRIPTION
## Summary
- guard ImPlot and ImPlot3D includes and demo code in `demo_backend.cpp` with `IMGUI_ENABLE_IMPLOT` and `IMGUI_ENABLE_IMPLOT3D`

## Testing
- `cmake -S . -B build` *(fails: include could not find cmake/deps/implot3d.cmake; nlohmann_json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b334cd46e0832c86c6c1cff42fbf45