### PR TITLE
docs(readme): list bundled submodules

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -384,6 +384,21 @@ fontsBuildNow();
 
 Все шрифты включены без изменений. См. `THIRD-PARTY-NOTICES.md` для указания авторства по семействам.
 
+## Связанные проекты
+
+ImGuiX включает ряд внешних библиотек в качестве git-сабмодулей:
+
+- [Dear ImGui](https://github.com/ocornut/imgui) — базовая библиотека для immediate-mode UI.
+- [fmt](https://github.com/fmtlib/fmt) — быстрый типобезопасный форматер строк для C++.
+- [FreeType](https://github.com/freetype/freetype) — движок растеризации шрифтов.
+- [GLFW](https://github.com/glfw/glfw) — кроссплатформенное создание окон, контекстов и ввод.
+- [ImGui-SFML](https://github.com/SFML/imgui-sfml) — связывает Dear ImGui с SFML.
+- [ImNodeFlow](https://github.com/Fattorino/ImNodeFlow) — редактор узлов и блюпринтов для Dear ImGui.
+- [ImPlot](https://github.com/epezent/implot) — библиотека построения графиков для Dear ImGui.
+- [ImPlot3D](https://github.com/brenocq/implot3d) — 3D-дополнение к ImPlot.
+- [nlohmann/json](https://github.com/nlohmann/json) — заголовочная библиотека работы с JSON.
+- [SFML](https://github.com/SFML/SFML) — Simple and Fast Multimedia Library для графики, аудио и окон.
+
 ## Лицензия
 
 MIT — см. [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -392,6 +392,21 @@ This repository bundles third-party fonts under their original licenses:
 
 All fonts are included unmodified. See `THIRD-PARTY-NOTICES.md` for per-family attributions.
 
+## Related Projects
+
+ImGuiX bundles several upstream libraries as git submodules:
+
+- [Dear ImGui](https://github.com/ocornut/imgui) — immediate-mode GUI library we build on.
+- [fmt](https://github.com/fmtlib/fmt) — fast, type-safe formatting for modern C++.
+- [FreeType](https://github.com/freetype/freetype) — font rasterization engine used for high-quality text rendering.
+- [GLFW](https://github.com/glfw/glfw) — multi-platform window, context, and input library.
+- [ImGui-SFML](https://github.com/SFML/imgui-sfml) — binding that integrates Dear ImGui with SFML.
+- [ImNodeFlow](https://github.com/Fattorino/ImNodeFlow) — node-based editor & blueprint system for Dear ImGui.
+- [ImPlot](https://github.com/epezent/implot) — immediate-mode plotting for Dear ImGui.
+- [ImPlot3D](https://github.com/brenocq/implot3d) — 3D plotting extension for ImPlot.
+- [nlohmann/json](https://github.com/nlohmann/json) — header-only JSON library.
+- [SFML](https://github.com/SFML/SFML) — Simple and Fast Multimedia Library for graphics, audio, and windowing.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE)


### PR DESCRIPTION
## Summary
- mention all git submodules in new “Related Projects” sections of README and README-RU

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON`
- `cmake --build build` *(fails: no match for `operator!=` in imgui-SFML)*
- `ctest --test-dir build` *(missing executables due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b1d32700832c9d2169c8224c7a13