### PR TITLE
fix(theme): align DarkGraphite selection colors with cyan base

### DIFF
--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -88,9 +88,9 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 PlotHistogramHovered  = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
 
         // Misc / Navigation
-        constexpr ImVec4 TextSelectedBg        = AccentBlueSoft;
+        constexpr ImVec4 TextSelectedBg        = CyanBase;
         constexpr ImVec4 DragDropTarget        = CyanBase;
-        constexpr ImVec4 NavHighlight          = AccentBlue;
+        constexpr ImVec4 NavHighlight          = CyanBase;
         constexpr ImVec4 NavWindowingHighlight = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
         constexpr ImVec4 NavWindowingDimBg     = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
         constexpr ImVec4 ModalWindowDimBg      = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
@@ -105,7 +105,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_InputTextCursor]            = AccentBlue;
+            colors[ImGuiCol_InputTextCursor]            = CyanBase;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;


### PR DESCRIPTION
## Summary
- use CyanBase for TextSelectedBg and NavHighlight in DarkGraphiteTheme
- switch InputTextCursor color to CyanBase for consistency

## Testing
- `cmake -S . -B build -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF -DIMGUIX_BUILD_EXAMPLES=OFF` *(fails: Cannot find source file /workspace/ImGuiX/libs/imgui/imgui.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d43260f4832c9f5c97b9b6aa4cb6