### PR TITLE
Fix CMake export for bundled dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,9 +309,9 @@ else()
         set_target_properties(imguix PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
     endif()
 
-    # Link external dependencies as PRIVATE to keep export minimal
+    # Link external dependencies; expose fmt and json for public headers
     target_link_libraries(imguix
-        PRIVATE fmt::fmt nlohmann_json::nlohmann_json
+        PUBLIC fmt::fmt nlohmann_json::nlohmann_json
         PRIVATE ${IMGUI_LIB} ${BACKEND_LIBS}
     )
 
@@ -699,20 +699,40 @@ function(imguix_install_target_with_headers tgt)
     if(NOT TARGET ${tgt})
         return()
     endif()
+    get_target_property(_type ${tgt} TYPE)
     get_target_property(_pub ${tgt} PUBLIC_HEADER)
-    if(_pub)
-        install(TARGETS ${tgt}
-            ARCHIVE DESTINATION lib
-            LIBRARY DESTINATION lib
-            RUNTIME DESTINATION bin
-            PUBLIC_HEADER DESTINATION include
-        )
+    get_target_property(_imported ${tgt} IMPORTED)
+    if(_imported)
+        return()
+    endif()
+    if(_type STREQUAL "INTERFACE_LIBRARY")
+        if(_pub)
+            install(TARGETS ${tgt}
+                EXPORT ImGuiXTargets
+                PUBLIC_HEADER DESTINATION include
+            )
+        else()
+            install(TARGETS ${tgt}
+                EXPORT ImGuiXTargets
+            )
+        endif()
     else()
-        install(TARGETS ${tgt}
-            ARCHIVE DESTINATION lib
-            LIBRARY DESTINATION lib
-            RUNTIME DESTINATION bin
-        )
+        if(_pub)
+            install(TARGETS ${tgt}
+                EXPORT ImGuiXTargets
+                ARCHIVE DESTINATION lib
+                LIBRARY DESTINATION lib
+                RUNTIME DESTINATION bin
+                PUBLIC_HEADER DESTINATION include
+            )
+        else()
+            install(TARGETS ${tgt}
+                EXPORT ImGuiXTargets
+                ARCHIVE DESTINATION lib
+                LIBRARY DESTINATION lib
+                RUNTIME DESTINATION bin
+            )
+        endif()
     endif()
 endfunction()
 
@@ -757,6 +777,8 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
         endif()
     endif()
 
+    imguix_install_target_with_headers(imgui)
+
 
     # --- ImGui-SFML: static library and headers ---
     if(TARGET ImGui-SFML)
@@ -787,6 +809,7 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
 
     # --- nlohmann-json (header-only) when vendored ---
     if(IMGUIX_VENDOR_JSON)
+        imguix_install_target_with_headers(nlohmann_json)
         if(EXISTS "${PROJECT_SOURCE_DIR}/libs/json/include/nlohmann")
             install(DIRECTORY "${PROJECT_SOURCE_DIR}/libs/json/include/nlohmann"
                     DESTINATION include)
@@ -794,6 +817,7 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
     endif()
 
     # --- ImPlot: headers ---
+    imguix_install_target_with_headers(implot)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/implot/implot.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/implot/implot.h"
@@ -801,8 +825,9 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
             DESTINATION include
         )
     endif()
-    
+
     # --- ImPlot3D: headers ---
+    imguix_install_target_with_headers(implot3d)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/implot3d/implot3d.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/implot3d/implot3d.h"
@@ -813,22 +838,25 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
     
     
     # --- ImNodeFlow: headers ---
+    imguix_install_target_with_headers(imnodeflow)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/ImNodeFlow/include/ImNodeFlow.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/ImNodeFlow/include/ImNodeFlow.h"
             DESTINATION include
         )
     endif()
-    
+
     # --- ImGuiFileDialog: headers ---
+    imguix_install_target_with_headers(imguifiledialog)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/ImGuiFileDialog/ImGuiFileDialog.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/ImGuiFileDialog/ImGuiFileDialog.h"
             "${PROJECT_SOURCE_DIR}/libs/ImGuiFileDialog/ImGuiFileDialogConfig.h"
             DESTINATION include)
     endif()
