### PR TITLE
docs: document compile-time macros

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -27,6 +27,7 @@
 - [Архитектура](#архитектура)
 - [Web/Emscripten](#webemscripten)
 - [Опции CMake (сводка)](#опции-cmake-сводка)
+- [Макросы компиляции](#макросы-компиляции)
 - [Темы](#темы)
 - [Шрифты и лицензии](#шрифты-и-лицензии)
 - [Лицензия](#лицензия)
@@ -256,6 +257,16 @@ run-test-sdl2-ems.bat     :: запускает emrun на локальном с
 * JSON: `IMGUIX_VENDOR_JSON` — положить заголовки `nlohmann_json` в SDK.
 * Режимы зависимостей:
   `IMGUIX_DEPS_MODE= AUTO|SYSTEM|BUNDLED` + пер-пакетные `IMGUIX_DEPS_*_MODE` (`fmt`, `SFML`, `ImGui`, `ImGui-SFML`, `freetype`, `json`, `mdbx`).
+
+## Макросы компиляции
+
+ImGuiX проверяет набор макросов для подключения дополнительных модулей. Они задаются автоматически при включении соответствующих опций CMake.
+
+- `IMGUI_ENABLE_FREETYPE` — использование FreeType для растеризации шрифтов (`IMGUIX_IMGUI_FREETYPE`).
+- `IMGUI_ENABLE_IMPLOT` — интеграция [ImPlot](https://github.com/epezent/implot) (`IMGUIX_USE_IMPLOT`).
+- `IMGUI_ENABLE_IMPLOT3D` — интеграция [ImPlot3D](https://github.com/jimgries/implot3d) (`IMGUIX_USE_IMPLOT3D`).
+
+Полный список конфигурационных макросов см. в [docs/CONFIGURATION-RU.md](docs/CONFIGURATION-RU.md).
 
 ## Темы
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ independently of rendering.
 - [Architecture](#architecture)
 - [Web/Emscripten](#webemscripten)
 - [CMake Options (Summary)](#cmake-options-summary)
+- [Compile-Time Macros](#compile-time-macros)
 - [Themes](#themes)
 - [Fonts and Licensing](#fonts-and-licensing)
 - [License](#license)
@@ -258,6 +259,16 @@ After building, open `http://localhost:8081/index.html` in your browser.
 * JSON: `IMGUIX_VENDOR_JSON` — place `nlohmann_json` headers in the SDK.
 * Dependency modes:
   `IMGUIX_DEPS_MODE= AUTO|SYSTEM|BUNDLED` plus per-package `IMGUIX_DEPS_*_MODE` (`fmt`, `SFML`, `ImGui`, `ImGui-SFML`, `freetype`, `json`).
+
+## Compile-Time Macros
+
+ImGuiX checks several macros to toggle optional integrations. They are defined automatically when corresponding CMake options are enabled.
+
+- `IMGUI_ENABLE_FREETYPE` — use FreeType for font rasterization (`IMGUIX_IMGUI_FREETYPE`).
+- `IMGUI_ENABLE_IMPLOT` — integrate [ImPlot](https://github.com/epezent/implot) (`IMGUIX_USE_IMPLOT`).
+- `IMGUI_ENABLE_IMPLOT3D` — integrate [ImPlot3D](https://github.com/jimgries/implot3d) (`IMGUIX_USE_IMPLOT3D`).
+
+See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for other configuration macros.
 
 ## Themes
 

--- a/docs/CONFIGURATION-RU.md
+++ b/docs/CONFIGURATION-RU.md
@@ -1,0 +1,75 @@
+# Конфигурация и макросы
+
+English version: [CONFIGURATION.md](CONFIGURATION.md).
+
+ImGuiX использует ряд макросов для подключения дополнительных модулей и задания значений по умолчанию. Ниже приведены основные из них.
+
+## Макросы сборки
+
+Эти макросы включаются автоматически при активации соответствующих опций CMake.
+
+- `IMGUI_ENABLE_FREETYPE` — использование FreeType для растеризации шрифтов (`IMGUIX_IMGUI_FREETYPE`).
+- `IMGUI_ENABLE_IMPLOT` — интеграция [ImPlot](https://github.com/epezent/implot) (`IMGUIX_USE_IMPLOT`).
+- `IMGUI_ENABLE_IMPLOT3D` — интеграция [ImPlot3D](https://github.com/jimgries/implot3d) (`IMGUIX_USE_IMPLOT3D`).
+
+## Конфигурационные заголовки
+
+В папке `include/imguix/config/` находятся заголовки, задающие пути по умолчанию, цвета, иконки и другие настройки. Подключите `<imguix/config.hpp>`, чтобы получить их все. Значения можно переопределить, определив макросы до подключения или через опции компилятора.
+
+### Пути
+
+- `IMGUIX_CONFIG_DIR` — директория для конфигурационных файлов. По умолчанию `data/config`.
+- `IMGUIX_OPTIONS_FILENAME` — имя файла с опциями. По умолчанию `options.json`.
+
+### Шрифты
+
+- `IMGUIX_FONTS_DIR` — директория со шрифтами по умолчанию.
+- `IMGUIX_FONTS_CONFIG` — файл конфигурации шрифтов.
+- `IMGUIX_FONTS_CONFIG_BASENAME` — базовое имя файла конфигурации.
+- `IMGUIX_FONTS_FALLBACK_BODY_BASENAME` — запасной шрифт для текста.
+- `IMGUIX_FONTS_FALLBACK_ICONS_BASENAME` — запасной иконный шрифт.
+
+### Локализация
+
+- `IMGUIX_I18N_DIR` — директория ресурсов локализации.
+- `IMGUIX_I18N_JSON_BASENAME` — базовое имя файла локализации.
+- `IMGUIX_I18N_PLURALS_FILENAME` — файл правил множественного числа.
+- `IMGUIX_RESOLVE_PATHS_REL_TO_EXE` — при ненулевом значении пути считаются относительно исполняемого файла.
+
+### Опции
+
+- `IMGUIX_OPTIONS_SAVE_DELAY_SEC` — задержка перед сохранением опций в секундах.
+
+### Шаблоны размеров
+
+- `IMGUIX_SIZING_TIME_SIGNED` — пример строки времени со знаком.
+- `IMGUIX_SIZING_TIME_UNSIGNED` — пример строки времени без знака.
+- `IMGUIX_SIZING_HMS` — пример строки часов/минут/секунд.
+- `IMGUIX_SIZING_DATE` — пример строки даты.
+- `IMGUIX_SIZING_YEAR_SIGNED` — пример строки года со знаком.
+- `IMGUIX_SIZING_YEAR_UNSIGNED` — пример строки года без знака.
+- `IMGUIX_SIZING_WEEKDAYS` — список дней недели через запятую.
+
+### Цвета
+
+- `IMGUIX_COLOR_ERROR` — цвет ошибки.
+- `IMGUIX_COLOR_WARNING` — цвет предупреждения.
+- `IMGUIX_COLOR_INFO` — информационный цвет.
+- `IMGUIX_COLOR_SUCCESS` — цвет успешных действий.
+- `IMGUIX_COLOR_OHLC_BULL` — цвет роста OHLC-графиков.
+- `IMGUIX_COLOR_OHLC_BEAR` — цвет падения OHLC-графиков.
+
+### Иконки
+
+- `IMGUIX_ICON_KEYBOARD`, `IMGUIX_ICON_HELP`, `IMGUIX_ICON_WARNING`, `IMGUIX_ICON_INFO`, `IMGUIX_ICON_SUCCESS`.
+- `IMGUIX_ICON_ADD`, `IMGUIX_ICON_REMOVE`, `IMGUIX_ICON_EYE_SHOW`, `IMGUIX_ICON_EYE_HIDE`, `IMGUIX_ICON_COPY`, `IMGUIX_ICON_PASTE`.
+
+### Уведомления
+
+- `IMGUIX_NOTIFY_ICON_SUCCESS`, `IMGUIX_NOTIFY_ICON_WARNING`, `IMGUIX_NOTIFY_ICON_ERROR`, `IMGUIX_NOTIFY_ICON_INFO`, `IMGUIX_NOTIFY_ICON_CLOSE`.
+- `IMGUIX_NOTIFY_COLOR_SUCCESS`, `IMGUIX_NOTIFY_COLOR_WARNING`, `IMGUIX_NOTIFY_COLOR_ERROR`, `IMGUIX_NOTIFY_COLOR_INFO`, `IMGUIX_NOTIFY_COLOR_DEFAULT`.
+
+### Константы темы
+
+`config/theme_config.hpp` содержит константы `ImGuiX::Config` для отступов, скруглений и других метрик интерфейса.
+

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,75 @@
+# Configuration and Macros
+
+For the Russian version, see [CONFIGURATION-RU.md](CONFIGURATION-RU.md).
+
+ImGuiX exposes several compile-time switches and configuration macros. This document summarizes them and where they come from.
+
+## Compile-Time Macros
+
+These macros enable optional integrations and are defined automatically when matching CMake options are set.
+
+- `IMGUI_ENABLE_FREETYPE` — use FreeType for font rasterization (`IMGUIX_IMGUI_FREETYPE`).
+- `IMGUI_ENABLE_IMPLOT` — integrate [ImPlot](https://github.com/epezent/implot) (`IMGUIX_USE_IMPLOT`).
+- `IMGUI_ENABLE_IMPLOT3D` — integrate [ImPlot3D](https://github.com/jimgries/implot3d) (`IMGUIX_USE_IMPLOT3D`).
+
+## Configuration Headers
+
+`include/imguix/config/` contains headers that define default paths, colors, icons and other settings. Include `<imguix/config.hpp>` to pull them all in. Values can be overridden by redefining macros before inclusion or via compiler options.
+
+### Paths
+
+- `IMGUIX_CONFIG_DIR` — directory for configuration files. Default `data/config`.
+- `IMGUIX_OPTIONS_FILENAME` — options storage filename. Default `options.json`.
+
+### Fonts
+
+- `IMGUIX_FONTS_DIR` — default fonts directory.
+- `IMGUIX_FONTS_CONFIG` — default fonts configuration file.
+- `IMGUIX_FONTS_CONFIG_BASENAME` — basename of the fonts config.
+- `IMGUIX_FONTS_FALLBACK_BODY_BASENAME` — fallback body font.
+- `IMGUIX_FONTS_FALLBACK_ICONS_BASENAME` — fallback icon font.
+
+### Internationalization
+
+- `IMGUIX_I18N_DIR` — directory with localization resources.
+- `IMGUIX_I18N_JSON_BASENAME` — basename of the localization file.
+- `IMGUIX_I18N_PLURALS_FILENAME` — plural rules filename.
+- `IMGUIX_RESOLVE_PATHS_REL_TO_EXE` — resolve resource paths relative to the executable when nonzero.
+
+### Options
+
+- `IMGUIX_OPTIONS_SAVE_DELAY_SEC` — delay before saving options in seconds.
+
+### Sizing Templates
+
+- `IMGUIX_SIZING_TIME_SIGNED` — sample signed time string.
+- `IMGUIX_SIZING_TIME_UNSIGNED` — sample unsigned time string.
+- `IMGUIX_SIZING_HMS` — sample hours/minutes/seconds string.
+- `IMGUIX_SIZING_DATE` — sample date string.
+- `IMGUIX_SIZING_YEAR_SIGNED` — sample signed year string.
+- `IMGUIX_SIZING_YEAR_UNSIGNED` — sample unsigned year string.
+- `IMGUIX_SIZING_WEEKDAYS` — comma-separated weekday names.
+
+### Colors
+
+- `IMGUIX_COLOR_ERROR` — error color.
+- `IMGUIX_COLOR_WARNING` — warning color.
+- `IMGUIX_COLOR_INFO` — info color.
+- `IMGUIX_COLOR_SUCCESS` — success color.
+- `IMGUIX_COLOR_OHLC_BULL` — bullish OHLC color.
+- `IMGUIX_COLOR_OHLC_BEAR` — bearish OHLC color.
+
+### Icons
+
+- `IMGUIX_ICON_KEYBOARD`, `IMGUIX_ICON_HELP`, `IMGUIX_ICON_WARNING`, `IMGUIX_ICON_INFO`, `IMGUIX_ICON_SUCCESS`.
+- `IMGUIX_ICON_ADD`, `IMGUIX_ICON_REMOVE`, `IMGUIX_ICON_EYE_SHOW`, `IMGUIX_ICON_EYE_HIDE`, `IMGUIX_ICON_COPY`, `IMGUIX_ICON_PASTE`.
+
+### Notifications
+
+- `IMGUIX_NOTIFY_ICON_SUCCESS`, `IMGUIX_NOTIFY_ICON_WARNING`, `IMGUIX_NOTIFY_ICON_ERROR`, `IMGUIX_NOTIFY_ICON_INFO`, `IMGUIX_NOTIFY_ICON_CLOSE`.
+- `IMGUIX_NOTIFY_COLOR_SUCCESS`, `IMGUIX_NOTIFY_COLOR_WARNING`, `IMGUIX_NOTIFY_COLOR_ERROR`, `IMGUIX_NOTIFY_COLOR_INFO`, `IMGUIX_NOTIFY_COLOR_DEFAULT`.
+
+### Theme Constants
+
+`config/theme_config.hpp` provides `ImGuiX::Config` constexpr values for paddings, roundings and similar UI metrics.
+


### PR DESCRIPTION
## Summary
- document build-time and configuration macros in new docs/CONFIGURATION files
- mention IMGUI_ENABLE_* macros in README and README-RU

## Testing
- `cmake -S . -B build -DIMGUIX_HEADER_ONLY=ON` *(fails: include could not find requested file cmake/deps/implot3d.cmake; nlohmann_json submodule missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b331c499e4832c9f9329c28cdf6bb9