### PR TITLE
docs: fix Doxygen tag style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -674,7 +674,7 @@ return ImGui::GetIO().Fonts->AddFontFromFileTTF(
 * Bind the symbol to the type: `ImFont*`, `const Foo&`.
 
 ### Doxygen
-* Use `///` comments in English with concise `@brief`, `@param`, `@return`, and `@note` tags.
+* Use `///` comments in English with concise `\brief`, `\param`, `\return`, and `\note` tags.
 
 ### Includes
 * Order includes as: header of the current file, then standard library headers `<...>`, then external or project headers `"..."`.


### PR DESCRIPTION
## Summary
- correct Doxygen style instructions to use backslash tags

## Testing
- `cmake -S . -B build -DIMGUIX_HEADER_ONLY=ON -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMGUI_MD=OFF -DIMGUIX_IMGUI_FREETYPE=OFF -DIMGUIX_USE_IMSPINNER=OFF` *(fails: No SOURCES given to target: imgui)*

------
https://chatgpt.com/codex/tasks/task_e_68bb13ce801c832ca0bae57dc7126eac