-    
+
     # --- ImGuiColorTextEdit: headers ---
+    imguix_install_target_with_headers(imtexteditor)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/ImGuiColorTextEdit/ImGuiColorTextEdit.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/ImGuiColorTextEdit/ImGuiColorTextEdit.h"
@@ -836,34 +864,40 @@ if(IMGUIX_SDK_BUNDLE_DEPS)
     endif()
     
     # --- portable-file-dialogs: headers ---
+    imguix_install_target_with_headers(pfd)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/portable-file-dialogs/portable-file-dialogs.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/portable-file-dialogs/portable-file-dialogs.h"
             DESTINATION include
         )
     endif()
-    
+
     # --- imspinner: headers ---
+    imguix_install_target_with_headers(imspinner)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/imspinner/imspinner.h")
         install(FILES "${PROJECT_SOURCE_DIR}/libs/imspinner/imspinner.h"
                 DESTINATION include)
     endif()
-    
+
     # --- imgui-command-palette: headers ---
+    imguix_install_target_with_headers(imcmd)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/imgui-command-palette/imcmd_command_palette.h")
         install(FILES
             "${PROJECT_SOURCE_DIR}/libs/imgui-command-palette/imcmd_command_palette.h"
             "${PROJECT_SOURCE_DIR}/libs/imgui-command-palette/imcmd_fuzzy_search.h"
             DESTINATION include)
     endif()
-    
+
     # --- ImCoolBar: headers ---
+    imguix_install_target_with_headers(imcoolbar)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/ImCoolBar/ImCoolBar.h")
         install(FILES "${PROJECT_SOURCE_DIR}/libs/ImCoolBar/ImCoolBar.h"
                 DESTINATION include)
     endif()
-    
+
     # --- imgui_md: headers ---
+    imguix_install_target_with_headers(imgui_md)
+    imguix_install_target_with_headers(md4c)
     if(EXISTS "${PROJECT_SOURCE_DIR}/libs/imgui_md/imgui_md.h")
         install(FILES "${PROJECT_SOURCE_DIR}/libs/imgui_md/imgui_md.h"
                 DESTINATION include)

--- a/cmake/deps/imcmd.cmake
+++ b/cmake/deps/imcmd.cmake
@@ -16,7 +16,10 @@ function(imguix_use_or_fetch_imcmd OUT_VAR)
     )
     add_library(imcmd::imcmd ALIAS imcmd)
 
