### PR TITLE
fix: delete GL context before window destruction

### DIFF
--- a/include/imguix/core/window/Sdl2WindowInstance.ipp
+++ b/include/imguix/core/window/Sdl2WindowInstance.ipp
@@ -128,10 +128,10 @@ namespace ImGuiX {
             if (event.type == SDL_QUIT) {
                 Events::WindowClosedEvent evt(id(), name());
                 notify(evt);
-                SDL_DestroyWindow(m_window);
                 SDL_GL_DeleteContext(m_gl_context);
-                m_window = nullptr;
+                SDL_DestroyWindow(m_window);
                 m_gl_context = nullptr;
+                m_window = nullptr;
                 m_is_open = false;
             }
         }
@@ -192,10 +192,10 @@ namespace ImGuiX {
         if (m_window) {
             Events::WindowClosedEvent evt(id(), name());
             notify(evt);
-            SDL_DestroyWindow(m_window);
             SDL_GL_DeleteContext(m_gl_context);
-            m_window = nullptr;
+            SDL_DestroyWindow(m_window);
             m_gl_context = nullptr;
+            m_window = nullptr;
         }
     }
 


### PR DESCRIPTION
## Summary
- fix SDL2 window cleanup order by deleting GL context before destroying the window
- reset GL context and window pointers after cleanup

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b795896204832c925264c38b5f17e6