### PR TITLE
fix: avoid GetColorU32 in config defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,7 @@ if (ImGui::BeginCombo(cfg.label ? cfg.label : u8"Days", preview.c_str(),
 | Content sticks to popup edges | No inner padding | Inside popup: `Indent(style.FramePadding.x)` on the left and `SameLine(0,0); Dummy({style.FramePadding.x,0})` on the right; then `Unindent` |
 | Popup closes when clicking a cell | `Selectable` missing flag | Use `ImGuiSelectableFlags_DontClosePopups` for multi-select |
 | Hardcoded width factors | `GetWindowWidth()*k` | Use `SetNextItemWidth(Calc*ComboWidth)`/`CalcItemWidth()` |
+| Crash before window created | Config default calls `ImGui::GetColorU32` | Store `0`/`IM_COL32` in config and convert at draw-time |
 
 Quick grep patterns:
 

--- a/docs/THEMES-RU.md
+++ b/docs/THEMES-RU.md
@@ -38,6 +38,8 @@ English version: [THEMES.md](THEMES.md).
 
 Реализуйте интерфейс `ImGuiX::Themes::Theme` и переопределите методы `apply`.
 Используйте `applyDefaultImGuiStyle`, чтобы задать общие значения отступов и скруглений.
+Не вызывайте `ImGui::GetColorU32` вне активного контекста ImGui.
+В конфигурациях храните «сырые» значения `ImVec4` или `ImU32` и переводите их в цвета при отрисовке.
 
 ```cpp
 class MyTheme final : public ImGuiX::Themes::Theme {

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -38,6 +38,8 @@ This document lists the color themes bundled with ImGuiX and shows how to create
 ## Creating a custom theme
 
 Implement the `ImGuiX::Themes::Theme` interface and override the `apply` methods. Use `applyDefaultImGuiStyle` to set common spacing and rounding values.
+Do not call `ImGui::GetColorU32` outside an active ImGui frame.
+Store raw `ImVec4` or `ImU32` values in configuration structs and convert during rendering.
 
 ```cpp
 class MyTheme final : public ImGuiX::Themes::Theme {

--- a/include/imguix/widgets/time/days_selector.hpp
+++ b/include/imguix/widgets/time/days_selector.hpp
@@ -45,7 +45,7 @@ namespace ImGuiX::Widgets {
         // Cell borders (like HoursSelector)
         bool    show_cell_borders        = true;           ///< Draw cell borders.
         float   cell_border_thickness    = 1.0f;           ///< Border thickness.
-        ImU32   cell_border_color        = ImGui::GetColorU32(ImGuiCol_Separator); ///< Cell border color (default ImGuiCol_Separator).
+        ImU32   cell_border_color        = 0;             ///< 0 -> ImGuiCol_Separator.
         ImU32   cell_border_color_hovered = 0;             ///< 0 -> ImGuiCol_HeaderHovered.
         ImU32   cell_border_color_selected =0;             ///< 0 -> ImGuiCol_Header.
         float   cell_rounding            = 0.0f;           ///< <0 -> use style.FrameRounding.

--- a/include/imguix/widgets/time/hours_selector.hpp
+++ b/include/imguix/widgets/time/hours_selector.hpp
@@ -33,7 +33,7 @@ namespace ImGuiX::Widgets {
         bool        use_header_color_for_selected = true; ///< Use ImGuiCol_Header for selected bg.
         bool    show_cell_borders   = true;      ///< Draw cell borders.
         float   cell_border_thickness = 1.0f;   ///< Border thickness.
-        ImU32   cell_border_color   = ImGui::GetColorU32(ImGuiCol_Separator); ///< Cell border color (default ImGuiCol_Separator).
+        ImU32   cell_border_color   = 0;           ///< 0 -> ImGuiCol_Separator.
         ImU32   cell_border_color_hovered = 0;   ///< 0 -> ImGuiCol_HeaderHovered.
         ImU32   cell_border_color_selected = 0;  ///< 0 -> ImGuiCol_Header.
         float   cell_rounding = 0.0f;            ///< Cell rounding radius.


### PR DESCRIPTION
## Summary
- avoid ImGui::GetColorU32 in widget config defaults
- document that default colors must not call ImGui::GetColorU32
- note the restriction in AGENTS

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF` *(fails: imgui-command-palette not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b98fafd7ec832ca73403424ee59863