### PR TITLE
feat(theme): expand Visual Studio dark palette

### DIFF
--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -49,7 +49,7 @@ namespace ImGuiX::Themes {
         // Buttons / headers / separators
         constexpr ImVec4 Button             = Panel;
         constexpr ImVec4 ButtonHovered      = PanelHover;
-        constexpr ImVec4 ButtonActive       = PanelHover;
+        constexpr ImVec4 ButtonActive       = PanelActive;
 
         constexpr ImVec4 Header             = Panel;
         constexpr ImVec4 HeaderHovered      = PanelHover;
@@ -72,8 +72,11 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 ResizeGripActive   = LightBg;
 
         constexpr ImVec4 TextSelectedBg     = PanelActive;
-        constexpr ImVec4 DragDropTarget     = Bg;
+        constexpr ImVec4 DragDropTarget     = PanelActive;
         constexpr ImVec4 NavHighlight       = Bg;
+        constexpr ImVec4 NavWindowingHighlight = ImVec4(PanelActive.x, PanelActive.y, PanelActive.z, 0.70f);
+        constexpr ImVec4 NavWindowingDimBg  = ImVec4(0.000f, 0.000f, 0.000f, 0.30f);
+        constexpr ImVec4 ModalWindowDimBg   = ImVec4(0.000f, 0.000f, 0.000f, 0.45f);
 
         // Plots
         constexpr ImVec4 PlotLines          = PanelActive;
@@ -144,6 +147,9 @@ namespace ImGuiX::Themes {
 
             colors[ImGuiCol_DragDropTarget]        = DragDropTarget;
             colors[ImGuiCol_NavHighlight]          = NavHighlight;
+            colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
+            colors[ImGuiCol_NavWindowingDimBg]     = NavWindowingDimBg;
+            colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             colors[ImGuiCol_Tab]                   = Tab;
             colors[ImGuiCol_TabHovered]            = TabHovered;


### PR DESCRIPTION
## Summary
- refine Visual Studio dark theme with distinct button active color and bright drag-drop target
- add navigation windowing and modal dimming colors

## Testing
- `git submodule update --init --recursive`
- `sudo apt-get install -y build-essential cmake ninja-build pkg-config git libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev mesa-common-dev libasound2-dev libflac-dev libvorbis-dev libogg-dev libsndfile1-dev libopenal-dev libfreetype-dev libudev-dev libdrm-dev`
- `cmake -S . -B build -G "Ninja" -DIMGUIX_DEPS_MODE=BUNDLED -DIMGUIX_VENDOR_JSON=ON -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_BUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DIMGUIX_BUILD_SHARED=OFF -DIMGUIX_IMGUI_FREETYPE=ON`
- `cmake --build build` *(fails: no match for operator!= in imgui-SFML.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cb5ca280832c8b75179a20601cac