### PR TITLE
refactor(pubsub): simplify awaiter cleanup

### DIFF
--- a/include/imguix/core/pubsub/EventBus.ipp
+++ b/include/imguix/core/pubsub/EventBus.ipp
@@ -126,9 +126,9 @@ namespace ImGuiX::Pubsub {
             std::lock_guard<std::mutex> lk(m_awaiters_mutex);
             auto& v = m_awaiters;
             v.erase(std::remove_if(v.begin(), v.end(), [](const std::weak_ptr<IAwaiterEx>& w){
-                if (w.expired()) return true;
-                if (auto sp = w.lock()) return !sp->isActive();
-                return true;
+                auto sp = w.lock();
+                if (!sp) return true;
+                return !sp->isActive();
             }), v.end());
             live.reserve(v.size());
             for (auto& w : v) {


### PR DESCRIPTION
## Summary
- simplify EventBus awaiter cleanup by locking each weak pointer once

## Testing
- `g++ -std=c++20 -Iinclude -DIMGUIX_HEADER_ONLY tests/test_event_await.cpp -pthread -o build/test_event_await && ./build/test_event_await`
- `cmake --build build -j2` *(fails: no match for `operator!=` between ImTextureRef and ImTextureID in imgui-SFML.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68b795821ca0832cbcbcf6c137639704