### PR TITLE
fix(cmake): propagate implot targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,10 +245,12 @@ if(IMGUIX_HEADER_ONLY)
 
     if(IMGUIX_USE_IMPLOT)
         target_compile_definitions(imguix INTERFACE IMGUI_ENABLE_IMPLOT)
+        target_link_libraries(imguix INTERFACE ${IMPLOT_TARGET})
     endif()
 
     if(IMGUIX_USE_IMPLOT3D)
         target_compile_definitions(imguix INTERFACE IMGUI_ENABLE_IMPLOT3D)
+        target_link_libraries(imguix INTERFACE ${IMPLOT3D_TARGET})
     endif()
     
     if(IMGUIX_USE_IMNODEFLOW)
@@ -285,8 +287,6 @@ if(IMGUIX_HEADER_ONLY)
         target_compile_definitions(imguix INTERFACE IMGUI_ENABLE_IMGUI_MD)
     endif()
 
-    # Clean interface to avoid exporting foreign targets
-    set_property(TARGET imguix PROPERTY INTERFACE_LINK_LIBRARIES "")
 
 else()
     set(_imguix_type STATIC)
@@ -360,12 +360,12 @@ else()
 
     if(IMGUIX_USE_IMPLOT)
         target_compile_definitions(imguix PUBLIC IMGUI_ENABLE_IMPLOT)
-        target_link_libraries(imguix PRIVATE ${IMPLOT_TARGET})
+        target_link_libraries(imguix PUBLIC ${IMPLOT_TARGET})
     endif()
-    
+
     if(IMGUIX_USE_IMPLOT3D)
         target_compile_definitions(imguix PUBLIC IMGUI_ENABLE_IMPLOT3D)
-        target_link_libraries(imguix PRIVATE ${IMPLOT3D_TARGET})
+        target_link_libraries(imguix PUBLIC ${IMPLOT3D_TARGET})
     endif()
     
     if(IMGUIX_USE_IMNODEFLOW)
@@ -408,8 +408,6 @@ else()
         target_link_libraries(imguix PRIVATE ${IMGUI_MD_TARGET})
     endif()
 
-    # Clean interface to avoid exporting foreign targets
-    set_property(TARGET imguix PROPERTY INTERFACE_LINK_LIBRARIES "")
 endif()
 
 # ===== Tests =====


### PR DESCRIPTION
## Summary
- expose ImPlot and ImPlot3D targets to dependents

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_EXAMPLES=ON -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_USE_SFML_BACKEND=ON -DIMGUIX_SFML_MAJOR=3` *(fails: Could not find SFML package)*
- `cmake -S . -B build -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_BUILD_TESTS=OFF -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF` *(fails: install(EXPORT "ImGuiXTargets" ...) includes target "imguix" which requires target "imgui" that is not in any export set)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9a6e6854832cbfa069d3ff2868fc