### PR TITLE
fix(theme): raise border opacity and set selector border color

### DIFF
--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -28,7 +28,7 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 PopupBg                = ImVec4(0.93f, 0.93f, 0.93f, 0.98f);
 
         // Borders
-        constexpr ImVec4 Border                 = ImVec4(0.71f, 0.71f, 0.71f, 0.08f);
+        constexpr ImVec4 Border                 = ImVec4(0.71f, 0.71f, 0.71f, 0.40f);
         constexpr ImVec4 BorderShadow           = ImVec4(0.00f, 0.00f, 0.00f, 0.04f);
 
         // Frames

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -28,7 +28,7 @@ namespace ImGuiX::Themes {
         constexpr ImVec4 PopupBg                = ImVec4(0.93f, 0.93f, 0.93f, 0.98f);
 
         // Borders
-        constexpr ImVec4 Border                 = ImVec4(0.71f, 0.71f, 0.71f, 0.08f);
+        constexpr ImVec4 Border                 = ImVec4(0.71f, 0.71f, 0.71f, 0.40f);
         constexpr ImVec4 BorderShadow           = ImVec4(0.00f, 0.00f, 0.00f, 0.04f);
 
         // Frames

--- a/include/imguix/widgets/time/days_selector.hpp
+++ b/include/imguix/widgets/time/days_selector.hpp
@@ -45,7 +45,7 @@ namespace ImGuiX::Widgets {
         // Cell borders (like HoursSelector)
         bool    show_cell_borders        = true;           ///< Draw cell borders.
         float   cell_border_thickness    = 1.0f;           ///< Border thickness.
-        ImU32   cell_border_color        = 0;              ///< 0 -> ImGuiCol_Border.
+        ImU32   cell_border_color        = ImGui::GetColorU32(ImGuiCol_Separator); ///< Cell border color (default ImGuiCol_Separator).
         ImU32   cell_border_color_hovered = 0;             ///< 0 -> ImGuiCol_HeaderHovered.
         ImU32   cell_border_color_selected =0;             ///< 0 -> ImGuiCol_Header.
         float   cell_rounding            = 0.0f;           ///< <0 -> use style.FrameRounding.

--- a/include/imguix/widgets/time/hours_selector.hpp
+++ b/include/imguix/widgets/time/hours_selector.hpp
@@ -33,7 +33,7 @@ namespace ImGuiX::Widgets {
         bool        use_header_color_for_selected = true; ///< Use ImGuiCol_Header for selected bg.
         bool    show_cell_borders   = true;      ///< Draw cell borders.
         float   cell_border_thickness = 1.0f;   ///< Border thickness.
-        ImU32   cell_border_color   = 0;        ///< 0 -> ImGuiCol_Border.
+        ImU32   cell_border_color   = ImGui::GetColorU32(ImGuiCol_Separator); ///< Cell border color (default ImGuiCol_Separator).
         ImU32   cell_border_color_hovered = 0;   ///< 0 -> ImGuiCol_HeaderHovered.
         ImU32   cell_border_color_selected = 0;  ///< 0 -> ImGuiCol_Header.
         float   cell_rounding = 0.0f;            ///< Cell rounding radius.


### PR DESCRIPTION
## Summary
- darken border color for LightGreen and LightBlue themes
- default DaysOfWeekSelector and HoursSelector borders to ImGuiCol_Separator

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json: no system package and no submodule at libs/json)*
- `cmake --build build` *(fails: Makefile: No such file or directory)*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d40b226c832ca3a3b4fc30883c20