### PR TITLE
docs(cmake): translate SDK option descriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,10 @@ option(IMGUIX_SDK_FLATTEN_MISC_HEADERS
 
 # SDK
 # Install SDK extras (quickstart, templates, assets)
-option(IMGUIX_SDK_INSTALL      "Устанавливать SDK-«добавки» (quickstart, шаблоны, ассеты)" ON)
+option(IMGUIX_SDK_INSTALL      "Install SDK extras (quickstart, templates, assets)" ON)
 option(IMGUIX_SDK_BUNDLE_DEPS  "Install 3rd-party deps into SDK stage" ON)
 # Place quickstart template into SDK
-option(IMGUIX_SDK_INSTALL_QUICKSTART "Класть quickstart-шаблон в SDK" ON)
+option(IMGUIX_SDK_INSTALL_QUICKSTART "Install quickstart template into SDK" ON)
 
 # ===== Deps mode =====
 set(IMGUIX_DEPS_MODE "AUTO" CACHE STRING "AUTO|SYSTEM|BUNDLED")


### PR DESCRIPTION
## Summary
- translate SDK option descriptions from Russian to English

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF`
- `cmake --build build -j 2` *(fails: `DeltaClockSfml` was not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b33cf3c3ec832c85fd2f46f4a57425