### PR TITLE
Join async thread in Application destructor

### DIFF
--- a/include/imguix/core/application/Application.hpp
+++ b/include/imguix/core/application/Application.hpp
@@ -18,8 +18,8 @@ namespace ImGuiX {
         /// \brief Constructs the application instance.
         Application();
 
-        /// \brief Destructor.
-        ~Application() = default;
+        /// \brief Destructs the application and joins async thread.
+        ~Application();
 
         Application(const Application&) = delete;
         Application& operator=(Application) = delete;

--- a/include/imguix/core/application/Application.ipp
+++ b/include/imguix/core/application/Application.ipp
@@ -39,6 +39,12 @@ namespace ImGuiX {
         });
     }
 
+    Application::~Application() {
+        if (m_main_thread.joinable()) {
+            m_main_thread.join();
+        }
+    }
+
     void Application::run(bool async) {
 #       ifdef IMGUIX_USE_SFML_BACKEND
         if (!registry().registerResource<DeltaClockSfml>()) {


### PR DESCRIPTION
## Summary
- join async main loop thread in Application destructor

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=ON`
- `cmake --build build` *(fails: no match for `operator!=` in imgui-SFML.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68b765c7b978832ca51de04510a0954c