### PR TITLE
feat(widgets): move demos into headers

### DIFF
--- a/include/imguix/widgets/auth/auth_js_panel.hpp
+++ b/include/imguix/widgets/auth/auth_js_panel.hpp
@@ -62,6 +62,15 @@ namespace ImGuiX::Widgets {
     /// \return True if any field changed this frame.
     bool AuthJsPanel(const char* id, AuthJsPanelConfig& cfg, AuthJsSettings& st);
 
+#   ifdef IMGUIX_DEMO
+    /// \brief Render demo for AuthJsPanel widget.
+    inline void DemoAuthJsPanel() {
+        static AuthJsPanelConfig cfg{};
+        static AuthJsSettings st{};
+        AuthJsPanel("js.panel", cfg, st);
+    }
+#   endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/auth/auth_panel.hpp
+++ b/include/imguix/widgets/auth/auth_panel.hpp
@@ -16,6 +16,7 @@
 #include <imguix/config/fonts.hpp>
 #include <imguix/widgets/input/validated_password_input.hpp>
 #include <imguix/config/colors.hpp>
+#include <imguix/core/controller/Controller.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -173,6 +174,36 @@ namespace ImGuiX::Widgets {
             AuthPanelConfig& cfg,
             AuthData& data
         );
+
+#   ifdef IMGUIX_DEMO
+    /// \brief Render demo for AuthPanel widget.
+    /// \param ctrl Controller to access options storage.
+    inline void DemoAuthPanel(ImGuiX::Controller* ctrl) {
+        static AuthPanelConfig auth_cfg{};
+        static AuthData auth_data{};
+        AuthPanel("login.panel", auth_cfg, auth_data);
+
+        AuthPanelConfig cfg_api{};
+        cfg_api.header              = u8"Authorization (API key)";
+        cfg_api.show_api_keys       = true;
+        cfg_api.vk_api_key          = true;
+        cfg_api.vk_api_secret       = true;
+        cfg_api.show_connect_button = false;
+        const auto res = AuthPanel("login.api", cfg_api, auth_data);
+        using E = AuthPanelResult;
+        if (ctrl) {
+            if (Has(res, E::HostChanged) && auth_data.host_valid) {
+                ctrl->options().setStr("host", auth_data.host);
+            }
+            if (Has(res, E::EmailChanged) && auth_data.email_valid) {
+                ctrl->options().setStr("email", auth_data.email);
+            }
+            if (Has(res, E::PasswordChanged)) {
+                ctrl->options().setStr("password", auth_data.password);
+            }
+        }
+    }
+#   endif
 
 } // namespace ImGuiX::Widgets
 

--- a/include/imguix/widgets/auth/domain_selector.hpp
+++ b/include/imguix/widgets/auth/domain_selector.hpp
@@ -56,6 +56,15 @@ namespace ImGuiX::Widgets {
             std::string& host
         );
 
+#   ifdef IMGUIX_DEMO
+    /// \brief Render demo for DomainSelector widget.
+    inline void DemoDomainSelector() {
+        static DomainSelectorConfig cfg{};
+        static std::string host;
+        DomainSelector("domain.selector", cfg, host);
+    }
+#   endif
+
 } // namespace ImGuiX::Widgets
 
 #ifdef IMGUIX_HEADER_ONLY

--- a/include/imguix/widgets/notify/notifications.hpp
+++ b/include/imguix/widgets/notify/notifications.hpp
@@ -256,6 +256,102 @@ namespace ImGuiX::Widgets {
         InsertNotification(ctrl, std::move(n));
     }
 
