### PR TITLE
feat: add icon combo widget

### DIFF
--- a/include/imguix/widgets.hpp
+++ b/include/imguix/widgets.hpp
@@ -12,6 +12,7 @@
 
 #include <imguix/widgets/controls/circle_button.hpp>
 #include <imguix/widgets/controls/icon_button.hpp>
+#include <imguix/widgets/controls/icon_combo.hpp>
 #include <imguix/widgets/controls/system_button.hpp>
 #include <imguix/widgets/controls/toggle_button.hpp>
 

--- a/include/imguix/widgets/controls/icon_combo.hpp
+++ b/include/imguix/widgets/controls/icon_combo.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_ICON_COMBO_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_ICON_COMBO_HPP_INCLUDED
+
+/// \file icon_combo.hpp
+/// \brief Combo widget with custom icon on the right.
+
+#include <imgui.h>
+
+namespace ImGuiX::Widgets {
+
+    /// \brief Begin combo without arrow and draw overlay icon on the right.
+    /// \param id ImGui identifier.
+    /// \param preview Text preview shown in combo.
+    /// \param icon Icon text (UTF-8).
+    /// \param icon_slot_w Width reserved for icon overlay (0 -> auto from text).
+    /// \param flags ImGuiComboFlags.
+    /// \return True if combo is open.
+    inline bool BeginIconCombo(
+            const char* id,
+            const char* preview,
+            const char* icon,
+            float icon_slot_w = 0.0f,
+            ImGuiComboFlags flags = ImGuiComboFlags_HeightLargest | ImGuiComboFlags_PopupAlignLeft
+    );
+
+    /// \brief End combo started with BeginIconCombo.
+    inline void EndIconCombo();
+
+} // namespace ImGuiX::Widgets
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "icon_combo.ipp"
+#endif
+
+#endif // _IMGUIX_WIDGETS_ICON_COMBO_HPP_INCLUDED

--- a/include/imguix/widgets/controls/icon_combo.ipp
+++ b/include/imguix/widgets/controls/icon_combo.ipp
@@ -1,0 +1,34 @@
+namespace ImGuiX::Widgets {
+
+    inline bool BeginIconCombo(
+            const char* id,
+            const char* preview,
+            const char* icon,
+            float icon_slot_w,
+            ImGuiComboFlags flags
+    ) {
+        bool open = ImGui::BeginCombo(id, preview, flags | ImGuiComboFlags_NoArrowButton);
+        ImDrawList* dl = ImGui::GetWindowDrawList();
+        ImVec2 p0 = ImGui::GetItemRectMin();
+        ImVec2 p1 = ImGui::GetItemRectMax();
+
+        ImVec2 isz = ImGui::CalcTextSize(icon ? icon : "");
+        float slot_w = icon_slot_w > 0.0f ? icon_slot_w
+            : (isz.x + ImGui::GetStyle().FramePadding.x * 2.0f);
+
+        ImU32 slot_bg = ImGui::GetColorU32(ImGuiCol_FrameBgHovered);
+        dl->AddRectFilled(ImVec2(p1.x - slot_w, p0.y), p1, slot_bg, 0.0f);
+
+        ImVec2 ip;
+        ip.x = p1.x - slot_w + (slot_w - isz.x) * 0.5f;
+        ip.y = p0.y + (p1.y - p0.y - isz.y) * 0.5f;
+        dl->AddText(ip, ImGui::GetColorU32(ImGuiCol_Text), icon ? icon : "");
+
+        return open;
+    }
+
+    inline void EndIconCombo() {
+        ImGui::EndCombo();
+    }
+
+} // namespace ImGuiX::Widgets

--- a/tests/test_widgets.cpp
+++ b/tests/test_widgets.cpp
@@ -30,6 +30,7 @@
 #include <imguix/widgets/misc/loading_spinner.hpp>
 #include <imguix/widgets/misc/markers.hpp>
 #include <imguix/widgets/misc/theme_picker.hpp>
+#include <imguix/widgets/controls/icon_combo.hpp>
 
 // === Themes ===
 #include <imguix/themes/CorporateGreyTheme.hpp>
@@ -379,6 +380,21 @@ private:
 
         if (ImGui::CollapsingHeader("List Editors")) {
             ImGuiX::Widgets::DemoListEditor();
+        }
+
+        if (ImGui::CollapsingHeader("Icon Combo")) {
+            static int sel_idx = 0;
+            const char* items[] = {u8"One", u8"Two", u8"Three"};
+            const char* icons[] = {u8"☀", u8"🌙", u8"⭐"};
+            if (ImGuiX::Widgets::BeginIconCombo("demo_icon_combo", items[sel_idx], icons[sel_idx])) {
+                for (int i = 0; i < IM_ARRAYSIZE(items); ++i) {
+                    bool selected = (i == sel_idx);
+                    if (ImGui::Selectable(items[i], selected)) {
+                        sel_idx = i;
+                    }
+                }
+                ImGuiX::Widgets::EndIconCombo();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add BeginIconCombo/EndIconCombo to draw custom icon in combo preview
- demo icon combo usage in test widgets

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=ON -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF` *(fails: imgui::imgui target not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74446ca8c832c8738f0dcf1eb4f8d