### PR TITLE
fix: remove redundant SDL window pointer

### DIFF
--- a/include/imguix/core/window/WindowInstance.hpp
+++ b/include/imguix/core/window/WindowInstance.hpp
@@ -324,7 +324,6 @@ namespace ImGuiX {
 #elif defined(IMGUIX_USE_SDL2_BACKEND)
         SDL_Window* m_window = nullptr; ///< SDL window handle.
         SDL_GLContext m_gl_context = nullptr; ///< Associated GL context.
-        SDL_Window* m_window = nullptr;
         ImGuiContext* m_imgui_ctx = nullptr;
         const char* selectGlslForSdl(SDL_Window* w) noexcept;
 #endif


### PR DESCRIPTION
## Summary
- clean up duplicate SDL window pointer in WindowInstance

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b79555bb10832c9299bba1b3b5a96e