### PR TITLE
feat(theme): refine DeepDarkTheme accents

### DIFF
--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -28,7 +28,7 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 PopupBg                = ImVec4(0.19f, 0.19f, 0.19f, 0.92f);
 
         // Borders
-        constexpr ImVec4 Border                 = ImVec4(0.19f, 0.19f, 0.19f, 0.29f);
+        constexpr ImVec4 Border                 = ImVec4(0.33f, 0.33f, 0.33f, 0.60f);
         constexpr ImVec4 BorderShadow           = ImVec4(0.00f, 0.00f, 0.00f, 0.24f);
 
         // Frames
@@ -93,8 +93,9 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 PlotHistogramHovered   = ImVec4(1.00f, 0.00f, 0.00f, 1.00f);
 
         // Misc / Navigation
-        constexpr ImVec4 TextSelectedBg         = ImVec4(0.20f, 0.22f, 0.23f, 1.00f);
-        constexpr ImVec4 DragDropTarget         = ImVec4(0.33f, 0.67f, 0.86f, 1.00f);
+        constexpr ImVec4 TextSelectedBg         = CheckMark;
+        constexpr ImVec4 InputTextCursor        = ImVec4(0.80f, 0.80f, 0.80f, 1.00f);
+        constexpr ImVec4 DragDropTarget         = CheckMark;
 
         constexpr ImVec4 NavHighlight           = ImVec4(1.00f, 0.00f, 0.00f, 1.00f);
         constexpr ImVec4 NavWindowingHighlight  = ImVec4(1.00f, 0.00f, 0.00f, 0.70f);
@@ -111,7 +112,7 @@ namespace ImGuiX::Themes {
             ImVec4* colors = style.Colors;
 
             colors[ImGuiCol_Text]                  = Text;
-            colors[ImGuiCol_InputTextCursor]            = CheckMark;
+            colors[ImGuiCol_InputTextCursor]       = InputTextCursor;
             colors[ImGuiCol_TextDisabled]          = TextDisabled;
 
             colors[ImGuiCol_WindowBg]              = WindowBg;


### PR DESCRIPTION
## Summary
- lighten borders for clearer separation
- use cyan accent for selected text
- switch input cursor to neutral gray

## Testing
- `git submodule update --init --recursive`
- `apt-get install -y build-essential cmake ninja-build pkg-config git libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev mesa-common-dev libasound2-dev libflac-dev libvorbis-dev libogg-dev libsndfile1-dev libopenal-dev libfreetype-dev libudev-dev libdrm-dev`
- `cmake -S . -B build -G "Ninja" -DIMGUIX_DEPS_MODE=BUNDLED -DIMGUIX_VENDOR_JSON=ON -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_BUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DIMGUIX_BUILD_SHARED=OFF -DIMGUIX_IMGUI_FREETYPE=ON`
- `cmake --build build` *(fails: ImGui-SFML.cpp compile error)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d4237720832c81208c79922e01c1