### PR TITLE
feat(theme): dim modal and nav backgrounds

### DIFF
--- a/include/imguix/themes/CyberY2KTheme.hpp
+++ b/include/imguix/themes/CyberY2KTheme.hpp
@@ -99,6 +99,8 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 DragDropTarget         = ImVec4(0.000f, 0.898f, 1.000f, 0.950f);
         constexpr ImVec4 NavHighlight           = HeaderHovered;
         constexpr ImVec4 NavWindowingHighlight  = ImVec4(0.700f, 0.700f, 0.700f, 0.700f);
+        constexpr ImVec4 NavWindowingDimBg      = ImVec4(0.043f, 0.059f, 0.075f, 0.20f);
+        constexpr ImVec4 ModalWindowDimBg       = ImVec4(0.043f, 0.059f, 0.075f, 0.35f);
     } // namespace CyberY2KConstants
 
     /// \class CyberY2KTheme
@@ -169,7 +171,8 @@ namespace ImGuiX::Themes {
 
             colors[ImGuiCol_NavHighlight]          = NavHighlight;
             colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
-            // Note: NavWindowingDimBg / ModalWindowDimBg left as defaults.
+            colors[ImGuiCol_NavWindowingDimBg]     = NavWindowingDimBg;
+            colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unify sizes/roundings/paddings/borders from config
             applyDefaultImGuiStyle(style);

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -89,6 +89,8 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 DragDropTarget         = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
         constexpr ImVec4 NavHighlight           = HeaderHovered; // as in the original snippet
         constexpr ImVec4 NavWindowingHighlight  = ImVec4(0.70f, 0.70f, 0.70f, 0.70f);
+        constexpr ImVec4 NavWindowingDimBg      = ImVec4(0.86f, 0.86f, 0.86f, 0.20f);
+        constexpr ImVec4 ModalWindowDimBg       = ImVec4(0.86f, 0.86f, 0.86f, 0.35f);
     }
 
     /// \class LightBlueTheme
@@ -159,7 +161,8 @@ namespace ImGuiX::Themes {
 
             colors[ImGuiCol_NavHighlight]          = NavHighlight;
             colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
-            // Note: NavWindowingDimBg / ModalWindowDimBg not set in the original snippet.
+            colors[ImGuiCol_NavWindowingDimBg]     = NavWindowingDimBg;
+            colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unify sizes/roundings/paddings/borders from config
             applyDefaultImGuiStyle(style);

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -88,6 +88,8 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 TextSelectedBg         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
         constexpr ImVec4 NavHighlight           = HeaderHovered;
         constexpr ImVec4 NavWindowingHighlight  = ImVec4(0.70f, 0.70f, 0.70f, 0.70f);
+        constexpr ImVec4 NavWindowingDimBg      = ImVec4(0.94f, 0.94f, 0.94f, 0.20f);
+        constexpr ImVec4 ModalWindowDimBg       = ImVec4(0.94f, 0.94f, 0.94f, 0.35f);
     }
 
     /// \class OSXTheme
@@ -150,6 +152,8 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_TextSelectedBg]        = TextSelectedBg;
             colors[ImGuiCol_NavHighlight]          = NavHighlight;
             colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
+            colors[ImGuiCol_NavWindowingDimBg]     = NavWindowingDimBg;
+            colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unified roundings/paddings/borders from config
             applyDefaultImGuiStyle(style);


### PR DESCRIPTION
## Summary
- add transparent NavWindowingDimBg and ModalWindowDimBg colors to LightBlue theme
- define dim background colors for OSX theme
- extend CyberY2K theme with matching dim overlays

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c1a5f3ac832cb6c8fc7863efb78c