### PR TITLE
feat(theme): set text cursor colors

### DIFF
--- a/docs/THEMES-RU.md
+++ b/docs/THEMES-RU.md
@@ -46,6 +46,7 @@ public:
         ImGuiX::Themes::applyDefaultImGuiStyle(style);
         style.Colors[ImGuiCol_Text] = ImVec4(1.0f, 0.8f, 0.2f, 1.0f);
         // настройте остальные цвета...
+        style.Colors[ImGuiCol_TextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // цвет курсора
     }
 };
 ```
@@ -59,6 +60,8 @@ tm.setTheme("my-theme");
 // вызывать каждый кадр, чтобы применить при изменении
 tm.updateCurrentTheme();
 ```
+
+Все встроенные темы задают полный набор цветов `ImGuiCol_*`.
 
 ## Применение тем
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -46,6 +46,7 @@ public:
         ImGuiX::Themes::applyDefaultImGuiStyle(style);
         style.Colors[ImGuiCol_Text] = ImVec4(1.0f, 0.8f, 0.2f, 1.0f);
         // set other colors...
+        style.Colors[ImGuiCol_TextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // cursor color
     }
 };
 ```
@@ -59,6 +60,8 @@ tm.setTheme("my-theme");
 // call every frame to apply when changed
 tm.updateCurrentTheme();
 ```
+
+All built-in themes define the full set of `ImGuiCol_*` colors.
 
 ## Applying themes
 

--- a/include/imguix/themes/CorporateGreyTheme.hpp
+++ b/include/imguix/themes/CorporateGreyTheme.hpp
@@ -57,6 +57,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                   = White;
+            colors[ImGuiCol_TextCursor]             = Highlight;
             colors[ImGuiCol_TextDisabled]           = TextDisabled;
             colors[ImGuiCol_WindowBg]               = DarkGrey25;
             colors[ImGuiCol_ChildBg]                = DarkGrey25;

--- a/include/imguix/themes/CyberY2KTheme.hpp
+++ b/include/imguix/themes/CyberY2KTheme.hpp
@@ -110,6 +110,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = Cyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/CyberpunkUITheme.hpp
+++ b/include/imguix/themes/CyberpunkUITheme.hpp
@@ -107,6 +107,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = Cyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -109,6 +109,7 @@ namespace ImGuiX::Themes {
             // ImGui::StyleColorsDark(&style);
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = SliderGrabActive;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_WindowBg]              = WindowBg;
             colors[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -105,6 +105,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = AccentBlue;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -111,6 +111,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = AccentBase;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -111,6 +111,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = CheckMark;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/GoldBlackTheme.hpp
+++ b/include/imguix/themes/GoldBlackTheme.hpp
@@ -106,6 +106,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = GoldBright;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -112,6 +112,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = AccentCyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -100,6 +100,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -100,6 +100,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/NightOwlTheme.hpp
+++ b/include/imguix/themes/NightOwlTheme.hpp
@@ -125,6 +125,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = AccentPrimary;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/NordTheme.hpp
+++ b/include/imguix/themes/NordTheme.hpp
@@ -125,6 +125,7 @@ public:
         ImVec4* c = style.Colors;
 
         c[ImGuiCol_Text]                  = Text;
+        c[ImGuiCol_TextCursor]            = AccentPrimary;
         c[ImGuiCol_TextDisabled]          = TextDisabled;
 
         c[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -99,6 +99,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/PearlLightTheme.hpp
+++ b/include/imguix/themes/PearlLightTheme.hpp
@@ -83,6 +83,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_WindowBg]              = WindowBg;
             colors[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -83,6 +83,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = AccentBase;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_WindowBg]              = WindowBg;
             colors[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/TokyoNightStormTheme.hpp
+++ b/include/imguix/themes/TokyoNightStormTheme.hpp
@@ -120,6 +120,7 @@ public:
         ImVec4* c = style.Colors;
 
         c[ImGuiCol_Text]                  = Text;
+        c[ImGuiCol_TextCursor]            = AccentCyan;
         c[ImGuiCol_TextDisabled]          = TextDisabled;
         c[ImGuiCol_WindowBg]              = WindowBg;
         c[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/TokyoNightTheme.hpp
+++ b/include/imguix/themes/TokyoNightTheme.hpp
@@ -127,6 +127,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = AccentCyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -91,6 +91,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = PanelActive;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_TextSelectedBg]        = TextSelectedBg;
 

--- a/include/imguix/themes/Y2KTheme.hpp
+++ b/include/imguix/themes/Y2KTheme.hpp
@@ -125,6 +125,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
+            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;


### PR DESCRIPTION
## Summary
- add `ImGuiCol_TextCursor` to every built-in theme with contrast-aware colors
- document that built-in themes define the full set of `ImGuiCol_*` colors

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bbd42c14832cbd9a24f43f6d91e7