### PR TITLE
feat(themes): add ImPlot3D styling

### DIFF
--- a/include/imguix/themes/CorporateGreyTheme.hpp
+++ b/include/imguix/themes/CorporateGreyTheme.hpp
@@ -18,6 +18,9 @@
 /// \date 2025
 
 #include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -137,6 +140,26 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = Highlight;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            ImPlot3D::StyleColorsDark(&style);
+
+            using namespace CorporateGreyConstants;
+            style.Colors[ImPlot3DCol_FrameBg]      = MediumGrey;
+            style.Colors[ImPlot3DCol_PlotBg]       = DarkGrey25;
+            style.Colors[ImPlot3DCol_PlotBorder]   = ImVec4(0.15f, 0.15f, 0.15f, 1.0f);
+            style.Colors[ImPlot3DCol_LegendBg]     = DarkGrey25;
+            style.Colors[ImPlot3DCol_LegendBorder] = ImVec4(0.12f, 0.12f, 0.12f, 0.71f);
+            style.Colors[ImPlot3DCol_LegendText]   = White;
+            style.Colors[ImPlot3DCol_TitleText]    = White;
+            style.Colors[ImPlot3DCol_InlayText]    = White;
+            style.Colors[ImPlot3DCol_AxisText]     = White;
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.25f, 0.25f, 0.25f, 0.45f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.45f, 0.45f, 0.45f, 0.70f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -12,6 +12,9 @@
 ///  - provide matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -211,6 +214,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.000f, 0.391f, 0.000f, 1.00f);
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace DarkCharcoalConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.35f, 0.35f, 0.35f, 0.55f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.60f, 0.60f, 0.60f, 0.80f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -12,6 +12,9 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -204,6 +207,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = AccentBlue;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace DarkGraphiteConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.34f, 0.35f, 0.38f, 0.55f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.62f, 0.64f, 0.68f, 0.90f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -12,6 +12,9 @@
 ///  - provide matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -212,6 +215,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = AccentBase;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace DarkTealConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.25f, 0.35f, 0.42f, 0.50f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.55f, 0.65f, 0.70f, 0.85f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -12,6 +12,9 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -222,6 +225,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.00f, 0.00f, 0.00f, 1.00f);
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace DeepDarkConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.35f, 0.35f, 0.35f, 0.40f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.65f, 0.65f, 0.65f, 0.70f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/GoldBlackTheme.hpp
+++ b/include/imguix/themes/GoldBlackTheme.hpp
@@ -12,6 +12,9 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -207,6 +210,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = GoldBright;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace GoldBlackConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = GoldBorder;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = GoldBorder;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.40f, 0.32f, 0.18f, 0.45f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.75f, 0.60f, 0.30f, 0.85f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -12,6 +12,9 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -223,6 +226,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(0.13f, 0.75f, 0.75f, 1.00f); // teal
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace GreenBlueConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.35f, 0.35f, 0.36f, 0.55f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.60f, 0.60f, 0.62f, 0.85f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -12,6 +12,9 @@
 ///  - added matching ImPlot styling (light)
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -190,6 +193,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace LightBlueConstants;
+
+            ImPlot3D::StyleColorsLight(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.75f, 0.75f, 0.75f, 0.60f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -12,6 +12,9 @@
 ///  - added matching ImPlot styling (light)
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -190,6 +193,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace LightGreenConstants;
+
+            ImPlot3D::StyleColorsLight(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.75f, 0.75f, 0.75f, 0.60f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -13,6 +13,9 @@
 ///  - added matching ImPlot styling (light)
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -190,6 +193,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace OSXThemeConstants;
+
+            ImPlot3D::StyleColorsLight(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.78f, 0.78f, 0.78f, 0.60f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.35f, 0.35f, 0.35f, 0.90f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/PearlLightTheme.hpp
+++ b/include/imguix/themes/PearlLightTheme.hpp
@@ -11,6 +11,9 @@
 ///  - defines ImPlot colors to match the palette
 
 #include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -175,6 +178,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]   = AccentBase;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace PearlLightConstants;
+
+            ImPlot3D::StyleColorsLight(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.75f, 0.75f, 0.75f, 0.60f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -11,6 +11,9 @@
 ///  - defines ImPlot colors to match the palette
 
 #include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -175,6 +178,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]   = AccentBase;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace SlateDarkConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = FrameBg;
+            style.Colors[ImPlot3DCol_PlotBg]       = WindowBg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = PopupBg;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.30f, 0.30f, 0.30f, 0.50f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.55f, 0.55f, 0.55f, 0.80f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -12,6 +12,9 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#ifdef IMGUI_ENABLE_IMPLOT3D
+#   include <implot3d.h>
+#endif
 
 namespace ImGuiX::Themes {
 
@@ -188,6 +191,28 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Crosshairs]    = PanelActive;
 
             applyDefaultImPlotStyle(style);
+        }
+#endif
+#ifdef IMGUI_ENABLE_IMPLOT3D
+        void apply(ImPlot3DStyle& style) const override {
+            using namespace VisualStudioDarkConstants;
+
+            ImPlot3D::StyleColorsDark(&style);
+
+            style.Colors[ImPlot3DCol_FrameBg]      = Panel;
+            style.Colors[ImPlot3DCol_PlotBg]       = Bg;
+            style.Colors[ImPlot3DCol_PlotBorder]   = Border;
+            style.Colors[ImPlot3DCol_LegendBg]     = Panel;
+            style.Colors[ImPlot3DCol_LegendBorder] = Border;
+            style.Colors[ImPlot3DCol_LegendText]   = Text;
+            style.Colors[ImPlot3DCol_TitleText]    = Text;
+            style.Colors[ImPlot3DCol_InlayText]    = Text;
+            style.Colors[ImPlot3DCol_AxisText]     = Text;
+
+            style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.32f, 0.32f, 0.34f, 0.55f);
+            style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.60f, 0.60f, 0.62f, 0.90f);
+
+            applyDefaultImPlot3DStyle(style);
         }
 #endif
     };


### PR DESCRIPTION
## Summary
- extend theme headers with ImPlot3D style and color mappings

## Testing
- ⚠️ `cmake -S . -B build` *(missing SFML component: 'System')*

------
https://chatgpt.com/codex/tasks/task_e_68b33ca88024832ca8474f9be32fb2f7