### PR TITLE
refactor(theme): remove redundant ImPlot3D include

### DIFF
--- a/include/imguix/themes/CorporateGreyTheme.hpp
+++ b/include/imguix/themes/CorporateGreyTheme.hpp
@@ -18,9 +18,6 @@
 /// \date 2025
 
 #include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -12,9 +12,6 @@
 ///  - provide matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -12,9 +12,6 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -12,9 +12,6 @@
 ///  - provide matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -12,9 +12,6 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/GoldBlackTheme.hpp
+++ b/include/imguix/themes/GoldBlackTheme.hpp
@@ -12,9 +12,6 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -12,9 +12,6 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -12,9 +12,6 @@
 ///  - added matching ImPlot styling (light)
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -12,9 +12,6 @@
 ///  - added matching ImPlot styling (light)
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -13,9 +13,6 @@
 ///  - added matching ImPlot styling (light)
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/PearlLightTheme.hpp
+++ b/include/imguix/themes/PearlLightTheme.hpp
@@ -11,9 +11,6 @@
 ///  - defines ImPlot colors to match the palette
 
 #include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -11,9 +11,6 @@
 ///  - defines ImPlot colors to match the palette
 
 #include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 

--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -12,9 +12,6 @@
 ///  - added matching ImPlot styling
 
 #include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
-#ifdef IMGUI_ENABLE_IMPLOT3D
-#   include <implot3d.h>
-#endif
 
 namespace ImGuiX::Themes {
 


### PR DESCRIPTION
## Summary
- remove superfluous ImPlot3D include blocks from all theme headers

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f258a7c832cbbaea2927481fa7b