### PR TITLE
docs: add project tree overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,6 @@ The SDK can include a `quickstart/` folder with a minimal application example. C
 │   └── imguix/
 │       ├── config/
 │       ├── controllers/
-│       │   ├── ApplicationController.hpp
-│       │   ├── ExtendedController.hpp
-│       │   └── StrategicController.hpp
 │       ├── core/
 │       │   ├── application/
 │       │   ├── controller/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ independently of rendering.
 - [SDK Installation](#sdk-installation)
 - [Using as a Dependency](#using-as-a-dependency)
 - [Quick Start / Examples](#quick-start--examples)
+- [Project Structure](#project-structure)
 - [Architecture](#architecture)
 - [Web/Emscripten](#webemscripten)
 - [CMake Options (Summary)](#cmake-options-summary)
@@ -146,6 +147,43 @@ target_link_libraries(myapp PRIVATE ImGuiX::imguix)
 ## Quick Start / Examples
 
 The SDK can include a `quickstart/` folder with a minimal application example. Copy the `quickstart` directory into your project or add it as sources, build, and you're ready to go.
+
+## Project Structure
+
+```
+.
+├── include/
+│   └── imguix/
+│       ├── config/
+│       ├── controllers/
+│       │   ├── ApplicationController.hpp
+│       │   ├── ExtendedController.hpp
+│       │   └── StrategicController.hpp
+│       ├── core/
+│       │   ├── application/
+│       │   ├── controller/
+│       │   ├── events/
+│       │   ├── fonts/
+│       │   ├── i18n/
+│       │   ├── model/
+│       │   ├── notify/
+│       │   ├── options/
+│       │   ├── pubsub/
+│       │   ├── resource/
+│       │   ├── themes/
+│       │   └── window/
+│       ├── extensions/
+│       ├── themes/
+│       ├── utils/
+│       ├── widgets/
+│       └── windows/
+├── docs/
+├── examples/
+│   └── quickstart/
+├── libs/
+├── src/
+└── tests/
+```
 
 ## Architecture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,9 +15,6 @@ maintainable.
 │   └── imguix/
 │       ├── config/
 │       ├── controllers/
-│       │   ├── ApplicationController.hpp
-│       │   ├── ExtendedController.hpp
-│       │   └── StrategicController.hpp
 │       ├── core/
 │       │   ├── application/
 │       │   ├── controller/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,43 @@ object-oriented patterns. The framework organizes a UI application into
 well-defined components and communication channels so large projects remain
 maintainable.
 
+## Directory Layout
+
+```
+.
+├── include/
+│   └── imguix/
+│       ├── config/
+│       ├── controllers/
+│       │   ├── ApplicationController.hpp
+│       │   ├── ExtendedController.hpp
+│       │   └── StrategicController.hpp
+│       ├── core/
+│       │   ├── application/
+│       │   ├── controller/
+│       │   ├── events/
+│       │   ├── fonts/
+│       │   ├── i18n/
+│       │   ├── model/
+│       │   ├── notify/
+│       │   ├── options/
+│       │   ├── pubsub/
+│       │   ├── resource/
+│       │   ├── themes/
+│       │   └── window/
+│       ├── extensions/
+│       ├── themes/
+│       ├── utils/
+│       ├── widgets/
+│       └── windows/
+├── docs/
+├── examples/
+│   └── quickstart/
+├── libs/
+├── src/
+└── tests/
+```
+
 ## Core Components
 - **Application** – owns global services and the main loop.
 - **WindowManager** – creates and tracks windows.


### PR DESCRIPTION
## Summary
- document top-level layout in README and architecture doc
- link new project structure section from README table of contents

## Testing
- `cmake -S . -B build -DIMGUIX_HEADER_ONLY=ON -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF` *(fails: missing imgui sources)*

------
https://chatgpt.com/codex/tasks/task_e_68b34301bfb0832ca16861afc2cfa7d6