### PR TITLE
test: remove interactive waits from core tests

### DIFF
--- a/tests/test_event_system.cpp
+++ b/tests/test_event_system.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -74,18 +75,16 @@ int main() {
     MyEvent event("Hello world!");
     listener.notify(event);
 
-    if (!listener.received || !callback_received) {
-        std::cerr << "Test failed: not all listeners received event\n";
-        std::cin.get();
-        return 1;
-    }
+    bool success = listener.received && callback_received;
+    assert(success && "Test failed: not all listeners received event");
 
     // Test asynchronous queue
+    listener.received = false;
     auto async_event = std::make_unique<MyEvent>("From async queue");
     listener.notifyAsync(std::move(async_event));
     bus.process();
+    assert(listener.received && "Async event not processed");
 
     std::cout << "Test passed\n";
-    std::cin.get();
-    return 0;
+    return success ? 0 : 1;
 }

--- a/tests/test_resource_registry.cpp
+++ b/tests/test_resource_registry.cpp
@@ -1,5 +1,7 @@
+#include <cassert>
 #include <iostream>
 #include <string>
+
 #include "imguix/core/resource/ResourceRegistry.hpp"
 
 using namespace ImGuiX;
@@ -15,26 +17,22 @@ int main() {
     bool registered = registry.registerResource<DummyResource>([]() {
         return std::make_unique<DummyResource>(DummyResource{"MyResource"});
     });
-
     std::cout << "Resource registered: " << std::boolalpha << registered << "\n";
-
-    // Attempt to retrieve the resource
     auto& res = registry.getResource<DummyResource>();
     std::cout << "Resource retrieved: " << res.name << "\n";
-    
     auto res2 = registry.tryGetResource<DummyResource>();
     if (res2) {
         std::cout << "Resource retrieved: " << res2->get().name << "\n";
     } else {
         std::cout << "Resource not found!\n";
     }
-
-    // Test duplicate registration
     bool duplicate = registry.registerResource<DummyResource>([] {
         return std::make_unique<DummyResource>(DummyResource{"Duplicate"});
     });
-
     std::cout << "Duplicate registration result: " << std::boolalpha << duplicate << "\n";
-    std::cin.get();
-    return 0;
+
+    bool success = registered && res.name == "MyResource" && res2 &&
+        res2->get().name == "MyResource" && !duplicate;
+    assert(success && "Resource registry test failed");
+    return success ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- drop blocking `std::cin.get()` calls in event and resource registry tests
- assert test success and return appropriate exit code

## Testing
- `g++ -std=c++20 -DIMGUIX_HEADER_ONLY -Iinclude tests/test_event_system.cpp -o tests/test_event_system`
- `./tests/test_event_system`
- `g++ -std=c++20 -fno-char8_t -DIMGUIX_HEADER_ONLY -Iinclude tests/test_resource_registry.cpp -o tests/test_resource_registry`
- `./tests/test_resource_registry`

------
https://chatgpt.com/codex/tasks/task_e_68bb6f764250832cb5432e3c543470d8