+#   ifdef IMGUIX_DEMO
+    /// \brief Render demo for toast notifications.
+    /// \param ctrl Controller with a NotificationManager.
+    inline void DemoNotifications(Controller* ctrl) {
+        if (!ctrl) return;
+        if (ImGui::Button("Success")) {
+            NotifyFmt(
+                ctrl, ImGuiX::Notify::Type::Success, 0,
+                u8"That is a success! {}", "(Format here)"
+            );
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Warning")) {
+            NotifyFmt(
+                ctrl, ImGuiX::Notify::Type::Warning, 0,
+                u8"This is a warning!"
+            );
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Error")) {
+            NotifyFmt(
+                ctrl, ImGuiX::Notify::Type::Error, 0,
+                u8"Segmentation fault"
+            );
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Info")) {
+            NotifyFmt(
+                ctrl, ImGuiX::Notify::Type::Info, 0,
+                u8"Info about ImGui..."
+            );
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Info long")) {
+            NotifyFmt(
+                ctrl, ImGuiX::Notify::Type::Info, 0,
+                u8"Hi, I'm a long notification. I'm here to show you that you can write a lot of text in me. "
+                u8"I'm also here to show you that I can wrap text, so you don't have to worry about that."
+            );
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Notify with button")) {
+            NotifyWithButtonFmt(
+                ctrl,
+                ImGuiX::Notify::Type::Error,
+                0,
+                u8"Click me!",
+                [ctrl]() {
+                    NotifyFmt(
+                        ctrl, ImGuiX::Notify::Type::Success, 0,
+                        u8"Thanks for clicking!"
+                    );
+                },
+                u8"Notification", "Content with action"
+            );
+        }
+
+        ImGui::Separator();
+        ImGui::TextDisabled(u8"Do it yourself:");
+
+        static char title_buf[4096]   = u8"Hello there!";
+        static char content_buf[4096] = u8"General Kenobi! \n- Grievous";
+        ImGui::InputTextMultiline(u8"Title",   title_buf,   IM_ARRAYSIZE(title_buf));
+        ImGui::InputTextMultiline(u8"Content", content_buf, IM_ARRAYSIZE(content_buf));
+
+        static int duration_ms = 5000;
+        ImGui::InputInt(u8"Duration (ms)", &duration_ms, 100);
+        if (duration_ms < 0) duration_ms = 0;
+
+        static const char* type_str[] = { u8"None", u8"Success", u8"Warning", u8"Error", u8"Info" };
+        static ImGuiX::Notify::Type type = ImGuiX::Notify::Type::Success;
+        if (ImGui::BeginCombo(u8"Type", type_str[static_cast<int>(type)])) {
+            for (int n = 0; n < IM_ARRAYSIZE(type_str); ++n) {
+                const bool selected = (static_cast<int>(type) == n);
+                if (ImGui::Selectable(type_str[n], selected)) {
+                    type = static_cast<ImGuiX::Notify::Type>(n);
+                }
+                if (selected) ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+        }
+
+        static bool enable_title = true, enable_content = true;
+        ImGui::Checkbox(u8"Enable title", &enable_title);
+        ImGui::SameLine();
+        ImGui::Checkbox(u8"Enable content", &enable_content);
+
+        if (ImGui::Button(u8"Show")) {
+            ImGuiX::Notify::Notification toast(type, duration_ms);
+            if (enable_title)   toast.setTitle("%s", title_buf);
+            if (enable_content) toast.setContent("%s", content_buf);
+            InsertNotification(ctrl, std::move(toast));
+        }
+    }
+#   endif
+
 } // namespace ImGuiX::Widgets
 
 #endif // _IMGUIX_WIDGETS_NOTIFY_NOTIFICATIONS_HPP_INCLUDED