-    target_include_directories(imcmd PUBLIC "${_DIR}")
+    target_include_directories(imcmd PUBLIC
+        $<BUILD_INTERFACE:${_DIR}>
+        $<INSTALL_INTERFACE:include>
+    )
     target_link_libraries(imcmd PUBLIC imgui::imgui)
 
     set_target_properties(imcmd PROPERTIES

--- a/cmake/deps/imcoolbar.cmake
+++ b/cmake/deps/imcoolbar.cmake
@@ -14,7 +14,10 @@ function(imguix_use_or_fetch_imcoolbar OUT_VAR)
     add_library(imcoolbar STATIC "${_DIR}/ImCoolBar.cpp")
     add_library(imcoolbar::imcoolbar ALIAS imcoolbar)
 
-    target_include_directories(imcoolbar PUBLIC "${_DIR}")
+    target_include_directories(imcoolbar PUBLIC
+        $<BUILD_INTERFACE:${_DIR}>
+        $<INSTALL_INTERFACE:include>
+    )
     target_link_libraries(imcoolbar PUBLIC imgui::imgui)
 
     set_target_properties(imcoolbar PROPERTIES

--- a/cmake/deps/imgui_file_dialog.cmake
+++ b/cmake/deps/imgui_file_dialog.cmake
@@ -15,7 +15,10 @@ function(imguix_use_or_fetch_imguifiledialog OUT_VAR)
     )
     add_library(imguifiledialog::imguifiledialog ALIAS imguifiledialog)
 
-    target_include_directories(imguifiledialog PUBLIC "${_DIR}")
+    target_include_directories(imguifiledialog PUBLIC
+        $<BUILD_INTERFACE:${_DIR}>
+        $<INSTALL_INTERFACE:include>
+    )
     target_link_libraries(imguifiledialog PUBLIC imgui::imgui)
 
     # Опционально: переключить на std::filesystem (иначе используется dirent)

--- a/cmake/deps/imgui_md.cmake
+++ b/cmake/deps/imgui_md.cmake
@@ -65,7 +65,10 @@ function(imguix_use_or_fetch_imgui_md OUT_VAR)
             endif()
             enable_language(C)
             add_library(md4c STATIC "${_MD4C_SRC}")
-            target_include_directories(md4c PUBLIC "${_MD4C_INC}")
+            target_include_directories(md4c PUBLIC
+                $<BUILD_INTERFACE:${_MD4C_INC}>
+                $<INSTALL_INTERFACE:include>
+            )
             set_target_properties(md4c PROPERTIES POSITION_INDEPENDENT_CODE ON)
             set(MD4C_TGT md4c)
         endif()

--- a/cmake/deps/imnodeflow.cmake
+++ b/cmake/deps/imnodeflow.cmake
@@ -27,7 +27,8 @@ function(imguix_use_or_fetch_imnodeflow OUT_VAR)
     target_link_libraries(imnodeflow PUBLIC imgui::imgui)
 
     target_include_directories(imnodeflow PUBLIC
-        "${_IMNODEFLOW_DIR}/include"
+        $<BUILD_INTERFACE:${_IMNODEFLOW_DIR}/include>
+        $<INSTALL_INTERFACE:include>
     )
 
     # Recommended by upstream sample: enable ImGui math operators

--- a/cmake/deps/implot3d.cmake
+++ b/cmake/deps/implot3d.cmake
@@ -57,7 +57,10 @@ function(imguix_use_or_fetch_implot3d OUT_VAR)
 
     # ImPlot3D depends only on Dear ImGui
     target_link_libraries(implot3d PUBLIC imgui::imgui)
-    target_include_directories(implot3d PUBLIC "${_IMPLOT3D_DIR}")
+    target_include_directories(implot3d PUBLIC
+        $<BUILD_INTERFACE:${_IMPLOT3D_DIR}>
+        $<INSTALL_INTERFACE:include>
+    )
 
     # Optionally expose public header for SDK installers
     set_target_properties(implot3d PROPERTIES

--- a/cmake/deps/imspinner.cmake
+++ b/cmake/deps/imspinner.cmake
@@ -34,7 +34,10 @@ function(imguix_use_or_fetch_imspinner OUT_VAR)
 
     add_library(imspinner INTERFACE)
     add_library(imspinner::imspinner ALIAS imspinner)
-    target_include_directories(imspinner INTERFACE "${_IMSPIN_DIR}")
+    target_include_directories(imspinner INTERFACE
+        $<BUILD_INTERFACE:${_IMSPIN_DIR}>
+        $<INSTALL_INTERFACE:include>
+    )
     target_link_libraries(imspinner INTERFACE imgui::imgui) # для imgui_internal.h
     # Опц.: включить демо-функции через макрос IMSPINNER_DEMO на нужных таргетах
     set(${OUT_VAR} imspinner::imspinner PARENT_SCOPE)

--- a/cmake/deps/imtexteditor.cmake
+++ b/cmake/deps/imtexteditor.cmake
@@ -16,7 +16,10 @@ function(imguix_use_or_fetch_imtexteditor OUT_VAR)
     )
     add_library(imtexteditor::imtexteditor ALIAS imtexteditor)
 
-    target_include_directories(imtexteditor PUBLIC "${_DIR}")
+    target_include_directories(imtexteditor PUBLIC
+        $<BUILD_INTERFACE:${_DIR}>
+        $<INSTALL_INTERFACE:include>
+    )
     target_link_libraries(imtexteditor PUBLIC imgui::imgui)
 
     set_target_properties(imtexteditor PROPERTIES

--- a/cmake/deps/portable_file_dialogs.cmake
+++ b/cmake/deps/portable_file_dialogs.cmake
@@ -36,7 +36,10 @@ function(imguix_use_or_fetch_pfd OUT_VAR)
 
     add_library(pfd INTERFACE)
     add_library(pfd::pfd ALIAS pfd)
-    target_include_directories(pfd INTERFACE "${_PFD_DIR}")
+    target_include_directories(pfd INTERFACE
+        $<BUILD_INTERFACE:${_PFD_DIR}>
+        $<INSTALL_INTERFACE:include>
+    )
 
     # header-only: никаких линковок
     set(${OUT_VAR} pfd::pfd PARENT_SCOPE)

--- a/examples/quickstart/main.cpp
+++ b/examples/quickstart/main.cpp
@@ -1,4 +1,10 @@
-// demo_framed_showcase.cpp
+#define IMGUIX_HEADER_ONLY
+#define IMGUIX_DEMO
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+
 #include <imguix/core.hpp>
 #include <imguix/windows/ImGuiFramedWindow.hpp>
 #include <imguix/controllers/ExtendedController.hpp>
@@ -81,15 +87,15 @@ public:
             }
             ImGui::SameLine();
             if (ImGui::Button("Send Info Notification")) {
-                ImGuiX::Widgets::NotifyInfo("Hello", "This is a demo notification.");
+                ImGuiX::Widgets::NotifyInfo(this, "Hello: This is a demo notification.");
             }
             ImGui::SameLine();
             if (ImGui::Button("Send Warning")) {
-                ImGuiX::Widgets::NotifyWarn("Watch out", "Something to keep an eye on.");
+                ImGuiX::Widgets::NotifyWarning(this, "Watch out: Something to keep an eye on.");
             }
             ImGui::SameLine();
             if (ImGui::Button("Send Error")) {
-                ImGuiX::Widgets::NotifyError("Oops", "Something went wrong.");
+                ImGuiX::Widgets::NotifyError(this, "Oops: Something went wrong.");
             }
             ImGui::SeparatorText("Theme");
             // Theme picker integrated with this controller/window
@@ -236,13 +242,7 @@ private:
 
         const auto& bars = (tf_index == 0 ? bars_m1 : tf_index == 1 ? bars_m30 : bars_h1);
         ImGuiX::Widgets::OHLCChartConfig cfg{};
-        ImGuiX::Widgets::PlotOHLCChart<Bar>("Synthetic OHLC", bars, cfg,
-            [](const Bar& b){ return b.time;  },
-            [](const Bar& b){ return b.open;  },
-            [](const Bar& b){ return b.high;  },
-            [](const Bar& b){ return b.low;   },
-            [](const Bar& b){ return b.close; },
-            [](const Bar& b){ return b.volume;});
+        ImGuiX::Widgets::PlotOHLCChart<Bar>("Synthetic OHLC", bars, cfg);
     }
 #endif
 };

