### PR TITLE
docs(themes): document style application

### DIFF
--- a/include/imguix/themes/CorporateGreyTheme.hpp
+++ b/include/imguix/themes/CorporateGreyTheme.hpp
@@ -52,6 +52,8 @@ namespace ImGuiX::Themes {
     /// Configures both ImGui and ImPlot.
     class CorporateGreyTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace CorporateGreyConstants;
             ImVec4* colors = style.Colors;
@@ -121,6 +123,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsDark(&style);
 
@@ -146,6 +150,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             ImPlot3D::StyleColorsDark(&style);
 

--- a/include/imguix/themes/CyberY2KTheme.hpp
+++ b/include/imguix/themes/CyberY2KTheme.hpp
@@ -106,6 +106,8 @@ namespace ImGuiX::Themes {
     /// \brief Dark neon Cyber-Y2K theme with cyan/violet accents.
     class CyberY2KTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace CyberY2KConstants;
             ImVec4* colors = style.Colors;
@@ -184,6 +186,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace CyberY2KConstants;
 
@@ -216,6 +220,8 @@ namespace ImGuiX::Themes {
 #endif
 
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace CyberY2KConstants;
 

--- a/include/imguix/themes/CyberpunkUITheme.hpp
+++ b/include/imguix/themes/CyberpunkUITheme.hpp
@@ -102,6 +102,8 @@ namespace ImGuiX::Themes {
     /// \brief Dark neon mono-cyan theme (HUD look).
     class CyberpunkUITheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace CyberpunkUIConstants;
             ImVec4* colors = style.Colors;
@@ -181,6 +183,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace CyberpunkUIConstants;
 
@@ -215,6 +219,8 @@ namespace ImGuiX::Themes {
 #endif
 
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace CyberpunkUIConstants;
 

--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -104,6 +104,8 @@ namespace ImGuiX::Themes {
     /// \brief Dark Charcoal theme (orange accent), consistent with ImGuiX default layout config.
     class DarkCharcoalTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace DarkCharcoalConstants;
             ImVec4* colors = style.Colors;
@@ -191,6 +193,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace DarkCharcoalConstants;
 
@@ -222,6 +226,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace DarkCharcoalConstants;
 

--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -100,6 +100,8 @@ namespace ImGuiX::Themes {
     /// \brief Dark graphite theme with blue/cyan accents, unified with default layout config.
     class DarkGraphiteTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace DarkGraphiteConstants;
             ImVec4* colors = style.Colors;
@@ -183,6 +185,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace DarkGraphiteConstants;
 
@@ -212,6 +216,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace DarkGraphiteConstants;
 

--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -109,6 +109,8 @@ namespace ImGuiX::Themes {
     /// \brief Dark teal theme with blue accent, consistent with ImGuiX default layout config.
     class DarkTealTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace DarkTealConstants;
             ImVec4* colors = style.Colors;
@@ -192,6 +194,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace DarkTealConstants;
 
@@ -223,6 +227,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace DarkTealConstants;
 

--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -107,6 +107,8 @@ namespace ImGuiX::Themes {
     /// \brief Deep dark theme with cyan and red accents, unified with default layout config.
     class DeepDarkTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace DeepDarkConstants;
             ImVec4* colors = style.Colors;
@@ -200,6 +202,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace DeepDarkConstants;
 
@@ -231,6 +235,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace DeepDarkConstants;
 

--- a/include/imguix/themes/GoldBlackTheme.hpp
+++ b/include/imguix/themes/GoldBlackTheme.hpp
@@ -101,6 +101,8 @@ namespace ImGuiX::Themes {
     /// \brief Gold & Black theme with warm golden accents, unified with default layout config.
     class GoldBlackTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace GoldBlackConstants;
             ImVec4* colors = style.Colors;
@@ -184,6 +186,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace GoldBlackConstants;
 
@@ -215,6 +219,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace GoldBlackConstants;
 

--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -104,6 +104,8 @@ namespace ImGuiX::Themes {
     /// \brief Green & Blue theme with tri-tone accent (green/teal/cyan), unified with default layout config.
     class GreenBlueTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace GreenBlueConstants;
             ImVec4* colors = style.Colors;
@@ -197,6 +199,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace GreenBlueConstants;
 
@@ -228,6 +232,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace GreenBlueConstants;
 

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -97,6 +97,8 @@ namespace ImGuiX::Themes {
     /// \brief Light theme with soft blue accents, unified with default layout config.
     class LightBlueTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace LightBlueConstants;
             ImVec4* colors = style.Colors;
@@ -175,6 +177,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace LightBlueConstants;
 
@@ -206,6 +210,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace LightBlueConstants;
 

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -95,6 +95,8 @@ namespace ImGuiX::Themes {
     /// \brief Light theme with soft green accents, unified with default layout config.
     class LightGreenTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace LightGreenConstants;
             ImVec4* colors = style.Colors;
@@ -174,6 +176,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace LightGreenConstants;
 
@@ -205,6 +209,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace LightGreenConstants;
 

--- a/include/imguix/themes/NightOwlTheme.hpp
+++ b/include/imguix/themes/NightOwlTheme.hpp
@@ -120,6 +120,8 @@ namespace ImGuiX::Themes {
     /// \brief Dark Night Owl theme with cyan/blue primaries and readable contrast.
     class NightOwlTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace NightOwlConstants;
             ImVec4* colors = style.Colors;
@@ -206,6 +208,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace NightOwlConstants;
 
@@ -242,6 +246,8 @@ namespace ImGuiX::Themes {
 #endif
 
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace NightOwlConstants;
 

--- a/include/imguix/themes/NordTheme.hpp
+++ b/include/imguix/themes/NordTheme.hpp
@@ -2,8 +2,8 @@
 #ifndef _IMGUIX_THEMES_NORD_THEME_HPP_INCLUDED
 #define _IMGUIX_THEMES_NORD_THEME_HPP_INCLUDED
 
-/// @file NordTheme.hpp
-/// @brief Nord palette (Arctic Ice Studio) for ImGui/ImPlot.
+/// \file NordTheme.hpp
+/// \brief Nord palette (Arctic Ice Studio) for ImGui/ImPlot.
 ///
 /// Palette:
 ///  - Polar Night:  nord0 #2E3440, nord1 #3B4252, nord2 #434C5E, nord3 #4C566A
@@ -120,6 +120,8 @@ namespace NordConstants {
 
 class NordTheme final : public Theme {
 public:
+    /// \brief Apply theme colors to ImGui style.
+    /// \param style Target style.
     void apply(ImGuiStyle& style) const override {
         using namespace NordConstants;
         ImVec4* c = style.Colors;
@@ -204,6 +206,8 @@ public:
     }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+    /// \brief Apply theme colors to ImPlot style.
+    /// \param style Target style.
     void apply(ImPlotStyle& style) const override {
         using namespace NordConstants;
         ImPlot::StyleColorsDark(&style);
@@ -234,6 +238,8 @@ public:
 #endif
 
 #ifdef IMGUI_ENABLE_IMPLOT3D
+    /// \brief Apply theme colors to ImPlot3D style.
+    /// \param style Target style.
     void apply(ImPlot3DStyle& style) const override {
         using namespace NordConstants;
         ImPlot3D::StyleColorsDark(&style);
@@ -258,9 +264,9 @@ public:
 #endif
 };
 
-/// @brief Register Nord in ThemeManager.
-/// @param tm Theme manager.
-/// @param id Unique id (defaults to "nord").
+/// \brief Register Nord in ThemeManager.
+/// \param tm Theme manager.
+/// \param id Unique id (defaults to "nord").
 inline void registerNordTheme(ThemeManager& tm, std::string id = "nord") {
     tm.registerTheme(std::move(id), std::make_unique<NordTheme>());
 }

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -96,6 +96,8 @@ namespace ImGuiX::Themes {
     /// \brief macOS-like light theme, unified with default layout config.
     class OSXTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace OSXThemeConstants;
             ImVec4* colors = style.Colors;
@@ -171,6 +173,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace OSXThemeConstants;
 
@@ -202,6 +206,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace OSXThemeConstants;
 

--- a/include/imguix/themes/PearlLightTheme.hpp
+++ b/include/imguix/themes/PearlLightTheme.hpp
@@ -78,6 +78,8 @@ namespace ImGuiX::Themes {
     /// \brief Soft light theme with gentle grays and a blue accent, unified with default layout constants.
     class PearlLightTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace PearlLightConstants;
             ImVec4* colors = style.Colors;
@@ -158,6 +160,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace PearlLightConstants;
 
@@ -183,6 +187,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace PearlLightConstants;
 

--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -78,6 +78,8 @@ namespace ImGuiX::Themes {
     /// \brief Dense slate-dark theme with blue accent, consistent with default layout constants.
     class SlateDarkTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace SlateDarkConstants;
             ImVec4* colors = style.Colors;
@@ -158,6 +160,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace SlateDarkConstants;
 
@@ -183,6 +187,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace SlateDarkConstants;
 

--- a/include/imguix/themes/TokyoNightStormTheme.hpp
+++ b/include/imguix/themes/TokyoNightStormTheme.hpp
@@ -2,8 +2,8 @@
 #ifndef _IMGUIX_THEMES_TOKYO_NIGHT_STORM_THEME_HPP_INCLUDED
 #define _IMGUIX_THEMES_TOKYO_NIGHT_STORM_THEME_HPP_INCLUDED
 
-/// @file TokyoNightStormTheme.hpp
-/// @brief Tokyo Night — Storm variant for ImGui/ImPlot.
+/// \file TokyoNightStormTheme.hpp
+/// \brief Tokyo Night — Storm variant for ImGui/ImPlot.
 ///
 /// Aesthetics:
 ///  - stormy navy bg (#24283B), panels #1F2335, popups #1A1B26
@@ -115,6 +115,8 @@ namespace TokyoNightStormConstants {
 
 class TokyoNightStormTheme final : public Theme {
 public:
+    /// \brief Apply theme colors to ImGui style.
+    /// \param style Target style.
     void apply(ImGuiStyle& style) const override {
         using namespace TokyoNightStormConstants;
         ImVec4* c = style.Colors;
@@ -198,6 +200,8 @@ public:
     }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+    /// \brief Apply theme colors to ImPlot style.
+    /// \param style Target style.
     void apply(ImPlotStyle& style) const override {
         using namespace TokyoNightStormConstants;
         ImPlot::StyleColorsDark(&style);
@@ -228,6 +232,8 @@ public:
 #endif
 
 #ifdef IMGUI_ENABLE_IMPLOT3D
+    /// \brief Apply theme colors to ImPlot3D style.
+    /// \param style Target style.
     void apply(ImPlot3DStyle& style) const override {
         using namespace TokyoNightStormConstants;
         ImPlot3D::StyleColorsDark(&style);
@@ -252,9 +258,9 @@ public:
 #endif
 };
 
-/// @brief Register Tokyo Night Storm in ThemeManager.
-/// @param tm Theme manager.
-/// @param id Unique id (defaults to "tokyo-night-storm").
+/// \brief Register Tokyo Night Storm in ThemeManager.
+/// \param tm Theme manager.
+/// \param id Unique id (defaults to "tokyo-night-storm").
 inline void registerTokyoNightStormTheme(ThemeManager& tm, std::string id = "tokyo-night-storm") {
     tm.registerTheme(std::move(id), std::make_unique<TokyoNightStormTheme>());
 }

--- a/include/imguix/themes/TokyoNightTheme.hpp
+++ b/include/imguix/themes/TokyoNightTheme.hpp
@@ -122,6 +122,8 @@ namespace ImGuiX::Themes {
     /// \brief Tokyo Night theme with blue/cyan primaries and deeper contrast.
     class TokyoNightTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace TokyoNightConstants;
             ImVec4* colors = style.Colors;
@@ -206,6 +208,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace TokyoNightConstants;
 
@@ -237,6 +241,8 @@ namespace ImGuiX::Themes {
 #endif
 
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace TokyoNightConstants;
 

--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -89,6 +89,8 @@ namespace ImGuiX::Themes {
     /// \brief Visual Studio-like dark theme, unified with default layout config.
     class VisualStudioDarkTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace VisualStudioDarkConstants;
             ImVec4* colors = style.Colors;
@@ -172,6 +174,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace VisualStudioDarkConstants;
 
@@ -202,6 +206,8 @@ namespace ImGuiX::Themes {
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace VisualStudioDarkConstants;
 

--- a/include/imguix/themes/Y2KTheme.hpp
+++ b/include/imguix/themes/Y2KTheme.hpp
@@ -120,6 +120,8 @@ namespace ImGuiX::Themes {
     /// \brief Light Y2K theme with cobalt/azure accents and glassy panels.
     class Y2KTheme final : public Theme {
     public:
+        /// \brief Apply theme colors to ImGui style.
+        /// \param style Target style.
         void apply(ImGuiStyle& style) const override {
             using namespace Y2KConstants;
             ImVec4* colors = style.Colors;
@@ -210,6 +212,8 @@ namespace ImGuiX::Themes {
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
+        /// \brief Apply theme colors to ImPlot style.
+        /// \param style Target style.
         void apply(ImPlotStyle& style) const override {
             using namespace Y2KConstants;
 
@@ -242,6 +246,8 @@ namespace ImGuiX::Themes {
 #endif
 
 #ifdef IMGUI_ENABLE_IMPLOT3D
+        /// \brief Apply theme colors to ImPlot3D style.
+        /// \param style Target style.
         void apply(ImPlot3DStyle& style) const override {
             using namespace Y2KConstants;
 


### PR DESCRIPTION
## Summary
- document theme application methods across ImGui, ImPlot and ImPlot3D
- normalize Doxygen tag usage in theme headers

## Testing
- `cmake -S . -B build` *(fails: nlohmann_json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba77aa636c832ca9de39f9e424b5af