### PR TITLE
fix(theme): lighten LightGreen tab hover color

### DIFF
--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -73,7 +73,7 @@ namespace ImGuiX::Themes {
 
         // Tabs
         constexpr ImVec4 Tab                    = ImVec4(0.71f, 0.78f, 0.69f, 0.80f);
-        constexpr ImVec4 TabHovered             = ImVec4(0.71f, 0.78f, 0.69f, 0.80f); // close to HeaderHovered
+        constexpr ImVec4 TabHovered             = ImVec4(0.76f, 0.83f, 0.74f, 0.90f); // slightly lighter when hovered
         constexpr ImVec4 TabActive              = ImVec4(0.71f, 0.78f, 0.69f, 1.00f);
         constexpr ImVec4 TabUnfocused           = ImVec4(0.18f, 0.18f, 0.18f, 1.00f);
         constexpr ImVec4 TabUnfocusedActive     = ImVec4(0.36f, 0.36f, 0.36f, 0.54f);


### PR DESCRIPTION
## Summary
- tweak LightGreen theme tab hover color for better contrast

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68b8cb546870832cb47a15713e8a6ada