### PR TITLE
fix(themes): update cursor color enum for ImGui 1.92

### DIFF
--- a/docs/THEMES-RU.md
+++ b/docs/THEMES-RU.md
@@ -46,7 +46,7 @@ public:
         ImGuiX::Themes::applyDefaultImGuiStyle(style);
         style.Colors[ImGuiCol_Text] = ImVec4(1.0f, 0.8f, 0.2f, 1.0f);
         // настройте остальные цвета...
-        style.Colors[ImGuiCol_TextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // цвет курсора
+        style.Colors[ImGuiCol_InputTextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // цвет курсора
     }
 };
 ```

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -46,7 +46,7 @@ public:
         ImGuiX::Themes::applyDefaultImGuiStyle(style);
         style.Colors[ImGuiCol_Text] = ImVec4(1.0f, 0.8f, 0.2f, 1.0f);
         // set other colors...
-        style.Colors[ImGuiCol_TextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // cursor color
+        style.Colors[ImGuiCol_InputTextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // cursor color
     }
 };
 ```

--- a/include/imguix/themes/CorporateGreyTheme.hpp
+++ b/include/imguix/themes/CorporateGreyTheme.hpp
@@ -57,7 +57,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                   = White;
-            colors[ImGuiCol_TextCursor]             = Highlight;
+            colors[ImGuiCol_InputTextCursor]             = Highlight;
             colors[ImGuiCol_TextDisabled]           = TextDisabled;
             colors[ImGuiCol_WindowBg]               = DarkGrey25;
             colors[ImGuiCol_ChildBg]                = DarkGrey25;

--- a/include/imguix/themes/CyberY2KTheme.hpp
+++ b/include/imguix/themes/CyberY2KTheme.hpp
@@ -111,7 +111,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = Cyan;
+            colors[ImGuiCol_InputTextCursor]            = Cyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/CyberpunkUITheme.hpp
+++ b/include/imguix/themes/CyberpunkUITheme.hpp
@@ -107,7 +107,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = Cyan;
+            colors[ImGuiCol_InputTextCursor]            = Cyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -109,7 +109,7 @@ namespace ImGuiX::Themes {
             // ImGui::StyleColorsDark(&style);
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = SliderGrabActive;
+            colors[ImGuiCol_InputTextCursor]            = SliderGrabActive;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_WindowBg]              = WindowBg;
             colors[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -105,7 +105,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = AccentBlue;
+            colors[ImGuiCol_InputTextCursor]            = AccentBlue;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -111,7 +111,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = AccentBase;
+            colors[ImGuiCol_InputTextCursor]            = AccentBase;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -111,7 +111,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = CheckMark;
+            colors[ImGuiCol_InputTextCursor]            = CheckMark;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/GoldBlackTheme.hpp
+++ b/include/imguix/themes/GoldBlackTheme.hpp
@@ -106,7 +106,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = GoldBright;
+            colors[ImGuiCol_InputTextCursor]            = GoldBright;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -112,7 +112,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = AccentCyan;
+            colors[ImGuiCol_InputTextCursor]            = AccentCyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -102,7 +102,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+            colors[ImGuiCol_InputTextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -100,7 +100,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+            colors[ImGuiCol_InputTextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/NightOwlTheme.hpp
+++ b/include/imguix/themes/NightOwlTheme.hpp
@@ -125,7 +125,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = AccentPrimary;
+            colors[ImGuiCol_InputTextCursor]            = AccentPrimary;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/NordTheme.hpp
+++ b/include/imguix/themes/NordTheme.hpp
@@ -125,7 +125,7 @@ public:
         ImVec4* c = style.Colors;
 
         c[ImGuiCol_Text]                  = Text;
-        c[ImGuiCol_TextCursor]            = AccentPrimary;
+        c[ImGuiCol_InputTextCursor]            = AccentPrimary;
         c[ImGuiCol_TextDisabled]          = TextDisabled;
 
         c[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -101,7 +101,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+            colors[ImGuiCol_InputTextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/PearlLightTheme.hpp
+++ b/include/imguix/themes/PearlLightTheme.hpp
@@ -83,7 +83,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+            colors[ImGuiCol_InputTextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_WindowBg]              = WindowBg;
             colors[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -83,7 +83,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = AccentBase;
+            colors[ImGuiCol_InputTextCursor]            = AccentBase;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_WindowBg]              = WindowBg;
             colors[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/TokyoNightStormTheme.hpp
+++ b/include/imguix/themes/TokyoNightStormTheme.hpp
@@ -120,7 +120,7 @@ public:
         ImVec4* c = style.Colors;
 
         c[ImGuiCol_Text]                  = Text;
-        c[ImGuiCol_TextCursor]            = AccentCyan;
+        c[ImGuiCol_InputTextCursor]            = AccentCyan;
         c[ImGuiCol_TextDisabled]          = TextDisabled;
         c[ImGuiCol_WindowBg]              = WindowBg;
         c[ImGuiCol_ChildBg]               = ChildBg;

--- a/include/imguix/themes/TokyoNightTheme.hpp
+++ b/include/imguix/themes/TokyoNightTheme.hpp
@@ -127,7 +127,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = AccentCyan;
+            colors[ImGuiCol_InputTextCursor]            = AccentCyan;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;

--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -91,7 +91,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = PanelActive;
+            colors[ImGuiCol_InputTextCursor]            = PanelActive;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_TextSelectedBg]        = TextSelectedBg;
 

--- a/include/imguix/themes/Y2KTheme.hpp
+++ b/include/imguix/themes/Y2KTheme.hpp
@@ -125,7 +125,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_TextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+            colors[ImGuiCol_InputTextCursor]            = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;


### PR DESCRIPTION
## Summary
- replace deprecated `ImGuiCol_TextCursor` with `ImGuiCol_InputTextCursor`
- adjust theme docs for new cursor color enum

## Testing
- `cmake --build build -j 2` *(fails: `DeltaClockSfml` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ca47250c832ca738b68c706f5c8a