### PR TITLE
feat(theme): align selection colors with accent palette

### DIFF
--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -67,7 +67,7 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 PlotLinesHover  = ImVec4(1.00f, 0.45f, 0.35f, 1.00f);
         constexpr ImVec4 PlotHistogram   = ImVec4(0.95f, 0.77f, 0.16f, 1.00f);
         constexpr ImVec4 PlotHistogramHv = ImVec4(1.00f, 0.86f, 0.28f, 1.00f);
-        constexpr ImVec4 TextSelectedBg  = ImVec4(0.30f, 0.55f, 0.90f, 0.35f);
+        constexpr ImVec4 TextSelectedBg  = AccentSoft;
         constexpr ImVec4 ModalDimBg      = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
         constexpr ImVec4 DragDropTarget  = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
         constexpr ImVec4 NavDimBg        = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);

--- a/include/imguix/widgets/time/days_selector.hpp
+++ b/include/imguix/widgets/time/days_selector.hpp
@@ -36,7 +36,7 @@ namespace ImGuiX::Widgets {
         ImVec2      cell_size   = ImVec2(24, 20);          ///< Clickable cell size.
         int         rows        = 1;                       ///< Grid rows.
         int         cols        = 7;                       ///< Grid cols (rows*cols should cover 7).
-        bool        use_header_color_for_selected = true;  ///< Use theme selection colors.
+        bool        use_header_color_for_selected = true;  ///< Use ImGuiCol_TextSelectedBg for selected bg.
 
         // Quick actions toolbar
         bool        show_toolbar_all_none     = true;      ///< Show All/None buttons.

--- a/include/imguix/widgets/time/days_selector.ipp
+++ b/include/imguix/widgets/time/days_selector.ipp
@@ -149,17 +149,15 @@ namespace ImGuiX::Widgets {
 
                     bool selected = mark[idx];
                     if (selected && cfg.use_header_color_for_selected) {
-                        ImGui::PushStyleColor(ImGuiCol_Header,
-                            ImGui::GetStyleColorVec4(ImGuiCol_TextSelectedBg));
+                        const ImVec4 sel = ImGui::GetStyleColorVec4(ImGuiCol_TextSelectedBg);
+                        ImGui::PushStyleColor(ImGuiCol_Header, sel);
+                        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, sel);
+                        ImGui::PushStyleColor(ImGuiCol_HeaderActive, sel);
                     }
 
                     if (ImGui::Selectable(txt, selected, ImGuiSelectableFlags_DontClosePopups, cell)) {
                         mark[idx] = !selected;
                         changed = true;
-                    }
-
-                    if (selected && cfg.use_header_color_for_selected) {
-                        ImGui::PopStyleColor();
                     }
 
                     if (cfg.show_cell_borders) {
@@ -174,11 +172,15 @@ namespace ImGuiX::Widgets {
                             selected ? (cfg.cell_border_color_selected ? cfg.cell_border_color_selected
                                                                        : ImGui::GetColorU32(ImGuiCol_Header)) :
                             (ImGui::IsItemHovered() ? (cfg.cell_border_color_hovered ? cfg.cell_border_color_hovered
-                                                                                      : ImGui::GetColorU32(ImGuiCol_HeaderHovered))
+                                                                                       : ImGui::GetColorU32(ImGuiCol_HeaderHovered))
                                                     : (cfg.cell_border_color ? cfg.cell_border_color
                                                                              : ImGui::GetColorU32(ImGuiCol_Border)));
 
                         dl->AddRect(p0, p1, col, rounding, 0, cfg.cell_border_thickness);
+                    }
+
+                    if (selected && cfg.use_header_color_for_selected) {
+                        ImGui::PopStyleColor(3);
                     }
 
                     ImGui::PopID();


### PR DESCRIPTION
## Summary
- set SlateDark theme's TextSelectedBg to AccentSoft
- ensure Days selector uses TextSelectedBg across states
- clarify days selector config docs

## Testing
- `cmake -S . -B build` *(fails: SFML missing components)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c1a06390832c937db918901b99ce