### PR TITLE
fix: allow examples to find local package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,21 @@ if(IMGUIX_BUILD_TESTS)
     endforeach()
 endif()
 
+# ===== Package Config (build tree) =====
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/ImGuiXConfig.cmake.in
+    ${CMAKE_BINARY_DIR}/ImGuiXConfig.cmake
+    INSTALL_DESTINATION lib/cmake/ImGuiX
+)
+install(TARGETS imguix
+    EXPORT ImGuiXTargets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+)
+
 # ===== Examples =====
 if(IMGUIX_BUILD_EXAMPLES)
     file(GLOB SMOKE_EXAMPLES CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/examples/smoke/*.cpp")
@@ -641,20 +656,11 @@ if(IMGUIX_BUILD_EXAMPLES)
         )
     endforeach()
 
+    set(ImGuiX_DIR "${CMAKE_BINARY_DIR}")
     add_subdirectory(examples/framed_showcase)
 endif()
 
 # ===== Install / Export =====
-include(CMakePackageConfigHelpers)
-
-install(TARGETS imguix
-    EXPORT ImGuiXTargets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include
-)
-
 # Public headers of ImGuiX
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/imguix
         DESTINATION include)
@@ -670,19 +676,8 @@ install(EXPORT ImGuiXTargets
     NAMESPACE ImGuiX::
     DESTINATION lib/cmake/ImGuiX
 )
-
-configure_package_config_file(
-    cmake/ImGuiXConfig.cmake.in
-    ${CMAKE_BINARY_DIR}/ImGuiXConfig.cmake
-    INSTALL_DESTINATION lib/cmake/ImGuiX
-)
 install(FILES ${CMAKE_BINARY_DIR}/ImGuiXConfig.cmake
         DESTINATION lib/cmake/ImGuiX)
-
-# Export from build tree for local find_package()
-export(EXPORT ImGuiXTargets
-    NAMESPACE ImGuiX::
-    FILE "${CMAKE_BINARY_DIR}/ImGuiXTargets.cmake")
 
 # ===== SDK bundle of 3rd-party deps =====
 

--- a/cmake/ImGuiXConfig.cmake.in
+++ b/cmake/ImGuiXConfig.cmake.in
@@ -1,4 +1,6 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
 find_dependency(nlohmann_json)
-include("${CMAKE_CURRENT_LIST_DIR}/ImGuiXTargets.cmake")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/ImGuiXTargets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/ImGuiXTargets.cmake")
+endif()


### PR DESCRIPTION
## Summary
- generate package config before building examples
- allow build-tree config to work without installed targets

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_EXAMPLES=ON -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF -DIMGUIX_IMGUI_FREETYPE=OFF -DIMGUIX_VENDOR_JSON=ON -DIMGUIX_DEPS_MODE=BUNDLED` (failed: No GUI backend selected; using pure Dear ImGui)
- `cmake --build build --target imguix framed_showcase tests -- -j2` (failed: DeltaClockSfml not declared)


------
https://chatgpt.com/codex/tasks/task_e_68bb89be76b0832ca746caf0d31fe015