### PR TITLE
feat: add icon combo defaults for time widgets

### DIFF
--- a/include/imguix/config/icons.hpp
+++ b/include/imguix/config/icons.hpp
@@ -38,4 +38,16 @@
 /// \brief Clipboard paste icon.
 #define IMGUIX_ICON_PASTE u8"\uE2C8"
 
+/// \brief Clock icon used for time pickers.
+#define IMGUIX_ICON_CLOCK u8"\uE8B5"
+
+/// \brief Calendar icon for date pickers.
+#define IMGUIX_ICON_CALENDAR u8"\uE878"
+
+/// \brief Calendar week icon for weekday selectors.
+#define IMGUIX_ICON_CALENDAR_WEEK u8"\uEFE8"
+
+/// \brief Globe icon representing timezone selection.
+#define IMGUIX_ICON_GLOBE u8"\uE80B"
+
 #endif // _IMGUIX_CONFIG_ICONS_HPP_INCLUDED

--- a/include/imguix/widgets/time/date_picker.hpp
+++ b/include/imguix/widgets/time/date_picker.hpp
@@ -14,6 +14,7 @@
 #include <imguix/widgets/input/arrow_stepper.hpp>
 #include <imguix/utils/time_utils.hpp>  // days_from_civil, civil_from_days, num_days_in_month, clamp_ymdhms, month_short_name
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcDateComboWidth(), etc.
+#include <imguix/config/icons.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -28,6 +29,8 @@ namespace ImGuiX::Widgets {
         const char*     label           = u8"Date";      ///< Combo label.
         const char*     desc            = u8"YYYY-MM-DD";///< Format description.
         float           combo_width     = 0.0f;          ///< Width for combo preview.
+        bool            use_icon_combo  = true;          ///< Use BeginIconCombo for combo.
+        const char*     icon_text       = IMGUIX_ICON_CALENDAR; ///< Combo icon glyph.
         bool            show_desc       = true;          ///< Show format description.
         float           field_width     = 0.0f;          ///< Width per ArrowStepper field.
         int             min_year        = 1970;          ///< Inclusive lower year.

