### PR TITLE
fix: force cstdint include for imnodeflow

### DIFF
--- a/cmake/deps/imnodeflow.cmake
+++ b/cmake/deps/imnodeflow.cmake
@@ -17,6 +17,10 @@ function(imguix_use_or_fetch_imnodeflow OUT_VAR)
     add_library(imnodeflow STATIC
         "${_IMNODEFLOW_DIR}/src/ImNodeFlow.cpp"
     )
+    target_compile_options(imnodeflow PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:/FIcstdint>
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-include cstdint>
+    )
     add_library(imnodeflow::imnodeflow ALIAS imnodeflow)
 
     # ImNodeFlow depends only on Dear ImGui


### PR DESCRIPTION
## Summary
- ensure cstdint is included when compiling ImNodeFlow

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ae40fe0832cb44617e362f2eae9