--- a/tests/test_widgets.cpp
+++ b/tests/test_widgets.cpp
@@ -313,26 +313,7 @@ private:
 
     void demoAuthorization() {
         if (ImGui::CollapsingHeader("Authorization", ImGuiTreeNodeFlags_DefaultOpen)) {
-            ImGuiX::Widgets::AuthPanel(
-                "login.panel", m_state.auth_cfg, m_state.auth_data);
-
-            ImGuiX::Widgets::AuthPanelConfig cfg_api{};
-            cfg_api.header              = u8"Authorization (API key)";
-            cfg_api.show_api_keys       = true;
-            cfg_api.vk_api_key          = true;
-            cfg_api.vk_api_secret       = true;
-            cfg_api.show_connect_button = false;
-            const auto res = ImGuiX::Widgets::AuthPanel("login.api", cfg_api, m_state.auth_data);
-            using E = ImGuiX::Widgets::AuthPanelResult;
-            if (Has(res, E::HostChanged) && m_state.auth_data.host_valid) {
-                options().setStr("host", m_state.auth_data.host);
-            }
-            if (Has(res, E::EmailChanged) && m_state.auth_data.email_valid) {
-                options().setStr("email", m_state.auth_data.email);
-            }
-            if (Has(res, E::PasswordChanged)) {
-                options().setStr("password", m_state.auth_data.password);
-            }
+            ImGuiX::Widgets::DemoAuthPanel(this);
         }
 
         if (ImGui::CollapsingHeader("Validated Inputs")) {
@@ -351,14 +332,11 @@ private:
         }
 
         if (ImGui::CollapsingHeader("Domain Selector")) {
-            if (ImGuiX::Widgets::DomainSelector("domain.selector", m_state.dom_cfg, m_state.auth_data.host)) {
-                // Реакция на изменение хоста при необходимости
-            }
+            ImGuiX::Widgets::DemoDomainSelector();
         }
 
         if (ImGui::CollapsingHeader("JS Panel")) {
-            ImGuiX::Widgets::AuthJsPanelConfig js_cfg{};
-            ImGuiX::Widgets::AuthJsPanel("js.panel", js_cfg, m_state.js_st);
+            ImGuiX::Widgets::DemoAuthJsPanel();
         }
 
         if (ImGui::CollapsingHeader("Proxy Settings")) {
@@ -406,94 +384,7 @@ private:
 
     void demoNotifications() {
         if (ImGui::CollapsingHeader("Notifications", ImGuiTreeNodeFlags_DefaultOpen)) {
-            if (ImGui::Button("Success")) {
-                ImGuiX::Widgets::NotifyFmt(
-                    this, ImGuiX::Notify::Type::Success, 0,
-                    u8"That is a success! {}", "(Format here)"
-                );
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Warning")) {
-                ImGuiX::Widgets::NotifyFmt(
-                    this, ImGuiX::Notify::Type::Warning, 0,
-                    u8"This is a warning!"
-                );
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Error")) {
-                ImGuiX::Widgets::NotifyFmt(
-                    this, ImGuiX::Notify::Type::Error, 0,
-                    u8"Segmentation fault"
-                );
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Info")) {
-                ImGuiX::Widgets::NotifyFmt(
-                    this, ImGuiX::Notify::Type::Info, 0,
-                    u8"Info about ImGui..."
-                );
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Info long")) {
-                ImGuiX::Widgets::NotifyFmt(
-                    this, ImGuiX::Notify::Type::Info, 0,
-                    u8"Hi, I'm a long notification. I'm here to show you that you can write a lot of text in me. "
-                    u8"I'm also here to show you that I can wrap text, so you don't have to worry about that."
-                );
-            }
-            ImGui::SameLine();
-            if (ImGui::Button("Notify with button")) {
-                ImGuiX::Widgets::NotifyWithButtonFmt(
-                    this,
-                    ImGuiX::Notify::Type::Error,
-                    0,
-                    u8"Click me!",
-                    [this]() {
-                        ImGuiX::Widgets::NotifyFmt(
-                            this, ImGuiX::Notify::Type::Success, 0,
-                            u8"Thanks for clicking!"
-                        );
-                    },
-                    u8"Notification", "Content with action"
-                );
-            }
-
-            ImGui::Separator();
-            ImGui::TextDisabled(u8"Do it yourself:");
-
-            static char title_buf[4096]   = u8"Hello there!";
-            static char content_buf[4096] = u8"General Kenobi! \n- Grievous";
-            ImGui::InputTextMultiline(u8"Title",   title_buf,   IM_ARRAYSIZE(title_buf));
-            ImGui::InputTextMultiline(u8"Content", content_buf, IM_ARRAYSIZE(content_buf));
-
-            static int duration_ms = 5000;
-            ImGui::InputInt(u8"Duration (ms)", &duration_ms, 100);
-            if (duration_ms < 0) duration_ms = 0;
-
-            static const char* type_str[] = { u8"None", u8"Success", u8"Warning", u8"Error", u8"Info" };
-            static ImGuiX::Notify::Type type = ImGuiX::Notify::Type::Success;
-            if (ImGui::BeginCombo(u8"Type", type_str[static_cast<int>(type)])) {
-                for (int n = 0; n < IM_ARRAYSIZE(type_str); ++n) {
-                    const bool selected = (static_cast<int>(type) == n);
-                    if (ImGui::Selectable(type_str[n], selected)) {
-                        type = static_cast<ImGuiX::Notify::Type>(n);
-                    }
-                    if (selected) ImGui::SetItemDefaultFocus();
-                }
-                ImGui::EndCombo();
-            }
-
-            static bool enable_title = true, enable_content = true;
-            ImGui::Checkbox(u8"Enable title", &enable_title);
-            ImGui::SameLine();
-            ImGui::Checkbox(u8"Enable content", &enable_content);
-
-            if (ImGui::Button(u8"Show")) {
-                ImGuiX::Notify::Notification toast(type, duration_ms);
-                if (enable_title)   toast.setTitle("%s", title_buf);
-                if (enable_content) toast.setContent("%s", content_buf);
-                ImGuiX::Widgets::InsertNotification(this, std::move(toast));
-            }
+            ImGuiX::Widgets::DemoNotifications(this);
         }
     }
 


### PR DESCRIPTION
## Summary
- add demo helpers for AuthPanel, AuthJsPanel, DomainSelector and toast notifications
- simplify test_widgets by invoking new demo helpers

## Testing
- `git submodule update --init --recursive`
- `cmake -S . -B build -G "Ninja" -DIMGUIX_DEPS_MODE=BUNDLED -DIMGUIX_VENDOR_JSON=ON -DIMGUIX_BUILD_TESTS=ON -DBUILD_SHARED_LIBS=OFF -DIMGUIX_BUILD_SHARED=OFF -DIMGUIX_IMGUI_FREETYPE=ON` *(pass)*
- `cmake --build build` *(fail: ImGui-SFML.cpp operator!= error)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ff85aba8832c930b91987eca5ed8