### PR TITLE
Add expiry picker widget

### DIFF
--- a/include/imguix/utils/time_utils.hpp
+++ b/include/imguix/utils/time_utils.hpp
@@ -168,8 +168,13 @@ namespace ImGuiX::Utils {
                                     "Jul","Aug","Sep","Oct","Nov","Dec"};
         return (m>=1 && m<=12) ? k[m-1] : "???";
     }
-    
+
     // ---------- format ----------
+
+    /// \brief Format seconds as HH:MM:SS (no day component).
+    /// \param sec Seconds to format.
+    /// \return Formatted string.
+    std::string format_hms_u32(int sec);
 
     /// \brief Format seconds as "HH:MM:SS".
     /// \param sec Seconds to format.

--- a/include/imguix/utils/time_utils.ipp
+++ b/include/imguix/utils/time_utils.ipp
@@ -78,6 +78,17 @@ namespace ImGuiX::Utils {
         return w;                                                 // 0=Sun..6=Sat
     }
 
+    std::string format_hms_u32(int sec) {
+        sec = std::max(0, sec);
+        int h = sec / 3600;
+        sec -= h * 3600;
+        int m = sec / 60;
+        int s = sec - m * 60;
+        char buf[16];
+        std::snprintf(buf, sizeof(buf), u8"%02d:%02d:%02d", h, m, s);
+        return std::string(buf);
+    }
+
     std::string format_hms(int sec) {
         int h, m, s; ImGuiX::Utils::seconds_to_hms(sec, h, m, s);
         char buf[16]; std::snprintf(buf, sizeof(buf), u8"%02d:%02d:%02d", h, m, s);

--- a/include/imguix/widgets.hpp
+++ b/include/imguix/widgets.hpp
@@ -33,6 +33,7 @@
 #include <imguix/widgets/time/days_selector.hpp>
 #include <imguix/widgets/time/hours_selector.hpp>
 #include <imguix/widgets/time/time_picker.hpp>
+#include <imguix/widgets/time/expiry_picker.hpp>
 
 #ifdef IMGUI_ENABLE_IMPLOT
 #   include <imguix/widgets/plot/PlotOHLCChart.hpp>

--- a/include/imguix/widgets/time/expiry_picker.hpp
+++ b/include/imguix/widgets/time/expiry_picker.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_EXPIRY_PICKER_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_EXPIRY_PICKER_HPP_INCLUDED
+
+/// \file expiry_picker.hpp
+/// \brief Expiry picker with preset grid and H/M/S steppers.
+
+#include <imgui.h>
+
+#include <vector>
+
+#include <imguix/widgets/controls/icon_combo.hpp>
+
+namespace ImGuiX::Widgets {
+
+    /// \brief Preset entry for expiry picker.
+    struct ExpiryPreset {
+        const char* label;   ///< Display label (e.g. "S5", "M1").
+        int         seconds; ///< Value in seconds.
+    };
+
+    /// \brief Default presets similar to the screenshot.
+    /// \return Reference to built-in presets.
+    const std::vector<ExpiryPreset>& DefaultExpiryPresets();
+
+    /// \brief Configuration for ExpiryPicker.
+    struct ExpiryPickerConfig {
+        const char* label             = u8"Expiry"; ///< Combo label.
+        float       combo_width       = 0.0f;       ///< Preview width (0 -> default).
+        float       field_width       = 0.0f;       ///< H/M/S field width (0 -> auto).
+        float       cell_rounding     = 0.0f;       ///< 0 -> square. (<0 -> use style).
+        bool        show_cell_borders = true;       ///< Draw cell borders.
+        ImVec2      cell_size         = ImVec2(0, 0); ///< Preset cell size (0 -> frame height).
+        int         rows              = 3;          ///< Preset grid rows.
+        int         cols              = 3;          ///< Preset grid columns.
+
+        const char* icon_text       = u8"🕒"; ///< Icon text for combo.
+        float       icon_slot_width = 0.0f; ///< Width reserved for icon (0 -> auto).
+
+        int min_seconds = 0;                     ///< Minimum allowed seconds.
+        int max_seconds = 24 * 3600 - 1;        ///< Maximum allowed seconds.
+
+        const std::vector<ExpiryPreset>* presets = nullptr; ///< Optional custom presets.
+    };
+
+    /// \brief Expiry picker with H/M/S steppers and preset grid.
+    /// \param id Unique widget identifier.
+    /// \param seconds In/out expiry in seconds (clamped to [min,max]).
+    /// \param cfg Widget configuration.
+    /// \return True if value changed.
+    bool ExpiryPicker(
+            const char* id,
+            int& seconds,
+            const ExpiryPickerConfig& cfg = {});
+
+#ifdef IMGUIX_DEMO
+    /// \brief Render demo for expiry picker.
+    void DemoExpiryPicker();
+#endif
+
+} // namespace ImGuiX::Widgets
+
+#ifdef IMGUIX_HEADER_ONLY
+#   include "expiry_picker.ipp"
+#endif
+
+#endif // _IMGUIX_WIDGETS_EXPIRY_PICKER_HPP_INCLUDED

--- a/include/imguix/widgets/time/expiry_picker.ipp
+++ b/include/imguix/widgets/time/expiry_picker.ipp
@@ -1,0 +1,184 @@
+#include <imgui.h>
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <imguix/widgets/controls/icon_combo.hpp>
+#include <imguix/utils/time_utils.hpp>
+
+namespace ImGuiX::Widgets {
+
+    inline const std::vector<ExpiryPreset>& DefaultExpiryPresets() {
+        static const std::vector<ExpiryPreset> p = {
+            {"S5",   5},   {"S15",   15}, {"S30",   30},
+            {"M1",   60},  {"M3",   180}, {"M5",   300},
+            {"M30",  1800},{"H1",   3600},{"H4",  14400},
+        };
+        return p;
+    }
+
+    inline bool ExpiryPicker(
+            const char* id,
+            int& seconds,
+            const ExpiryPickerConfig& cfg
+    ) {
+        const auto& presets = cfg.presets ? *cfg.presets : DefaultExpiryPresets();
+
+        seconds = std::clamp(seconds, cfg.min_seconds, cfg.max_seconds);
+        std::string preview = Utils::format_hms_u32(seconds);
+
+        if (cfg.combo_width > 0.0f) {
+            ImGui::SetNextItemWidth(cfg.combo_width);
+        }
+
+        bool changed = false;
+        ImGui::PushID(id);
+
+        bool open = BeginIconCombo(
+                cfg.label ? cfg.label : u8"Expiry",
+                preview.c_str(),
+                cfg.icon_text,
+                cfg.icon_slot_width);
+
+        if (open) {
+            int h = seconds / 3600;
+            int m = (seconds / 60) % 60;
+            int s = seconds % 60;
+
+            const float frame_h = ImGui::GetFrameHeight();
+            const float fw = cfg.field_width > 0.0f ? cfg.field_width : frame_h * 2.0f;
+
+            auto plus = [&](int& v, int max, int step) { v = (v + step) % (max + 1); };
+            auto minus = [&](int& v, int max, int step) {
+                v -= step;
+                if (v < 0) {
+                    v += (max + 1);
+                }
+            };
+
+            ImGui::BeginGroup();
+            ImGui::PushID("plus");
+            if (ImGui::Button("+", ImVec2(fw, 0))) { plus(h, 23, 1); changed = true; }
+            ImGui::SameLine();
+            if (ImGui::Button("+", ImVec2(fw, 0))) { plus(m, 59, 1); changed = true; }
+            ImGui::SameLine();
+            if (ImGui::Button("+", ImVec2(fw, 0))) { plus(s, 59, 1); changed = true; }
+            ImGui::PopID();
+
+            auto centered_text_box = [&](const char* txt) {
+                ImVec2 tsz = ImGui::CalcTextSize(txt);
+                float extra = std::max(0.0f, fw - tsz.x);
+                ImGui::Dummy(ImVec2(extra * 0.5f, 0));
+                ImGui::SameLine(0, 0);
+                ImGui::TextUnformatted(txt);
+                ImGui::SameLine(0, 0);
+                ImGui::Dummy(ImVec2(extra * 0.5f, 0));
+            };
+            {
+                char buf[8];
+                std::snprintf(buf, sizeof(buf), "%02d", h); centered_text_box(buf);
+                ImGui::SameLine(); ImGui::TextUnformatted(":"); ImGui::SameLine();
+                std::snprintf(buf, sizeof(buf), "%02d", m); centered_text_box(buf);
+                ImGui::SameLine(); ImGui::TextUnformatted(":"); ImGui::SameLine();
+                std::snprintf(buf, sizeof(buf), "%02d", s); centered_text_box(buf);
+            }
+
+            ImGui::PushID("minus");
+            if (ImGui::Button("-", ImVec2(fw, 0))) { minus(h, 23, 1); changed = true; }
+            ImGui::SameLine();
+            if (ImGui::Button("-", ImVec2(fw, 0))) { minus(m, 59, 1); changed = true; }
+            ImGui::SameLine();
+            if (ImGui::Button("-", ImVec2(fw, 0))) { minus(s, 59, 1); changed = true; }
+            ImGui::PopID();
+
+            ImGui::EndGroup();
+
+            if (changed) {
+                int v = h * 3600 + m * 60 + s;
+                v = std::clamp(v, cfg.min_seconds, cfg.max_seconds);
+                if (v != seconds) {
+                    seconds = v;
+                }
+            }
+
+            const ImGuiStyle& st = ImGui::GetStyle();
+            ImVec2 cell = cfg.cell_size;
+            if (cell.x <= 0.0f || cell.y <= 0.0f) {
+                float fh = ImGui::GetFrameHeight();
+                cell = ImVec2(fh * 1.5f, fh * 1.2f);
+            }
+
+            int rows = std::max(1, cfg.rows);
+            int cols = std::max(1, cfg.cols);
+
+            ImGui::Dummy(ImVec2(0.0f, st.ItemSpacing.y * 0.5f));
+            ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
+                                cfg.cell_rounding >= 0.0f ? cfg.cell_rounding : 0.0f);
+
+            int pi = 0;
+            for (int r = 0; r < rows; ++r) {
+                for (int c = 0; c < cols; ++c) {
+                    if (c) {
+                        ImGui::SameLine();
+                    }
+                    ImGui::PushID(r * cols + c);
+                    if (pi < static_cast<int>(presets.size())) {
+                        bool sel = seconds == presets[pi].seconds;
+                        if (ImGui::Selectable(
+                                presets[pi].label,
+                                sel,
+                                ImGuiSelectableFlags_DontClosePopups,
+                                cell)) {
+                            int clamped = std::clamp(
+                                    presets[pi].seconds,
+                                    cfg.min_seconds,
+                                    cfg.max_seconds);
+                            if (seconds != clamped) {
+                                seconds = clamped;
+                                changed = true;
+                            }
+                        }
+                        if (cfg.show_cell_borders) {
+                            ImDrawList* dl = ImGui::GetWindowDrawList();
+                            ImVec2 a = ImGui::GetItemRectMin();
+                            ImVec2 b = ImGui::GetItemRectMax();
+                            a.x = std::floor(a.x) + 0.5f;
+                            a.y = std::floor(a.y) + 0.5f;
+                            b.x = std::floor(b.x) - 0.5f;
+                            b.y = std::floor(b.y) - 0.5f;
+                            ImU32 col = sel
+                                ? ImGui::GetColorU32(ImGuiCol_Header)
+                                : (ImGui::IsItemHovered()
+                                        ? ImGui::GetColorU32(ImGuiCol_HeaderHovered)
+                                        : ImGui::GetColorU32(ImGuiCol_Border));
+                            dl->AddRect(a, b, col, 0.0f, 0, 1.0f);
+                        }
+                        ++pi;
+                    } else {
+                        ImGui::Dummy(cell);
+                    }
+                    ImGui::PopID();
+                }
+            }
+            ImGui::PopStyleVar();
+
+            EndIconCombo();
+        }
+
+        ImGui::PopID();
+        return changed;
+    }
+
+#ifdef IMGUIX_DEMO
+    inline void DemoExpiryPicker() {
+        static int expiry_sec = 5;
+        ExpiryPickerConfig cfg;
+        cfg.label = u8"Expiration";
+        cfg.icon_text = u8"🕒";
+        cfg.combo_width = 180.0f;
+        ExpiryPicker("expiry", expiry_sec, cfg);
+    }
+#endif
+
+} // namespace ImGuiX::Widgets

--- a/tests/test_widgets.cpp
+++ b/tests/test_widgets.cpp
@@ -21,6 +21,7 @@
 #include <imguix/widgets/time/date_picker.hpp>
 #include <imguix/widgets/time/hours_selector.hpp>
 #include <imguix/widgets/time/days_selector.hpp>
+#include <imguix/widgets/time/expiry_picker.hpp>
 
 // === Уведомления ===
 #include <imguix/widgets/notify/notifications.hpp>
@@ -362,6 +363,10 @@ private:
 
         if (ImGui::CollapsingHeader("Date Picker")) {
             ImGuiX::Widgets::DemoDatePicker();
+        }
+
+        if (ImGui::CollapsingHeader("Expiry Picker")) {
+            ImGuiX::Widgets::DemoExpiryPicker();
         }
     }
 


### PR DESCRIPTION
## Summary
- add `ExpiryPicker` widget with presets and H/M/S editing
- expose expiry picker in widgets aggregation and demo
- move `format_hms_u32` to shared time utilities

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*
- `cmake --build build --target test_widgets` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68b748bd3d78832ca4e39181b189cea7