### PR TITLE
fix: validate Base64 decoding input

### DIFF
--- a/tests/test_base64.cpp
+++ b/tests/test_base64.cpp
@@ -1,6 +1,8 @@
-#include <imguix/utils/base64.hpp>
 #include <iostream>
+#include <stdexcept>
 #include <string>
+
+#include <imguix/utils/base64.hpp>
 
 int main() {
     const std::string original = "hello world";
@@ -12,6 +14,23 @@ int main() {
     }
     if (encoded != "aGVsbG8gd29ybGQ=") {
         std::cerr << "encode mismatch\n";
+        return 1;
+    }
+    auto expect_throw = [](std::string_view input) {
+        try {
+            (void)ImGuiX::Utils::decodeBase64(input);
+        } catch (const std::invalid_argument&) {
+            return true;
+        }
+        return false;
+    };
+
+    if (!expect_throw("abc")) {
+        std::cerr << "abc not rejected\n";
+        return 1;
+    }
+    if (!expect_throw("====a")) {
+        std::cerr << "====a not rejected\n";
         return 1;
     }
     return 0;


### PR DESCRIPTION
## Summary
- tighten Base64 decoder to reject malformed strings
- test Base64 decoder against invalid inputs

## Testing
- `g++ -std=c++20 -Iinclude tests/test_base64.cpp -o test_base64 && ./test_base64`


------
https://chatgpt.com/codex/tasks/task_e_68b7c28affa8832c98c72989095778ec