### PR TITLE
fix(plot): use std::string labels in MetricsPlot

### DIFF
--- a/include/imguix/widgets/plot/MetricsPlot.hpp
+++ b/include/imguix/widgets/plot/MetricsPlot.hpp
@@ -5,6 +5,7 @@
 /// \file MetricsPlot.hpp
 /// \brief Plot categorical metrics as bars or lines with drag-and-drop.
 
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -58,7 +59,7 @@ namespace ImGuiX::Widgets {
     /// \invariant labels.size() equals values.size() when values not empty.
     /// \invariant line_x[k].size() equals line_y[k].size() for all k; mismatched series are skipped.
     struct MetricsPlotData {
-        std::vector<std::string_view> labels;    ///< Category labels.
+        std::vector<std::string> labels;         ///< Category labels.
         std::vector<double> values;              ///< Bar values per category.
         std::vector<std::vector<double>> line_x; ///< Line X coordinates.
         std::vector<std::vector<double>> line_y; ///< Line Y coordinates.

--- a/include/imguix/widgets/plot/MetricsPlot.ipp
+++ b/include/imguix/widgets/plot/MetricsPlot.ipp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <imgui.h>


### PR DESCRIPTION
## Summary
- use std::string for MetricsPlot labels
- include <string> in MetricsPlot headers

## Testing
- `cmake -S . -B build -DIMGUIX_USE_SFML_BACKEND=ON -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF -DIMGUIX_BUILD_TESTS=ON`
- `cmake --build build -j$(nproc)` *(fails: no match for ‘operator!=’ in imgui-SFML)*

------
https://chatgpt.com/codex/tasks/task_e_68bf21aca0ac832cb0100f3c75ce01b9