--- a/include/imguix/widgets/time/date_picker.ipp
+++ b/include/imguix/widgets/time/date_picker.ipp
@@ -6,6 +6,7 @@
 #include <imguix/widgets/input/arrow_stepper.hpp>
 #include <imguix/utils/time_utils.hpp>  // days_from_civil, civil_from_days, num_days_in_month, clamp_ymdhms, month_short_name
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcDateComboWidth(), etc.
+#include <imguix/widgets/controls/icon_combo.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -37,7 +38,10 @@ namespace ImGuiX::Widgets {
 
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(combo_width);
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Date", preview.c_str())) {
+        bool open = cfg.use_icon_combo ?
+            BeginIconCombo(cfg.label ? cfg.label : u8"Date", preview.c_str(), cfg.icon_text) :
+            ImGui::BeginCombo(cfg.label ? cfg.label : u8"Date", preview.c_str());
+        if (open) {
             if (cfg.show_desc && cfg.desc) ImGui::TextUnformatted(cfg.desc);
 
             // --- direct string edit ------------------------------------------------
@@ -147,7 +151,10 @@ namespace ImGuiX::Widgets {
 
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(combo_width);
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Date", preview.c_str())) {
+        bool open = cfg.use_icon_combo ?
+            BeginIconCombo(cfg.label ? cfg.label : u8"Date", preview.c_str(), cfg.icon_text) :
+            ImGui::BeginCombo(cfg.label ? cfg.label : u8"Date", preview.c_str());
+        if (open) {
             if (cfg.show_desc && cfg.desc)
                 ImGui::TextUnformatted(cfg.desc);
 

--- a/include/imguix/widgets/time/days_selector.hpp
+++ b/include/imguix/widgets/time/days_selector.hpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cmath>
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcWeekdayComboWidth(), etc.
+#include <imguix/config/icons.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -29,6 +30,8 @@ namespace ImGuiX::Widgets {
         const char* label_weekend  = u8"Weekend";          ///< Weekend button label.
 
         float       combo_width = 0.0f;                    ///< SetNextItemWidth for combo preview.
+        bool        use_icon_combo = true;                 ///< Use BeginIconCombo for the combo.
+        const char* icon_text    = IMGUIX_ICON_CALENDAR_WEEK; ///< Combo icon glyph.
         ImVec2      popup_size  = ImVec2(0, 0);            ///< Scroll area size.
         ImVec2      cell_size   = ImVec2(24, 20);          ///< Clickable cell size.
         int         rows        = 1;                       ///< Grid rows.

--- a/include/imguix/widgets/time/days_selector.ipp
+++ b/include/imguix/widgets/time/days_selector.ipp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cmath>
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcWeekdayComboWidth(), etc.
+#include <imguix/widgets/controls/icon_combo.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -94,10 +95,17 @@ namespace ImGuiX::Widgets {
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(combo_width);
         ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, 300.0f));
-        if (ImGui::BeginCombo(
-                cfg.label ? cfg.label : u8"Days", preview.c_str(),
-                ImGuiComboFlags_HeightLargest | ImGuiComboFlags_PopupAlignLeft)
-            ) {
+        bool open = cfg.use_icon_combo ?
+            BeginIconCombo(
+                cfg.label ? cfg.label : u8"Days",
+                preview.c_str(),
+                cfg.icon_text,
+                ImGuiComboFlags_HeightLargest | ImGuiComboFlags_PopupAlignLeft) :
+            ImGui::BeginCombo(
+                cfg.label ? cfg.label : u8"Days",
+                preview.c_str(),
+                ImGuiComboFlags_HeightLargest | ImGuiComboFlags_PopupAlignLeft);
+        if (open) {
             ImGui::Indent(st.FramePadding.x);
 
             // Toolbar

--- a/include/imguix/widgets/time/hours_selector.hpp
+++ b/include/imguix/widgets/time/hours_selector.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcTimeComboWidth(), etc.
+#include <imguix/config/icons.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -27,6 +28,8 @@ namespace ImGuiX::Widgets {
         int         rows         = 3;            ///< Grid rows (rows*cols should cover 24).
         int         cols         = 8;            ///< Grid cols.
         float       combo_width  = 0.0f;         ///< SetNextItemWidth for the combo.
+        bool        use_icon_combo = true;       ///< Use BeginIconCombo instead of ImGui combo.
+        const char* icon_text   = IMGUIX_ICON_CLOCK; ///< Combo icon glyph.
         bool        use_header_color_for_selected = true; ///< Use ImGuiCol_Header for selected bg.
         bool    show_cell_borders   = true;      ///< Draw cell borders.
         float   cell_border_thickness = 1.0f;   ///< Border thickness.

--- a/include/imguix/widgets/time/hours_selector.ipp
+++ b/include/imguix/widgets/time/hours_selector.ipp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcTimeComboWidth(), etc.
+#include <imguix/widgets/controls/icon_combo.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -68,9 +69,17 @@ namespace ImGuiX::Widgets {
         ImGui::PushID(id);
         ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, 300.0f));
         ImGui::SetNextItemWidth(combo_width);
-        if (ImGui::BeginCombo(
-                cfg.label ? cfg.label : u8"Hours", preview.c_str(),
-                ImGuiComboFlags_HeightLargest | ImGuiComboFlags_PopupAlignLeft)) {
+        bool open = cfg.use_icon_combo ?
+            BeginIconCombo(
+                cfg.label ? cfg.label : u8"Hours",
+                preview.c_str(),
+                cfg.icon_text,
+                ImGuiComboFlags_HeightLargest | ImGuiComboFlags_PopupAlignLeft) :
+            ImGui::BeginCombo(
+                cfg.label ? cfg.label : u8"Hours",
+                preview.c_str(),
+                ImGuiComboFlags_HeightLargest | ImGuiComboFlags_PopupAlignLeft);
+        if (open) {
             const ImGuiStyle& st = ImGui::GetStyle();
             ImGui::Indent(st.FramePadding.x);
 

--- a/include/imguix/widgets/time/time_picker.hpp
+++ b/include/imguix/widgets/time/time_picker.hpp
@@ -15,6 +15,7 @@
 #include <imguix/widgets/input/arrow_stepper.hpp>
 #include <imguix/utils/time_utils.hpp>  // ImGuiX::Utils::format_hms, etc.
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcTimeComboWidth(), etc.
+#include <imguix/config/icons.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -25,6 +26,8 @@ namespace ImGuiX::Widgets {
         const char* label       = u8"Time";      ///< Combo label.
         const char* desc        = u8"HH:MM:SS"; ///< Format description.
         float       combo_width = 0.0f;         ///< Width for combo preview.
+        bool        use_icon_combo = true;      ///< Use BeginIconCombo for combo.
+        const char* icon_text = IMGUIX_ICON_CLOCK; ///< Combo icon glyph.
         bool        show_desc   = true;         ///< Show format description.
         float       field_width = 0.0f;         ///< Width per ArrowStepper field.
     };
@@ -46,6 +49,8 @@ namespace ImGuiX::Widgets {
         const char* label        = u8"Offset";     ///< Combo label.
         const char* desc         = u8"±HH:MM:SS"; ///< Format description.
         float       combo_width  = 0.0f;          ///< Width for combo preview.
+        bool        use_icon_combo = true;       ///< Use BeginIconCombo for combo.
+        const char* icon_text    = IMGUIX_ICON_GLOBE; ///< Combo icon glyph.
         bool        show_desc    = true;          ///< Show format description.
         bool        show_gmt     = true;          ///< Show GMT offset.
         bool        show_tz_list = true;          ///< Show timezone list.

--- a/include/imguix/widgets/time/time_picker.ipp
+++ b/include/imguix/widgets/time/time_picker.ipp
@@ -7,6 +7,7 @@
 #include <imguix/widgets/input/arrow_stepper.hpp>
 #include <imguix/utils/time_utils.hpp>  // ImGuiX::Utils::format_hms, etc.
 #include <imguix/extensions/sizing.hpp> // ImGuiX::Extensions::CalcTimeComboWidth(), etc.
+#include <imguix/widgets/controls/icon_combo.hpp>
 
 namespace ImGuiX::Widgets {
 
@@ -108,7 +109,10 @@ namespace ImGuiX::Widgets {
         bool changed = false;
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(combo_width);
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Time", preview.c_str())) {
+        bool open = cfg.use_icon_combo ?
+            BeginIconCombo(cfg.label ? cfg.label : u8"Time", preview.c_str(), cfg.icon_text) :
+            ImGui::BeginCombo(cfg.label ? cfg.label : u8"Time", preview.c_str());
+        if (open) {
             if (cfg.show_desc && cfg.desc)
                 ImGui::TextUnformatted(cfg.desc);
 
@@ -153,7 +157,10 @@ namespace ImGuiX::Widgets {
 
         ImGui::PushID(id);
         ImGui::SetNextItemWidth(combo_width);
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Time", preview.c_str())) {
+        bool open = cfg.use_icon_combo ?
+            BeginIconCombo(cfg.label ? cfg.label : u8"Time", preview.c_str(), cfg.icon_text) :
+            ImGui::BeginCombo(cfg.label ? cfg.label : u8"Time", preview.c_str());
+        if (open) {
             if (cfg.show_desc && cfg.desc) ImGui::TextUnformatted(cfg.desc);
 
             int h, m, s;
@@ -209,7 +216,10 @@ namespace ImGuiX::Widgets {
             ImVec2(0, 0),
             ImVec2(FLT_MAX, ImGui::GetTextLineHeightWithSpacing() * 16) // максимум 16 строк
         );
-        if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Offset", preview.c_str())) {
+        bool open = cfg.use_icon_combo ?
+            BeginIconCombo(cfg.label ? cfg.label : u8"Offset", preview.c_str(), cfg.icon_text) :
+            ImGui::BeginCombo(cfg.label ? cfg.label : u8"Offset", preview.c_str());
+        if (open) {
             if (cfg.show_desc && cfg.desc) ImGui::TextUnformatted(cfg.desc);
 
             // Timezone combo


### PR DESCRIPTION
## Summary
- default icons for date, time, weekday and timezone pickers
- support `BeginIconCombo` in HoursSelector, DaysOfWeekSelector, DatePicker, TimePicker and TimeOffsetPicker

## Testing
- `cmake .. -DIMGUIX_USE_SFML_BACKEND=OFF` *(fails: 'DeltaClockSfml' was not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd3db570832c8728800c6c54c6b5