### PR TITLE
fix(cmake): vendor nlohmann json without find

### DIFF
--- a/cmake/ImGuiXConfig.cmake.in
+++ b/cmake/ImGuiXConfig.cmake.in
@@ -1,6 +1,15 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
-find_dependency(nlohmann_json)
+if(@IMGUIX_VENDOR_JSON@)
+    if(NOT TARGET nlohmann_json::nlohmann_json)
+        add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)
+        get_filename_component(_imx_prefix "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+        target_include_directories(nlohmann_json::nlohmann_json INTERFACE "${_imx_prefix}/include")
+    endif()
+else()
+    find_dependency(nlohmann_json)
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/ImGuiXTargets.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/ImGuiXTargets.cmake")
 endif()


### PR DESCRIPTION
## Summary
- avoid requesting external `nlohmann_json` when vendored
- provide imported target for bundled JSON headers

## Testing
- `cmake --build build --target install` *(fails: imgui_stdlib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e460e84832c941b582238c41347