### PR TITLE
feat(windows): add ImPlot3D support

### DIFF
--- a/include/imguix/windows/GlfwImGuiFramedWindow.ipp
+++ b/include/imguix/windows/GlfwImGuiFramedWindow.ipp
@@ -16,11 +16,15 @@ namespace ImGuiX::Windows {
         glfwMakeContextCurrent(m_window);
 
         IMGUI_CHECKVERSION();
-        if (!ImGui::GetCurrentContext()) { 
+        if (!ImGui::GetCurrentContext()) {
             ImGui::CreateContext();
 #           ifdef IMGUI_ENABLE_IMPLOT
             m_implot_ctx = ImPlot::CreateContext();
             ImPlot::SetCurrentContext(m_implot_ctx);
+#           endif
+#           ifdef IMGUI_ENABLE_IMPLOT3D
+            m_implot3d_ctx = ImPlot3D::CreateContext();
+            ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #           endif
         }
         
@@ -47,6 +51,9 @@ namespace ImGuiX::Windows {
     void ImGuiFramedWindow::drawUi() {
 #       ifdef IMGUI_ENABLE_IMPLOT
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
         ImGui::PushID(id());
 

--- a/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
+++ b/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
@@ -19,11 +19,15 @@ namespace ImGuiX::Windows {
         SDL_GL_MakeCurrent(m_window, m_gl_context);
 
         IMGUI_CHECKVERSION();
-        if (!ImGui::GetCurrentContext()) { 
+        if (!ImGui::GetCurrentContext()) {
             ImGui::CreateContext();
 #           ifdef IMGUI_ENABLE_IMPLOT
             m_implot_ctx = ImPlot::CreateContext();
             ImPlot::SetCurrentContext(m_implot_ctx);
+#           endif
+#           ifdef IMGUI_ENABLE_IMPLOT3D
+            m_implot3d_ctx = ImPlot3D::CreateContext();
+            ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #           endif
         }
 
@@ -51,6 +55,9 @@ namespace ImGuiX::Windows {
     void ImGuiFramedWindow::drawUi() {
 #       ifdef IMGUI_ENABLE_IMPLOT
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
         ImGui::PushID(id());
 

--- a/include/imguix/windows/SfmlImGuiFramedWindow.ipp
+++ b/include/imguix/windows/SfmlImGuiFramedWindow.ipp
@@ -158,6 +158,10 @@ namespace ImGuiX::Windows {
         m_implot_ctx = ImPlot::CreateContext();
         ImPlot::SetCurrentContext(m_implot_ctx);
 #       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        m_implot3d_ctx = ImPlot3D::CreateContext();
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
+#       endif
 
         return m_is_open;
     }
@@ -277,6 +281,10 @@ namespace ImGuiX::Windows {
 #       ifdef IMGUI_ENABLE_IMPLOT
         m_implot_ctx = ImPlot::CreateContext();
         ImPlot::SetCurrentContext(m_implot_ctx);
+#       endif
+#       ifdef IMGUI_ENABLE_IMPLOT3D
+        m_implot3d_ctx = ImPlot3D::CreateContext();
+        ImPlot3D::SetCurrentContext(m_implot3d_ctx);
 #       endif
 
         return m_is_open;


### PR DESCRIPTION
## Summary
- extend SDL2, GLFW, and SFML framed window backends with optional ImPlot3D context creation and switching

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "imguix_use_or_fetch_implot3d")*


------
https://chatgpt.com/codex/tasks/task_e_68b3395a0618832cbf301a4c9815096a