### PR TITLE
fix(plot): warn and skip mismatched line series

### DIFF
--- a/include/imguix/widgets/plot/MetricsPlot.hpp
+++ b/include/imguix/widgets/plot/MetricsPlot.hpp
@@ -56,6 +56,7 @@ namespace ImGuiX::Widgets {
 
     /// \brief Data for MetricsPlot.
     /// \invariant labels.size() equals values.size() when values not empty.
+    /// \invariant line_x[k].size() equals line_y[k].size() for all k; mismatched series are skipped.
     struct MetricsPlotData {
         std::vector<std::string_view> labels;    ///< Category labels.
         std::vector<double> values;              ///< Bar values per category.

--- a/include/imguix/widgets/plot/MetricsPlot.ipp
+++ b/include/imguix/widgets/plot/MetricsPlot.ipp
@@ -213,7 +213,18 @@ namespace ImGuiX::Widgets {
             ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
             ImPlot::SetupAxisFormat(ImAxis_Y1, c.cfg.value_fmt);
 
+            // Validate that each line series has matching X/Y array lengths.
+            std::vector<bool> skip(c.state.dnd.size(), false);
             for (size_t k = 0; k < c.state.dnd.size(); ++k) {
+                if (c.data.line_x[k].size() != c.data.line_y[k].size()) {
+                    IM_ASSERT(c.data.line_x[k].size() == c.data.line_y[k].size() &&
+                              "MetricsPlot: line_x and line_y size mismatch");
+                    skip[k] = true;
+                }
+            }
+
+            for (size_t k = 0; k < c.state.dnd.size(); ++k) {
+                if (skip[k]) continue;
                 auto& it = c.state.dnd[k];
                 if (!it.is_plot) continue;
                 ImPlot::SetAxis(ImAxis_Y1);


### PR DESCRIPTION
## Summary
- validate line plot data and skip mismatched series with an IM_ASSERT warning
- document the line_x/line_y size requirement for MetricsPlotData

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1e716764832ca577ba7886f0f23c