### PR TITLE
fix(theme): use accent colors for selection and navigation highlight

### DIFF
--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -94,10 +94,7 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 CheckMark              = ImVec4(0.13f, 0.75f, 0.55f, 0.80f);
         constexpr ImVec4 SliderGrab             = ImVec4(0.13f, 0.75f, 0.75f, 0.80f);
         constexpr ImVec4 SliderGrabActive       = ImVec4(0.13f, 0.75f, 1.00f, 0.80f);
-
-        constexpr ImVec4 TextSelectedBg         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
         constexpr ImVec4 DragDropTarget         = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
-        constexpr ImVec4 NavHighlight           = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
         constexpr ImVec4 NavWindowingHighlight  = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
         constexpr ImVec4 NavWindowingDimBg      = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
         constexpr ImVec4 ModalWindowDimBg       = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
@@ -176,10 +173,10 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_PlotHistogramHovered]  = PlotHistogramHovered;
 
             // Misc / Navigation
-            colors[ImGuiCol_TextSelectedBg]        = TextSelectedBg;
+            colors[ImGuiCol_TextSelectedBg]        = AccentTeal;
             colors[ImGuiCol_DragDropTarget]        = DragDropTarget;
 
-            colors[ImGuiCol_NavHighlight]          = NavHighlight;
+            colors[ImGuiCol_NavHighlight]          = AccentCyan;
             colors[ImGuiCol_NavWindowingHighlight] = NavWindowingHighlight;
             colors[ImGuiCol_NavWindowingDimBg]     = NavWindowingDimBg;
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;


### PR DESCRIPTION
## Summary
- use AccentTeal for text selection background
- use AccentCyan for navigation highlight

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=ON -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF` *(fails: Target "demo_i18n_test" links to: imgui::imgui)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d41e6cfc832cac7ecd4b9784f033