### PR TITLE
docs: normalize Doxygen in misc widget headers

### DIFF
--- a/include/imguix/widgets/misc/loading_spinner.hpp
+++ b/include/imguix/widgets/misc/loading_spinner.hpp
@@ -13,23 +13,24 @@ namespace ImGuiX::Widgets {
 
     /// \brief Configuration for LoadingSpinner.
     struct LoadingSpinnerConfig {
-        float radius        = 24.0f;     ///< circle radius in pixels
-        float thickness     = 6.5f;      ///< stroke thickness in pixels
-        int   segments      = 20;        ///< number of segments used to draw the arc (>= 8 recommended)
-        float angular_speed = 4.0f;      ///< radians per second added to the phase
-        float sweep_ratio   = 0.80f;     ///< arc sweep as fraction of full circle (0..1], e.g. 0.8 → 288°
-        ImU32 color         = 0;         ///< 0 → use style's ImGuiCol_Text color
-        float extra_top_padding = 0.0f;  ///< optional extra vertical padding on top, px
+        float radius        = 24.0f;     ///< Circle radius in pixels.
+        float thickness     = 6.5f;      ///< Stroke thickness in pixels.
+        int   segments      = 20;        ///< Segment count for arc (>= 8 recommended).
+        float angular_speed = 4.0f;      ///< Radians per second added to the phase.
+        float sweep_ratio   = 0.80f;     ///< Arc sweep as fraction of full circle (0..1], e.g. 0.8 → 288°.
+        ImU32 color         = 0;         ///< 0 → use style's ImGuiCol_Text color.
+        float extra_top_padding = 0.0f;  ///< Optional extra top padding in pixels.
     };
-    
-    /// \brief
+
+    /// \brief Compute default spinner color from style.
+    /// \return Spinner color based on current style.
     ImU32 DefaultSpinnerColor();
 
     /// \brief Draw an animated loading spinner.
     /// \param id Unique widget identifier.
     /// \param cfg Spinner parameters.
     /// \return True if the item was submitted (not clipped).
-    /// \code
+    /// \code{.cpp}
     /// LoadingSpinner("busy");
     /// \endcode
     bool LoadingSpinner(const char* id, const LoadingSpinnerConfig& cfg = {});

--- a/include/imguix/widgets/misc/markers.hpp
+++ b/include/imguix/widgets/misc/markers.hpp
@@ -15,8 +15,8 @@ namespace ImGuiX::Widgets {
 
     /// \brief Marker display mode.
     enum class MarkerMode : int {
-        TooltipOnly = 0,  ///< icon/label + tooltip on hover
-        InlineText  = 1   ///< icon/label + inline wrapped text
+        TooltipOnly = 0,  ///< Icon/label with tooltip on hover.
+        InlineText  = 1   ///< Icon/label with inline wrapped text.
     };
 
     /// \brief Show tooltip text with word wrapping.

--- a/include/imguix/widgets/misc/text_center.hpp
+++ b/include/imguix/widgets/misc/text_center.hpp
@@ -24,8 +24,8 @@ namespace ImGuiX::Widgets {
 
     /// \brief Center a wrapped text block by placing it into a centered child.
     /// \param text Text to render.
-    /// \param wrap_width Desired wrap width in pixels (<= avail). If <= 0, uses available width.
-    /// \note The function creates a child region of the target width and centers it, then uses TextWrapped inside.
+    /// \param wrap_width Wrap width in pixels; if <= 0 uses available width.
+    /// \note Creates centered child of the target width and calls TextWrapped inside.
     void TextWrappedCentered(const char* text, float wrap_width = 0.0f);
     
     /// \brief Overload for std::string (unformatted).
@@ -36,7 +36,7 @@ namespace ImGuiX::Widgets {
 
     /// \brief Overload for std::string (wrapped).
     /// \param s Text to render.
-    /// \param wrap_width Desired wrap width in pixels.
+    /// \param wrap_width Wrap width in pixels; if <= 0 uses available width.
     inline void TextWrappedCentered(const std::string& s, float wrap_width = 0.0f) {
         TextWrappedCentered(s.c_str(), wrap_width);
     }

--- a/include/imguix/widgets/misc/theme_picker.hpp
+++ b/include/imguix/widgets/misc/theme_picker.hpp
@@ -61,6 +61,9 @@ namespace ImGuiX::Widgets {
     /// \param ctrl Controller that owns ThemeManager and OptionsStore.
     /// \param cfg Widget configuration.
     /// \return True if selection changed.
+    /// \code{.cpp}
+    /// ThemePicker("ui-theme", ctrl);
+    /// \endcode
     inline bool ThemePicker(const char* id,
                             Controller* ctrl,
                             const ThemePickerConfig& cfg = {}) {


### PR DESCRIPTION
## Summary
- document default spinner color and config fields
- refine marker and centering helper comments
- add usage example for theme picker

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aab7c41c832caf953711af48dce5