### PR TITLE
fix(pubsub): erase empty subscription entries

### DIFF
--- a/include/imguix/core/pubsub/EventBus.ipp
+++ b/include/imguix/core/pubsub/EventBus.ipp
@@ -55,27 +55,45 @@ namespace ImGuiX::Pubsub {
                 [owner](const CallbackRecord& rec) {
                     return rec.owner == owner;
                 }), list.end());
+            if (list.empty()) {
+                m_event_callbacks.erase(it_cb);
+            }
         }
 
         auto it_ls = m_event_listeners.find(type);
         if (it_ls != m_event_listeners.end()) {
             auto& list = it_ls->second;
             list.erase(std::remove(list.begin(), list.end(), owner), list.end());
+            if (list.empty()) {
+                m_event_listeners.erase(it_ls);
+            }
         }
     }
-    
+
     inline void EventBus::unsubscribeAll(EventListener* owner) {
         std::lock_guard<std::mutex> lock(m_subscriptions_mutex);
 
-        for (auto& [type, callback_list] : m_event_callbacks) {
+        for (auto it = m_event_callbacks.begin(); it != m_event_callbacks.end(); ) {
+            auto& callback_list = it->second;
             callback_list.erase(std::remove_if(callback_list.begin(), callback_list.end(),
                 [owner](const CallbackRecord& rec) {
                     return rec.owner == owner;
                 }), callback_list.end());
+            if (callback_list.empty()) {
+                it = m_event_callbacks.erase(it);
+            } else {
+                ++it;
+            }
         }
 
-        for (auto& [type, listener_list] : m_event_listeners) {
+        for (auto it = m_event_listeners.begin(); it != m_event_listeners.end(); ) {
+            auto& listener_list = it->second;
             listener_list.erase(std::remove(listener_list.begin(), listener_list.end(), owner), listener_list.end());
+            if (listener_list.empty()) {
+                it = m_event_listeners.erase(it);
+            } else {
+                ++it;
+            }
         }
     }
 

--- a/tests/test_event_unsubscribe.cpp
+++ b/tests/test_event_unsubscribe.cpp
@@ -1,0 +1,77 @@
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+#include "imguix/core/pubsub/Event.hpp"
+#include "imguix/core/pubsub/EventListener.hpp"
+
+#define private public
+#include "imguix/core/pubsub/EventBus.hpp"
+#undef private
+
+#include "imguix/core/pubsub/EventAwaiter.hpp"
+#include "imguix/core/pubsub/EventMediator.hpp"
+
+using namespace ImGuiX::Pubsub;
+
+struct EvA : Event {
+    std::type_index type() const override { return typeid(EvA); }
+    const char* name() const override { return "EvA"; }
+    std::unique_ptr<Event> clone() const override { return std::make_unique<EvA>(*this); }
+};
+
+struct EvB : Event {
+    std::type_index type() const override { return typeid(EvB); }
+    const char* name() const override { return "EvB"; }
+    std::unique_ptr<Event> clone() const override { return std::make_unique<EvB>(*this); }
+};
+
+int main() {
+    EventBus bus;
+    EventMediator med(bus);
+
+    med.subscribe<EvA>([](const EvA&) {});
+    if (bus.m_event_callbacks.size() != 1) {
+        std::cerr << "callback map not updated\n";
+        return 1;
+    }
+    med.unsubscribe<EvA>();
+    if (!bus.m_event_callbacks.empty()) {
+        std::cerr << "callback map not cleared\n";
+        return 1;
+    }
+
+    med.subscribe<EvA>();
+    if (bus.m_event_listeners.size() != 1) {
+        std::cerr << "listener map not updated\n";
+        return 1;
+    }
+    med.unsubscribe<EvA>();
+    if (!bus.m_event_listeners.empty()) {
+        std::cerr << "listener map not cleared\n";
+        return 1;
+    }
+
+    med.subscribe<EvA>([](const EvA&) {});
+    med.subscribe<EvB>();
+    if (bus.m_event_callbacks.size() != 1 || bus.m_event_listeners.size() != 1) {
+        std::cerr << "maps not updated for multiple events\n";
+        return 1;
+    }
+    med.unsubscribeAll();
+    if (!bus.m_event_callbacks.empty() || !bus.m_event_listeners.empty()) {
+        std::cerr << "maps not cleared after unsubscribeAll\n";
+        return 1;
+    }
+
+    std::cout << "EventBus unsubscribe tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- drop empty callback and listener vectors during unsubscribe operations
- add tests verifying subscription maps shrink after listener removal

## Testing
- `g++ -std=c++20 -DIMGUIX_HEADER_ONLY -I include tests/test_event_unsubscribe.cpp -o tests/test_event_unsubscribe && tests/test_event_unsubscribe`
- `g++ -std=c++20 -DIMGUIX_HEADER_ONLY -I include tests/test_event_cache.cpp -o tests/test_event_cache && tests/test_event_cache`
- `g++ -std=c++20 -DIMGUIX_HEADER_ONLY -I include tests/test_event_system.cpp -o tests/test_event_system && printf '\n' | tests/test_event_system`

------
https://chatgpt.com/codex/tasks/task_e_68b7b0f8c598832c974970dd09caac6c