### PR TITLE
refactor(widgets): move demos into widget headers

### DIFF
--- a/include/imguix/widgets/input/list_editor.hpp
+++ b/include/imguix/widgets/input/list_editor.hpp
@@ -58,6 +58,16 @@ namespace ImGuiX::Widgets {
             const ListEditorConfig& cfg = {}
         );
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for ListEditor widgets.
+    inline void DemoListEditor() {
+        static std::vector<std::string> names = {"Alice", "Bob"};
+        static std::vector<int> numbers = {1, 2, 3};
+        ListEditor("list.names",   "Names",   names);
+        ListEditor("list.numbers", "Numbers", numbers);
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/input/validated_password_input.hpp
+++ b/include/imguix/widgets/input/validated_password_input.hpp
@@ -105,6 +105,55 @@ bool InputPasswordWithToggleVK(
             ImGuiInputTextFlags extra_flags = 0
         );
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for validated input widgets.
+    inline void DemoValidatedInputs() {
+        static std::string email;
+        static std::string api_key;
+        bool email_valid   = false;
+        bool api_key_valid = false;
+
+        KeyboardToggleConfig kb_cfg;
+        kb_cfg.icon_text           = u8"\uE312";
+        kb_cfg.tooltip_toggle_on   = u8"Show keyboard";
+        kb_cfg.tooltip_toggle_off  = u8"Hide keyboard";
+
+        InputTextWithVKValidated(
+            "email##validated",
+            "email",
+            email,
+            true,
+            InputValidatePolicy::OnTouch,
+            R"(.+@.+\.\w+)",
+            email_valid,
+            kb_cfg
+        );
+
+        InputTextValidated(
+            "apikey##validated",
+            "api key (public)",
+            api_key,
+            true,
+            InputValidatePolicy::OnTouch,
+            R"(^[A-Za-z0-9.\-:]+$)",
+            api_key_valid
+        );
+
+        PasswordToggleConfig toggle_cfg;
+        InputPasswordWithToggleVK(
+            "apikey##togglevk",
+            "api key (public)",
+            api_key,
+            true,
+            InputValidatePolicy::OnTouch,
+            R"(^[A-Za-z0-9.\-:]+$)",
+            api_key_valid,
+            toggle_cfg,
+            kb_cfg
+        );
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/input/virtual_keyboard.hpp
+++ b/include/imguix/widgets/input/virtual_keyboard.hpp
@@ -441,6 +441,28 @@ namespace ImGuiX::Widgets {
         return VirtualKeyboard(id, text, cfg);
     }
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for VirtualKeyboard widget.
+    inline void DemoVirtualKeyboard() {
+        static bool show_email = false;
+        static bool show_pass  = false;
+        static bool show_host  = false;
+        static std::string email;
+        static std::string password;
+        static std::string host;
+        static VirtualKeyboardConfig cfg;
+        ImGui::Checkbox("Email VK",    &show_email); ImGui::SameLine();
+        ImGui::Checkbox("Password VK", &show_pass);  ImGui::SameLine();
+        ImGui::Checkbox("Host VK",     &show_host);
+        if (show_email)
+            VirtualKeyboard("vk.email", email, cfg);
+        if (show_pass)
+            VirtualKeyboard("vk.pass",  password, cfg);
+        if (show_host)
+            VirtualKeyboard("vk.host",  host, cfg);
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/misc/loading_spinner.hpp
+++ b/include/imguix/widgets/misc/loading_spinner.hpp
@@ -49,6 +49,19 @@ namespace ImGuiX::Widgets {
         return LoadingSpinner(id, cfg);
     }
 
+#   ifdef IMGUIX_DEMO
+    /// \brief Render demo for LoadingSpinner widget.
+    /// \param cfg Spinner configuration.
+    inline void DemoLoadingSpinner(LoadingSpinnerConfig& cfg) {
+        LoadingSpinner("spinner", cfg);
+        ImGui::SliderFloat("radius",    &cfg.radius,        2.0f, 48.0f, "%.0f");
+        ImGui::SliderFloat("thickness", &cfg.thickness,     1.0f, 12.0f, "%.1f");
+        ImGui::SliderInt  ("segments",  &cfg.segments,         8, 128);
+        ImGui::SliderFloat("sweep",     &cfg.sweep_ratio,   0.1f, 1.0f, "%.2f");
+        ImGui::SliderFloat("speed",     &cfg.angular_speed, 0.0f, 20.0f, "%.1f");
+    }
+#   endif
+
 } // namespace ImGuiX::Widgets
 #ifdef IMGUIX_HEADER_ONLY
 #   include "loading_spinner.ipp"

--- a/include/imguix/widgets/misc/markers.hpp
+++ b/include/imguix/widgets/misc/markers.hpp
@@ -7,6 +7,7 @@
 
 #include <imgui.h>
 #include <string>
+#include <vector>
 
 #include <imguix/config/icons.hpp>
 #include <imguix/config/colors.hpp>
@@ -98,6 +99,58 @@ namespace ImGuiX::Widgets {
             const ImVec4& color = IMGUIX_COLOR_SUCCESS,
             const char* icon_utf8 = IMGUIX_ICON_SUCCESS
         );
+
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for marker widgets.
+    inline void DemoMarkers() {
+        ImGui::TextDisabled("Colored markers:");
+        ColoredMarker("OK",         "All good",             ImVec4(0.10f, 0.75f, 0.30f, 1.0f));
+        ImGui::SameLine();
+        ColoredMarker("WARNING",    "Spread high",          ImVec4(0.95f, 0.75f, 0.10f, 1.0f));
+        ImGui::SameLine();
+        ColoredMarker("ERROR",      "Disconnected",         ImVec4(0.95f, 0.25f, 0.25f, 1.0f));
+        ImGui::SameLine();
+        ColoredMarker("SIMULATION", "Demo / paper trading", ImVec4(0.70f, 0.70f, 0.80f, 1.0f));
+
+        ImGui::Separator();
+
+        ImGui::TextDisabled("Message markers:");
+        ImGui::TextUnformatted("Help:");
+        ImGui::SameLine();
+        HelpMarker("Trading server to place real orders.\nUse with care.");
+
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x * 2);
+        ImGui::TextUnformatted("Info:");
+        ImGui::SameLine();
+        InfoMarker("New version available: v1.4.2. Update when idle.");
+
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x * 2);
+        ImGui::TextUnformatted("Warn:");
+        ImGui::SameLine();
+        WarningMarker("Funding API rate-limit almost reached; consider backoff.");
+
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x * 2);
+        ImGui::TextUnformatted("Success:");
+        ImGui::SameLine();
+        SuccessMarker("License validated. All features enabled.");
+        SuccessMarker("License validated.", MarkerMode::InlineText);
+
+        ImGui::Separator();
+
+        ImGui::TextDisabled("Selectable markers:");
+        static std::vector<std::string> presets = {
+            "London Session", "New York Session", "Asia Session", "Custom Range"
+        };
+        static int last_clicked = -1;
+        for (int i = 0; i < (int)presets.size(); ++i) {
+            if (SelectableMarker(presets[i])) {
+                last_clicked = i;
+            }
+        }
+        ImGui::Separator();
+        ImGui::Text("Last clicked: %s", (last_clicked >= 0 ? presets[last_clicked].c_str() : "none"));
+    }
+#endif
 
 } // namespace ImGuiX::Widgets
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/misc/text_center.hpp
+++ b/include/imguix/widgets/misc/text_center.hpp
@@ -41,6 +41,21 @@ namespace ImGuiX::Widgets {
         TextWrappedCentered(s.c_str(), wrap_width);
     }
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for centered text helpers.
+    inline void DemoTextCenter() {
+        static std::string email;
+        TextCenteredFmt(
+            "Welcome, %s!", email.empty() ? "guest" : email.c_str());
+        TextUnformattedCentered("This line is centered.");
+        TextWrappedCentered(
+            "This is a long message that demonstrates how wrapped text can be visually centered "
+            "by placing it inside a centered child region.",
+            420.0f
+        );
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 #ifdef IMGUIX_HEADER_ONLY
 #   include "text_center.ipp"

--- a/include/imguix/widgets/time/date_picker.hpp
+++ b/include/imguix/widgets/time/date_picker.hpp
@@ -64,6 +64,27 @@ namespace ImGuiX::Widgets {
                     int64_t& ts,
                     const DatePickerConfig& cfg = {});
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for DatePicker widget.
+    inline void DemoDatePicker() {
+        static int64_t y = 2025;
+        static int     m = 8, d = 25;
+        DatePickerConfig dc;
+        dc.label        = "Date";
+        dc.show_weekday = true;
+        dc.min_year     = 1950;
+        dc.max_year     = 2100;
+        DatePicker("date_struct", y, m, d, dc);
+
+        static int64_t ts = 0;
+        DatePickerConfig dc_ts;
+        dc_ts.label               = "Date (timestamp)";
+        dc_ts.show_weekday        = true;
+        dc_ts.preserve_time_of_day = false;
+        DatePicker("date_ts", ts, dc_ts);
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/time/days_selector.hpp
+++ b/include/imguix/widgets/time/days_selector.hpp
@@ -63,6 +63,19 @@ namespace ImGuiX::Widgets {
             std::vector<int>& selected_days,
             const DaysSelectorConfig& cfg = {});
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for DaysOfWeekSelector widget.
+    inline void DemoDaysOfWeekSelector() {
+        static std::vector<int> selected_days;
+        static DaysSelectorConfig cfg;
+        cfg.label       = u8"Working days";
+        cfg.short_names = { u8"Пн", u8"Вт", u8"Ср", u8"Чт", u8"Пт", u8"Сб", u8"Вс" };
+        if (DaysOfWeekSelector("##days_selector", selected_days, cfg)) {
+            // handle selected days
+        }
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/time/hours_selector.hpp
+++ b/include/imguix/widgets/time/hours_selector.hpp
@@ -43,6 +43,35 @@ namespace ImGuiX::Widgets {
     /// \return True if selection changed this frame.
     bool HoursSelector(const char* id, std::vector<int>& selected_hours, const HoursSelectorConfig& cfg = {});
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for HoursSelector widget.
+    inline void DemoHoursSelector() {
+        static std::vector<int> hours;
+        static HoursSelectorConfig cfg;
+        if (ImGui::SmallButton("Work 9–18")) {
+            hours.clear();
+            for (int h = 9; h <= 18; ++h) hours.push_back(h);
+        }
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Night 0–6")) {
+            hours.clear();
+            for (int h = 0; h <= 6; ++h) hours.push_back(h);
+        }
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Even hours")) {
+            hours.clear();
+            for (int h = 0; h < 24; h += 2) hours.push_back(h);
+        }
+
+        bool changed = HoursSelector("hours", hours, cfg);
+        ImGui::SameLine();
+        ImGui::TextDisabled("(%d selected)", (int)hours.size());
+        if (changed) {
+            // handle hour changes
+        }
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/time/time_picker.hpp
+++ b/include/imguix/widgets/time/time_picker.hpp
@@ -90,6 +90,35 @@ namespace ImGuiX::Widgets {
             int&     tz_index_io,
             const TimeOffsetPickerConfig& cfg = {});
 
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for time and offset pickers.
+    inline void DemoTimePicker() {
+        static int h = 14, m = 30, s = 0;
+        TimePickerConfig simple_tp;
+        simple_tp.label = "Time (H/M/S)";
+        TimePicker("simple.time", h, m, s, simple_tp);
+
+        static int      seconds = 18 * 3600;
+        static int64_t  tz_offset_sec = 2 * 3600;
+        static bool     has_dst_out = false;
+        static int      tz_index_io = 0;
+        static TimePickerConfig       tp_cfg;
+        static TimeOffsetPickerConfig to_cfg;
+        bool t_changed = TimePicker("time", seconds, tp_cfg);
+        ImGui::SameLine();
+        bool tz_changed = TimeOffsetPicker(
+            "offset",
+            tz_offset_sec,
+            has_dst_out,
+            tz_index_io,
+            to_cfg
+        );
+        if (t_changed || tz_changed) {
+            // handle new time/offset
+        }
+    }
+#endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/tests/test_widgets.cpp
+++ b/tests/test_widgets.cpp
@@ -336,47 +336,7 @@ private:
         }
 
         if (ImGui::CollapsingHeader("Validated Inputs")) {
-            bool email_valid   = false;
-            bool api_key_valid = false;
-
-            ImGuiX::Widgets::KeyboardToggleConfig kb_cfg;
-            kb_cfg.icon_text           = u8"\uE312";
-            kb_cfg.tooltip_toggle_on   = u8"Show keyboard";
-            kb_cfg.tooltip_toggle_off  = u8"Hide keyboard";
-
-            ImGuiX::Widgets::InputTextWithVKValidated(
-                "email##validated",
-                "email",
-                m_state.auth_data.email,
-                true,
-                ImGuiX::Widgets::InputValidatePolicy::OnTouch,
-                R"(.+@.+\.\w+)",
-                email_valid,
-                kb_cfg
-            );
-
-            ImGuiX::Widgets::InputTextValidated(
-                "apikey##validated",
-                "api key (public)",
-                m_state.auth_data.api_key,
-                true,
-                ImGuiX::Widgets::InputValidatePolicy::OnTouch,
-                R"(^[A-Za-z0-9.\-:]+$)",
-                api_key_valid
-            );
-
-            ImGuiX::Widgets::PasswordToggleConfig toggle_cfg;
-            ImGuiX::Widgets::InputPasswordWithToggleVK(
-                "apikey##togglevk",
-                "api key (public)",
-                m_state.auth_data.api_key,
-                true,
-                ImGuiX::Widgets::InputValidatePolicy::OnTouch,
-                R"(^[A-Za-z0-9.\-:]+$)",
-                api_key_valid,
-                toggle_cfg,
-                kb_cfg
-            );
+            ImGuiX::Widgets::DemoValidatedInputs();
         }
 
         if (ImGui::CollapsingHeader("Status Info")) {
@@ -387,16 +347,7 @@ private:
         }
 
         if (ImGui::CollapsingHeader("Virtual Keyboards")) {
-            ImGui::Checkbox("Email VK",    &m_state.kbd_email); ImGui::SameLine();
-            ImGui::Checkbox("Password VK", &m_state.kbd_pass);  ImGui::SameLine();
-            ImGui::Checkbox("Host VK",     &m_state.kbd_host);
-
-            if (m_state.kbd_email)
-                ImGuiX::Widgets::VirtualKeyboard("vk.email", m_state.auth_data.email,    m_state.kcfg);
-            if (m_state.kbd_pass)
-                ImGuiX::Widgets::VirtualKeyboard("vk.pass",  m_state.auth_data.password, m_state.kcfg);
-            if (m_state.kbd_host)
-                ImGuiX::Widgets::VirtualKeyboard("vk.host",  m_state.auth_data.host,     m_state.kcfg);
+            ImGuiX::Widgets::DemoVirtualKeyboard();
         }
 
         if (ImGui::CollapsingHeader("Domain Selector")) {
@@ -419,157 +370,37 @@ private:
 
     void demoTime() {
         if (ImGui::CollapsingHeader("Hours Selector")) {
-            if (ImGui::SmallButton("Work 9–18")) {
-                m_state.hours.clear();
-                for (int h = 9; h <= 18; ++h) m_state.hours.push_back(h);
-            }
-            ImGui::SameLine();
-            if (ImGui::SmallButton("Night 0–6")) {
-                m_state.hours.clear();
-                for (int h = 0; h <= 6; ++h) m_state.hours.push_back(h);
-            }
-            ImGui::SameLine();
-            if (ImGui::SmallButton("Even hours")) {
-                m_state.hours.clear();
-                for (int h = 0; h < 24; h += 2) m_state.hours.push_back(h);
-            }
-
-            bool changed = ImGuiX::Widgets::HoursSelector("hours", m_state.hours, m_state.hs_cfg);
-            ImGui::SameLine();
-            ImGui::TextDisabled("(%d selected)", (int)m_state.hours.size());
-            if (changed) {
-                // обработать изменения часов
-            }
+            ImGuiX::Widgets::DemoHoursSelector();
         }
 
         if (ImGui::CollapsingHeader("WeekDays Selector")) {
-            static std::vector<int> selected_days;
-
-            ImGuiX::Widgets::DaysSelectorConfig cfg;
-            cfg.label       = u8"Working days";
-            //cfg.combo_width = 180.0f;
-            cfg.short_names = { u8"Пн", u8"Вт", u8"Ср", u8"Чт", u8"Пт", u8"Сб", u8"Вс" };
-            if (ImGuiX::Widgets::DaysOfWeekSelector("##days_selector", selected_days, cfg)) {
-                // обработать выбранные дни
-            }
+            ImGuiX::Widgets::DemoDaysOfWeekSelector();
         }
 
         if (ImGui::CollapsingHeader("Time & Offset")) {
-            static int h = 14, m = 30, s = 0;
-            ImGuiX::Widgets::TimePickerConfig simple_tp;
-            simple_tp.label = "Time (H/M/S)";
-            ImGuiX::Widgets::TimePicker("simple.time", h, m, s, simple_tp);
-
-            bool t_changed = ImGuiX::Widgets::TimePicker(
-                "time", m_state.time_of_day_sec, m_state.tp_cfg);
-
-            ImGui::SameLine();
-
-            bool tz_changed = ImGuiX::Widgets::TimeOffsetPicker(
-                "offset",
-                m_state.tz_offset_sec,
-                m_state.has_dst_out,
-                m_state.tz_index_io,
-                m_state.to_cfg
-            );
-
-            if (t_changed || tz_changed) {
-                // обработать новое время/смещение
-            }
+            ImGuiX::Widgets::DemoTimePicker();
         }
 
         if (ImGui::CollapsingHeader("Date Picker")) {
-            static int64_t y = 2025;
-            static int     m = 8, d = 25;
-            ImGuiX::Widgets::DatePickerConfig dc;
-            dc.label        = "Date";
-            dc.show_weekday = true;
-            dc.min_year     = 1950;
-            dc.max_year     = 2100;
-            ImGuiX::Widgets::DatePicker("date_struct", y, m, d, dc);
-
-            static int64_t ts = 0;
-            ImGuiX::Widgets::DatePickerConfig dc_ts;
-            dc_ts.label               = "Date (timestamp)";
-            dc_ts.show_weekday        = true;
-            dc_ts.preserve_time_of_day = false;
-            ImGuiX::Widgets::DatePicker("date_ts", ts, dc_ts);
+            ImGuiX::Widgets::DemoDatePicker();
         }
     }
 
     void demoMisc() {
         if (ImGui::CollapsingHeader("Markers")) {
-            ImGui::TextDisabled("Colored markers:");
-            ImGuiX::Widgets::ColoredMarker("OK",          "All good",                  ImVec4(0.10f, 0.75f, 0.30f, 1.0f));
-            ImGui::SameLine();
-            ImGuiX::Widgets::ColoredMarker("WARNING",     "Spread high",               ImVec4(0.95f, 0.75f, 0.10f, 1.0f));
-            ImGui::SameLine();
-            ImGuiX::Widgets::ColoredMarker("ERROR",       "Disconnected",              ImVec4(0.95f, 0.25f, 0.25f, 1.0f));
-            ImGui::SameLine();
-            ImGuiX::Widgets::ColoredMarker("SIMULATION",  "Demo / paper trading",      ImVec4(0.70f, 0.70f, 0.80f, 1.0f));
-
-            ImGui::Separator();
-
-            ImGui::TextDisabled("Message markers:");
-            ImGui::TextUnformatted("Help:");
-            ImGui::SameLine();
-            ImGuiX::Widgets::HelpMarker("Trading server to place real orders.\nUse with care.");
-
-            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x * 2);
-            ImGui::TextUnformatted("Info:");
-            ImGui::SameLine();
-            ImGuiX::Widgets::InfoMarker("New version available: v1.4.2. Update when idle.");
-
-            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x * 2);
-            ImGui::TextUnformatted("Warn:");
-            ImGui::SameLine();
-            ImGuiX::Widgets::WarningMarker("Funding API rate-limit almost reached; consider backoff.");
-
-            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x * 2);
-            ImGui::TextUnformatted("Success:");
-            ImGui::SameLine();
-            ImGuiX::Widgets::SuccessMarker("License validated. All features enabled.");
-            ImGuiX::Widgets::SuccessMarker("License validated.", ImGuiX::Widgets::MarkerMode::InlineText);
-
-            ImGui::Separator();
-
-            ImGui::TextDisabled("Selectable markers:");
-            static std::vector<std::string> presets = {
-                "London Session", "New York Session", "Asia Session", "Custom Range"
-            };
-            static int last_clicked = -1;
-            for (int i = 0; i < (int)presets.size(); ++i) {
-                if (ImGuiX::Widgets::SelectableMarker(presets[i])) {
-                    last_clicked = i;
-                }
-            }
-            ImGui::Separator();
-            ImGui::Text("Last clicked: %s", (last_clicked >= 0 ? presets[last_clicked].c_str() : "none"));
+            ImGuiX::Widgets::DemoMarkers();
         }
 
         if (ImGui::CollapsingHeader("Loading Spinner")) {
-            ImGuiX::Widgets::LoadingSpinner("spinner", m_state.sp_cfg);
-            ImGui::SliderFloat("radius",    &m_state.sp_cfg.radius,        2.0f, 48.0f, "%.0f");
-            ImGui::SliderFloat("thickness", &m_state.sp_cfg.thickness,     1.0f, 12.0f, "%.1f");
-            ImGui::SliderInt  ("segments",  &m_state.sp_cfg.segments,         8, 128);
-            ImGui::SliderFloat("sweep",     &m_state.sp_cfg.sweep_ratio,   0.1f, 1.0f, "%.2f");
-            ImGui::SliderFloat("speed",     &m_state.sp_cfg.angular_speed, 0.0f, 20.0f, "%.1f");
+            ImGuiX::Widgets::DemoLoadingSpinner(m_state.sp_cfg);
         }
 
         if (ImGui::CollapsingHeader("Text Centering")) {
-            ImGuiX::Widgets::TextCenteredFmt(
-                "Welcome, %s!", m_state.auth_data.email.empty() ? "guest" : m_state.auth_data.email.c_str());
-            ImGuiX::Widgets::TextUnformattedCentered("This line is centered.");
-            ImGuiX::Widgets::TextWrappedCentered(
-                "This is a long message that demonstrates how wrapped text can be visually centered "
-                "by placing it inside a centered child region.",
-                420.0f
-            );
+            ImGuiX::Widgets::DemoTextCenter();
         }
 
         if (ImGui::CollapsingHeader("List Editors")) {
-            ImGuiX::Widgets::ListEditor("list.names",   "Names",   m_state.names);
-            ImGuiX::Widgets::ListEditor("list.numbers", "Numbers", m_state.numbers);
+            ImGuiX::Widgets::DemoListEditor();
         }
     }
 


### PR DESCRIPTION
## Summary
- add DemoListEditor for string and integer lists
- add DemoVirtualKeyboard with toggleable fields
- add DemoValidatedInputs combining VK, validation, and password toggle
- add DemoHoursSelector with preset ranges
- add DemoLoadingSpinner and unified markers demo
- add DemoTextCenter for centered text helpers
- add DemoDaysOfWeekSelector, DemoTimePicker, and DemoDatePicker
- call new demo helpers from test_widgets

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b4f8424950832ca47b091711395263