### PR TITLE
fix(pubsub): use event->type in notify

### DIFF
--- a/include/imguix/core/pubsub/EventBus.ipp
+++ b/include/imguix/core/pubsub/EventBus.ipp
@@ -80,7 +80,7 @@ namespace ImGuiX::Pubsub {
     }
 
     inline void EventBus::notify(const Event* const event) const {
-        auto type = std::type_index(typeid(*event));
+        auto type = event->type();
         
         callback_list_t callbacks_copy;
         listener_list_t listeners_copy;


### PR DESCRIPTION
## Summary
- Use event->type() in EventBus::notify instead of RTTI lookup

## Testing
- `g++ -std=c++17 -DIMGUIX_HEADER_ONLY -I include tests/test_event_system.cpp -pthread -o test_event_system`
- `./test_event_system <<'EOF'

EOF`


------
https://chatgpt.com/codex/tasks/task_e_68b7a9b7d684832c84d5a5df7d437df7