### PR TITLE
fix: correct SlateDark header guard name

### DIFF
--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef _IMGUIX_THEMES_STALE_DARK_THEME_HPP_INCLUDED
-#define _IMGUIX_THEMES_STALE_DARK_THEME_HPP_INCLUDED
+#ifndef _IMGUIX_THEMES_SLATE_DARK_THEME_HPP_INCLUDED
+#define _IMGUIX_THEMES_SLATE_DARK_THEME_HPP_INCLUDED
 
 /// \file SlateDarkTheme.hpp
 /// \brief Extra themes (SlateDark) implemented in the same pattern as CorporateGreyTheme.
@@ -212,4 +212,4 @@ namespace ImGuiX::Themes {
 
 } // namespace ImGuiX::Themes
 
-#endif // _IMGUIX_THEMES_STALE_DARK_THEME_HPP_INCLUDED
+#endif // _IMGUIX_THEMES_SLATE_DARK_THEME_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- fix SlateDark theme header guard name

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF -DIMGUIX_BUILD_EXAMPLES=OFF`
- `cmake --build build` *(fails: DeltaClockSfml not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c1974868832c97e5ded9f58c3e89