### PR TITLE
fix(theme): soften DarkTeal input cursor color

### DIFF
--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -61,6 +61,9 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 SliderGrab            = ImVec4(0.28f, 0.56f, 1.00f, 1.00f);
         constexpr ImVec4 SliderGrabActive      = ImVec4(0.37f, 0.61f, 1.00f, 1.00f);
 
+        // Input cursor
+        constexpr ImVec4 InputCursor           = ImVec4(0.55f, 0.65f, 0.70f, 1.00f);
+
         // Buttons / Headers
         constexpr ImVec4 Button                = ImVec4(0.20f, 0.25f, 0.29f, 1.00f);
         constexpr ImVec4 ButtonHovered         = ImVec4(0.28f, 0.56f, 1.00f, 1.00f);
@@ -111,7 +114,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_InputTextCursor]            = AccentBase;
+            colors[ImGuiCol_InputTextCursor]            = InputCursor;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;


### PR DESCRIPTION
## Summary
- soften InputText cursor for DarkTeal theme

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF -DIMGUIX_IMGUI_FREETYPE=OFF -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_IMGUI_STDLIB=ON`
- `cmake --build build -j$(nproc)` *(fails: imgui_stdlib.h not found, DeltaClockSfml missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d42b91d4832c84942ffb45c92f4d