### PR TITLE
fix(theme): neutral cursor for Dark Charcoal

### DIFF
--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -53,6 +53,9 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 SliderGrab           = ImVec4(0.391f, 0.391f, 0.391f, 1.000f);
         constexpr ImVec4 SliderGrabActive     = ImVec4(1.000f, 0.391f, 0.000f, 1.000f); // orange accent
 
+        // Cursor
+        constexpr ImVec4 InputTextCursor      = ImVec4(1.000f, 1.000f, 1.000f, 1.000f);
+
         // Buttons
         constexpr ImVec4 Button               = ImVec4(1.000f, 1.000f, 1.000f, 0.000f);
         constexpr ImVec4 ButtonHovered        = ImVec4(1.000f, 1.000f, 1.000f, 0.156f);
@@ -109,7 +112,7 @@ namespace ImGuiX::Themes {
             // ImGui::StyleColorsDark(&style);
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_InputTextCursor]            = SliderGrabActive;
+            colors[ImGuiCol_InputTextCursor]            = InputTextCursor;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
             colors[ImGuiCol_WindowBg]              = WindowBg;
             colors[ImGuiCol_ChildBg]               = ChildBg;


### PR DESCRIPTION
## Summary
- switch Dark Charcoal input cursor to a neutral tone
- introduce explicit InputTextCursor color constant

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d438ccf0832c969195deeb21c762