--- a/include/imguix/windows/ImGuiFramedWindow.hpp
+++ b/include/imguix/windows/ImGuiFramedWindow.hpp
@@ -5,8 +5,13 @@
 /// \file ImGuiFramedWindow.hpp
 /// \brief Window implementation with custom title bar and control buttons.
 
-#include "window_flags.hpp"
+#ifdef _WIN32
+#   include <windows.h>
+#endif
+
 #include <imgui.h>
+
+#include "window_flags.hpp"
 
 namespace ImGuiX::Windows {
 


### PR DESCRIPTION
## Summary
- export `imgui` and skip imported targets when installing bundled libs
- normalize bundled dependency include dirs for relocatable SDK exports
- expose fmt and nlohmann_json usage requirements to downstream consumers
- include Windows headers in framed window and update quickstart demo for new notification and plotting APIs

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DIMGUIX_DEPS_MODE=BUNDLED -DIMGUIX_BUILD_SHARED=OFF -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_BUILD_EXAMPLES=ON -DIMGUIX_USE_SFML_BACKEND=ON -DIMGUIX_IMGUI_FREETYPE=ON -DIMGUIX_VENDOR_JSON=ON` *(fails: nlohmann_json: no system package and no submodule at libs/json)*
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DIMGUIX_DEPS_MODE=BUNDLED -DIMGUIX_BUILD_SHARED=OFF -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_BUILD_EXAMPLES=ON -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_IMGUI_FREETYPE=ON -DIMGUIX_VENDOR_JSON=ON` *(fails: nlohmann_json: no system package and no submodule at libs/json)*


------
https://chatgpt.com/codex/tasks/task_e_68bba3380e98832c93878efbff6a878a