### PR TITLE
Add ImPlot3D context support

### DIFF
--- a/include/imguix/core.hpp
+++ b/include/imguix/core.hpp
@@ -32,6 +32,10 @@
 #include <implot.h>
 #endif
 
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#include <implot3d.h>
+#endif
+
 #include <imgui.h>
 
 // --- Event and PubSub system ---

--- a/include/imguix/core/window/GlfwWindowInstance.ipp
+++ b/include/imguix/core/window/GlfwWindowInstance.ipp
@@ -17,6 +17,14 @@ namespace ImGuiX {
             m_implot_ctx = nullptr;
         }
 #       endif
+
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        if (m_implot3d_ctx) {
+            ImPlot3D::SetCurrentContext(m_implot3d_ctx);
+            ImPlot3D::DestroyContext(m_implot3d_ctx);
+            m_implot3d_ctx = nullptr;
+        }
+#       endif
         
         if (m_imgui_ctx) {
             ImGui::SetCurrentContext(m_imgui_ctx);
@@ -48,6 +56,11 @@ namespace ImGuiX {
 #       ifdef IMGUI_ENABLE_IMPLOT
         m_implot_ctx = ImPlot::CreateContext();
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        m_implot3d_ctx = ImPlot3D::CreateContext();
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
 
         ImGui_ImplGlfw_InitForOpenGL(m_window, true);
@@ -197,10 +210,16 @@ namespace ImGuiX {
 #       ifdef IMGUI_ENABLE_IMPLOT
         if (!m_implot_ctx) return;
 #       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        if (!m_implot3d_ctx) return;
+#       endif
         glfwMakeContextCurrent(m_window);
         ImGui::SetCurrentContext(m_imgui_ctx);
 #       ifdef IMGUI_ENABLE_IMPLOT
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
     }
 

--- a/include/imguix/core/window/Sdl2WindowInstance.ipp
+++ b/include/imguix/core/window/Sdl2WindowInstance.ipp
@@ -16,6 +16,14 @@ namespace ImGuiX {
         }
 #       endif
 
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        if (m_implot3d_ctx) {
+            ImPlot3D::SetCurrentContext(m_implot3d_ctx);
+            ImPlot3D::DestroyContext(m_implot3d_ctx);
+            m_implot3d_ctx = nullptr;
+        }
+#       endif
+
         if (m_imgui_ctx) {
             ImGui::SetCurrentContext(m_imgui_ctx);
             ImGui_ImplOpenGL3_Shutdown();
@@ -60,6 +68,11 @@ namespace ImGuiX {
 #       ifdef IMGUI_ENABLE_IMPLOT
         m_implot_ctx = ImPlot::CreateContext();
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        m_implot3d_ctx = ImPlot3D::CreateContext();
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
         
         ImGui_ImplSDL2_InitForOpenGL(m_window, m_gl_context);
@@ -220,10 +233,16 @@ namespace ImGuiX {
 #       ifdef IMGUI_ENABLE_IMPLOT
         if (!m_implot_ctx) return;
 #       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        if (!m_implot3d_ctx) return;
+#       endif
         SDL_GL_MakeCurrent(m_window, m_gl_context);
         ImGui::SetCurrentContext(m_imgui_ctx);
 #       ifdef IMGUI_ENABLE_IMPLOT
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
     }
 

--- a/include/imguix/core/window/SfmlWindowInstance.ipp
+++ b/include/imguix/core/window/SfmlWindowInstance.ipp
@@ -29,6 +29,14 @@ namespace ImGuiX {
             m_implot_ctx = nullptr;
         }
 #       endif
+
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        if (m_implot3d_ctx) {
+            ImPlot3D::SetCurrentContext(m_implot3d_ctx);
+            ImPlot3D::DestroyContext(m_implot3d_ctx);
+            m_implot3d_ctx = nullptr;
+        }
+#       endif
         ImGui::SFML::Shutdown(m_window);
     }
 
@@ -42,6 +50,11 @@ namespace ImGuiX {
 #       ifdef IMGUI_ENABLE_IMPLOT
         m_implot_ctx = ImPlot::CreateContext();
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        m_implot3d_ctx = ImPlot3D::CreateContext();
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
 
 #       ifdef _WIN32
@@ -295,6 +308,11 @@ namespace ImGuiX {
 #           ifdef IMGUI_ENABLE_IMPLOT
             if (m_implot_ctx) {
                 ImPlot::SetCurrentContext(m_implot_ctx);
+            }
+#           endif
+#           ifdef IMGUI_ENABLE_IMPLOT3D
+            if (m_implot3d_ctx) {
+                ImPlot3D::SetCurrentContext(m_implot3d_ctx);
             }
 #           endif
         }

--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -29,6 +29,10 @@
 #include <implot.h>
 #endif
 
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#include <implot3d.h>
+#endif
+
 #include "WindowInterface.hpp"
 #include <imguix/config/paths.hpp>
 
@@ -325,6 +329,9 @@ namespace ImGuiX {
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT
         ImPlotContext* m_implot_ctx = nullptr; ///<
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        ImPlot3DContext* m_implot3d_ctx = nullptr; ///<
 #endif
         int m_window_id;                    ///< Unique window identifier.
         std::string m_window_name;          ///< Internal window name.


### PR DESCRIPTION
## Summary
- add ImPlot3D header includes and context members
- manage ImPlot3D context creation and destruction across window backends
- switch ImPlot3D context when activating windows

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: cmake/deps/implot3d.cmake; nlohmann_json submodule missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b335ce2de4832ca641a9824abd87fa