### PR TITLE
docs: add Russian architecture overview and references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,7 @@ Format: `type(scope): short description` where the scope is optional. Keep messa
 
 | Path                     | Role                                                   |
 | ------------------------ | ------------------------------------------------------ |
+| `docs/ARCHITECTURE.md`   | System architecture overview (Russian: `docs/ARCHITECTURE-RU.md`) |
 | `docs/FONTS-GUIDE.md` | FontManager usage; preset tokens including `MiscSymbols`, `Dingbats`, `Arrows`, `PUA` |
 | `docs/THEMES.md`        | Theme guide for built-in styles and creating custom themes |
 

--- a/README-RU.md
+++ b/README-RU.md
@@ -146,6 +146,8 @@ SDK может включать папку `quickstart/` с минимальны
 
 ## Архитектура
 
+Подробное описание см. в [docs/ARCHITECTURE-RU.md](docs/ARCHITECTURE-RU.md) (англоязычная версия: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)).
+
 ImGuiX объединяет философию Immediate Mode GUI с классическими паттернами проектирования:
 
 - **Immediate-Mode MVC**

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ The SDK can include a `quickstart/` folder with a minimal application example. C
 
 ## Architecture
 
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a full overview (Russian version: [docs/ARCHITECTURE-RU.md](docs/ARCHITECTURE-RU.md)).
+
 ImGuiX combines the **Immediate Mode GUI paradigm** with classical design patterns:
 
 - **Immediate-Mode MVC**  

--- a/docs/ARCHITECTURE-RU.md
+++ b/docs/ARCHITECTURE-RU.md
@@ -1,0 +1,106 @@
+# Архитектура
+
+ImGuiX сочетает подход **Immediate Mode GUI** из Dear ImGui с классическими
+объектно‑ориентированными паттернами. Фреймворк организует приложение UI в
+чётко определённые компоненты и каналы взаимодействия, благодаря чему большие
+проекты остаются поддерживаемыми.
+
+## Основные компоненты
+- **Application** — владеет глобальными сервисами и главным циклом.
+- **WindowManager** — создаёт и отслеживает окна.
+- **WindowInstance** — представляет отдельное окно и его контекст рендеринга.
+- **Controller** — объединяет покадровую логику и отрисовку.
+- **Model** — пользовательские данные или бэкенды вроде `OptionsStore`.
+- **EventBus** — асинхронный узел Publisher–Subscriber для развязанного обмена.
+- **ResourceRegistry** — потокобезопасный доступ к общим ресурсам (шрифты,
+  темы, виджеты и т.п.).
+
+## Архитектурные паттерны
+- **Immediate‑Mode MVC**: `WindowInstance` выступает в роли View, подклассы
+  `Controller` совмещают логику и отображение, а модели хранят постоянное
+  состояние.
+- **Событийное взаимодействие**: компоненты отправляют события в `EventBus`;
+  слушатели получают уведомления во время `EventBus::process()`.
+- **Жизненный цикл / Template Method**: окна и контроллеры предоставляют хуки
+  `onInit`, `drawContent` и `drawUi`, вызываемые циклом приложения в фиксированном
+  порядке.
+- **Фабрики**: контроллеры и модели создаются через фабричные функции.
+  `WindowInstance::createController<T>()` возвращает ограниченный
+  `WindowInterface&`, сохраняя инварианты.
+- **Стратегии и расширяемость**: темы, шрифты и виджеты регистрируются динамически.
+  `StrategicController` выбирает стратегии, а `ExtendedController` агрегирует
+  дочерние элементы.
+- **Посредник**: `EventMediator` упрощает управление подписками для всех
+  контроллеров и моделей.
+- **Реестр ресурсов**: почти синглтон‑реестр; повторная регистрация одного типа
+  вызывает ошибку.
+- **Контракт событий**: каждое событие наследует `Pubsub::Event` и реализует
+  методы `type()` и `name()`.
+- **Ограничения моделей**: прямые синхронные вызовы `notify` удалены; вне
+  `process()` используйте `notifyAsync`. Внутри `process()` доступен переданный
+  `SyncNotifier`.
+
+## Обзор системы
+```mermaid
+graph TD
+    A[Application]
+    WM[WindowManager]
+    W[WindowInstance]
+    C[Controller]
+    M[Model]
+    EB[EventBus]
+    RR[ResourceRegistry]
+
+    A-->WM
+    A-->M
+    A-->EB
+    A-->RR
+    WM-->W
+    W-->C
+    C-->EB
+    M-->EB
+    C-->RR
+    M-->RR
+```
+
+## Поток событий
+```mermaid
+sequenceDiagram
+    participant Model
+    participant EventBus
+    participant Controller
+    Model->>EventBus: notifyAsync(Event)
+    Note right of EventBus: queued
+    EventBus-->>EventBus: process()
+    EventBus->>Controller: notify(Event)
+```
+
+## Структура модулей
+```mermaid
+graph LR
+    core[core]
+    windows[windows]
+    controllers[controllers]
+    widgets[widgets]
+    extensions[extensions]
+    utils[utils]
+
+    core --> windows
+    core --> controllers
+    windows --> controllers
+    controllers --> widgets
+    controllers --> extensions
+    controllers --> utils
+```
+
+## Этапы жизненного цикла
+1. `Application` инициализирует сервисы и `WindowManager`.
+2. `WindowManager` создаёт объекты `WindowInstance`.
+3. `WindowInstance::onInit()` строит контроллеры через `createController<T>()`.
+4. Каждый кадр:
+   - события ввода ставятся в очередь `EventBus`;
+   - `EventBus::process()` доставляет сообщения;
+   - `WindowInstance` вызывает хуки контроллеров (`drawContent`, `drawUi`).
+5. Завершение работы выполняет хуки в обратном порядке.
+
+Такая структура сохраняет модульность кода и простоту Immediate Mode‑рендеринга.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+For the Russian version, see [ARCHITECTURE-RU.md](ARCHITECTURE-RU.md).
+
 ImGuiX blends the **Immediate Mode GUI** approach of Dear ImGui with classic
 object-oriented patterns. The framework organizes a UI application into
 well-defined components and communication channels so large projects remain


### PR DESCRIPTION
## Summary
- add Russian translation for the architecture guide
- link architecture docs across README and AGENTS

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b30b14a1f0832c8744e13e67af209b