### PR TITLE
fix(pubsub): include optional header

### DIFF
--- a/include/imguix/core/pubsub/EventMediator.hpp
+++ b/include/imguix/core/pubsub/EventMediator.hpp
@@ -6,6 +6,8 @@
 /// \brief Defines the EventMediator class for managing subscriptions and notifications through EventBus.
 /// \ingroup Core
 
+#include <optional>
+
 namespace ImGuiX::Pubsub {
 
     /// \class EventMediator


### PR DESCRIPTION
## Summary
- add `<optional>` include for EventMediator cache API

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF`
- `cmake --build build --target test_event_unsubscribe`


------
https://chatgpt.com/codex/tasks/task_e_68b7e56e6540832c863371579ca1e682