### PR TITLE
docs(readme): fix mermaid and update related libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ graph TD
     M-->EB
     C-->RR
     M-->RR
-````
+```
 
 ### Event Flow
 
@@ -397,14 +397,23 @@ All fonts are included unmodified. See `THIRD-PARTY-NOTICES.md` for per-family a
 ImGuiX bundles several upstream libraries as git submodules:
 
 - [Dear ImGui](https://github.com/ocornut/imgui) — immediate-mode GUI library we build on.
+- [AESCPP](https://github.com/NewYaroslav/aescpp) — AES encryption routines for C++.
 - [fmt](https://github.com/fmtlib/fmt) — fast, type-safe formatting for modern C++.
 - [FreeType](https://github.com/freetype/freetype) — font rasterization engine used for high-quality text rendering.
 - [GLFW](https://github.com/glfw/glfw) — multi-platform window, context, and input library.
+- [ImCoolBar](https://github.com/NewYaroslav/ImCoolBar) — animated toolbar widget for ImGui.
+- [ImGui Command Palette](https://github.com/pthom/imgui-command-palette) — Sublime/VSCode-style command palette.
 - [ImGui-SFML](https://github.com/SFML/imgui-sfml) — binding that integrates Dear ImGui with SFML.
+- [ImGuiColorTextEdit](https://github.com/NewYaroslav/ImGuiColorTextEdit) — syntax-highlighting text editor for ImGui.
+- [ImGuiFileDialog](https://github.com/aiekick/ImGuiFileDialog) — file selection dialog for ImGui.
+- [imgui_md](https://github.com/NewYaroslav/imgui_md) — Markdown renderer based on MD4C.
 - [ImNodeFlow](https://github.com/Fattorino/ImNodeFlow) — node-based editor & blueprint system for Dear ImGui.
 - [ImPlot](https://github.com/epezent/implot) — immediate-mode plotting for Dear ImGui.
 - [ImPlot3D](https://github.com/brenocq/implot3d) — 3D plotting extension for ImPlot.
+- [ImSpinner](https://github.com/dalerank/imspinner) — spinner widgets for loading and progress indicators.
+- [md4c](https://github.com/mity/md4c) — Markdown parser used by imgui_md.
 - [nlohmann/json](https://github.com/nlohmann/json) — header-only JSON library.
+- [portable-file-dialogs](https://github.com/samhocevar/portable-file-dialogs) — cross-platform native file dialogs.
 - [SFML](https://github.com/SFML/SFML) — Simple and Fast Multimedia Library for graphics, audio, and windowing.
 
 ## License


### PR DESCRIPTION
## Summary
- fix System Overview mermaid diagram in README
- expand Related Projects to mention all bundled libraries

## Testing
- `sudo apt-get install -y build-essential cmake ninja-build pkg-config git libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev mesa-common-dev libasound2-dev libflac-dev libvorbis-dev libogg-dev libsndfile1-dev libopenal-dev libfreetype-dev libudev-dev libdrm-dev` (fails: Unable to locate package libxrandr-dev, libxinerama-dev, libxcursor-dev, libxi-dev, libgl1-mesa-dev, mesa-common-dev, libasound2-dev, libflac-dev, libvorbis-dev, libogg-dev, libsndfile1-dev, libopenal-dev, libudev-dev, libdrm-dev)
- `cmake -S . -B build -G "Ninja" -DIMGUIX_DEPS_MODE=BUNDLED -DIMGUIX_VENDOR_JSON=ON -DIMGUIX_BUILD_TESTS=ON -DBUILD_SHARED_LIBS=OFF -DIMGUIX_BUILD_SHARED=OFF -DIMGUIX_IMGUI_FREETYPE=ON` (fails: Could NOT find X11 (missing: Xrandr Xcursor Xi))
- `cmake --build build` (fails: ninja: error: loading 'build.ninja': No such file or directory)
- `ctest --test-dir build` (fails: No tests were found)


------
https://chatgpt.com/codex/tasks/task_e_68b7e4702af4832c9118610a2cca691e