### PR TITLE
fix: add dimming background colors for themes

### DIFF
--- a/include/imguix/themes/CyberpunkUITheme.hpp
+++ b/include/imguix/themes/CyberpunkUITheme.hpp
@@ -167,6 +167,9 @@ namespace ImGuiX::Themes {
 
             colors[ImGuiCol_NavHighlight]          = NavHighlight;
             colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
+            colors[ImGuiCol_NavWindowingDimBg]     = ImVec4(0.00f, 0.00f, 0.00f, 0.30f);
+            colors[ImGuiCol_ModalWindowDimBg]      = ImVec4(0.00f, 0.00f, 0.00f, 0.40f);
+            // Dimming overlays for windowing and modals.
 
             // Baseline sizes/roundings from config
             applyDefaultImGuiStyle(style);

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -160,7 +160,9 @@ namespace ImGuiX::Themes {
 
             colors[ImGuiCol_NavHighlight]          = NavHighlight;
             colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
-            // Note: NavWindowingDimBg / ModalWindowDimBg not set in the original snippet.
+            colors[ImGuiCol_NavWindowingDimBg]     = ImVec4(0.00f, 0.00f, 0.00f, 0.20f);
+            colors[ImGuiCol_ModalWindowDimBg]      = ImVec4(0.00f, 0.00f, 0.00f, 0.35f);
+            // Subtle dimming overlays for windowing and modals.
 
             // Unify sizes/roundings/paddings/borders from config
             applyDefaultImGuiStyle(style);


### PR DESCRIPTION
## Summary
- provide dim overlays for windowing and modals in LightGreenTheme
- add matching dim overlays in CyberpunkUITheme

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_EXAMPLES=OFF`
- `cmake --build build` *(fails: no match for operator!= in imgui-SFML.cpp)*
- `ctest --test-dir build` *(fails: executables not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cb55b210832c90f2897105a8060f