### PR TITLE
Add MetricsPlotSet widget for dataset selection

### DIFF
--- a/examples/smoke/widgets_demo.cpp
+++ b/examples/smoke/widgets_demo.cpp
@@ -60,6 +60,7 @@
 #ifdef IMGUI_ENABLE_IMPLOT
 #include <imguix/widgets/plot/PlotOHLCChart.hpp>
 #include <imguix/widgets/plot/MetricsPlot.hpp>
+#include <imguix/widgets/plot/MetricsPlotSet.hpp>
 #endif
 
 #ifdef IMGUIX_DEMO
@@ -459,6 +460,7 @@ private:
         }
         if (ImGui::CollapsingHeader(u8"Metrics / Plot")) {
             ImGuiX::Widgets::DemoMetricsPlot();
+            ImGuiX::Widgets::DemoMetricsPlotSet();
         }
     }
 #   endif

--- a/include/imguix/events/MetricsPlotSetUpdateEvent.hpp
+++ b/include/imguix/events/MetricsPlotSetUpdateEvent.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#ifndef _IMGUIX_EVENTS_METRICS_PLOT_SET_UPDATE_EVENT_HPP_INCLUDED
+#define _IMGUIX_EVENTS_METRICS_PLOT_SET_UPDATE_EVENT_HPP_INCLUDED
+
+/// \file MetricsPlotSetUpdateEvent.hpp
+/// \brief Emitted when a MetricsPlotSet data collection is updated.
+
+#ifdef IMGUI_ENABLE_IMPLOT
+
+#include <memory>
+#include <typeindex>
+
+#include <imguix/core/pubsub/Event.hpp>
+#include <imguix/widgets/plot/MetricsPlotSetData.hpp>
+
+namespace ImGuiX::Events {
+
+    /// \brief Carries updated MetricsPlotSet data.
+    struct MetricsPlotSetUpdateEvent : Pubsub::Event {
+        std::shared_ptr<const Widgets::MetricsPlotSetData> data; ///< Updated data.
+
+        /// \brief Construct event with data.
+        /// \param d Shared MetricsPlotSet data.
+        explicit MetricsPlotSetUpdateEvent(
+                std::shared_ptr<const Widgets::MetricsPlotSetData> d)
+            : data(std::move(d)) {}
+
+        /// \copydoc Pubsub::Event::type
+        std::type_index type() const override {
+            return typeid(MetricsPlotSetUpdateEvent);
+        }
+
+        /// \copydoc Pubsub::Event::name
+        const char* name() const override {
+            return u8"MetricsPlotSetUpdateEvent";
+        }
+
+        /// \copydoc Pubsub::Event::clone
+        std::unique_ptr<Event> clone() const override {
+            return std::make_unique<MetricsPlotSetUpdateEvent>(*this);
+        }
+    };
+
+} // namespace ImGuiX::Events
+
+#endif // IMGUI_ENABLE_IMPLOT
+
+#endif // _IMGUIX_EVENTS_METRICS_PLOT_SET_UPDATE_EVENT_HPP_INCLUDED

--- a/include/imguix/widgets/plot/MetricsPlotSet.hpp
+++ b/include/imguix/widgets/plot/MetricsPlotSet.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_PLOT_METRICS_PLOT_SET_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_PLOT_METRICS_PLOT_SET_HPP_INCLUDED
+
+/// \file MetricsPlotSet.hpp
+/// \brief Render MetricsPlotData sets with single-selection list.
+
+#include <imguix/widgets/plot/MetricsPlotSetData.hpp>
+#include <imguix/widgets/plot/MetricsPlot.hpp>
+
+namespace ImGuiX::Widgets {
+
+    /// \brief Runtime state for MetricsPlotSet.
+    /// \invariant selected >= 0 && selected < data.sets.size() when not empty.
+    struct MetricsPlotSetState {
+        int selected = 0;              ///< Index of currently selected data set.
+        MetricsPlotState plot_state;   ///< State passed to inner MetricsPlot.
+    };
+
+    /// \brief Render selectable MetricsPlotData sets.
+    /// \param data Data sets with labels.
+    /// \param state Runtime state (modified in-place).
+    /// \param cfg Plot configuration.
+    /// \thread_safety Not thread-safe.
+    void MetricsPlotSet(
+            const MetricsPlotSetData& data,
+            MetricsPlotSetState& state,
+            const MetricsPlotConfig& cfg = {}
+        );
+
+#   ifdef IMGUIX_DEMO
+    /// \brief Engineering demo for MetricsPlotSet.
+    /// \thread_safety Not thread-safe.
+    inline void DemoMetricsPlotSet();
+#   endif
+
+} // namespace ImGuiX::Widgets
+
+#include "MetricsPlotSet.ipp"
+
+#endif // _IMGUIX_WIDGETS_PLOT_METRICS_PLOT_SET_HPP_INCLUDED

--- a/include/imguix/widgets/plot/MetricsPlotSet.ipp
+++ b/include/imguix/widgets/plot/MetricsPlotSet.ipp
@@ -1,0 +1,129 @@
+#include <algorithm>
+#include <cmath>
+
+#include <imgui.h>
+#include <implot.h>
+
+namespace ImGuiX::Widgets {
+
+    namespace detail {
+        // reuse kUpdateCounterMax and calc_plot_height from MetricsPlot
+    }
+
+    inline void MetricsPlotSet(
+            const MetricsPlotSetData& data,
+            MetricsPlotSetState& state,
+            const MetricsPlotConfig& cfg
+        ) {
+        ImGui::PushID(cfg.id);
+
+        const float dnd_w = cfg.dnd_width > 0.0f ? cfg.dnd_width : CalcMetricsDndWidth();
+        const float plot_h = IM_TRUNC(detail::calc_plot_height(cfg));
+
+        if (!data.sets.empty()) {
+            if (state.selected < 0 || state.selected >= (int)data.sets.size()) {
+                state.selected = 0;
+                state.plot_state.initialized = false;
+            }
+        }
+
+        ImGui::BeginGroup();
+        {
+            const ImGuiStyle& st = ImGui::GetStyle();
+            if (cfg.left_panel_bordered) {
+                ImGui::PushStyleColor(ImGuiCol_ChildBg, st.Colors[ImGuiCol_FrameBg]);
+                ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, st.FrameRounding);
+                ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, st.FrameBorderSize);
+            }
+
+            ImGui::BeginChild("##child_left", ImVec2(dnd_w, plot_h), ImGuiChildFlags_Borders);
+            {
+                if (!data.sets.empty() && !data.sets[state.selected].values.empty()) {
+                    ImGui::Checkbox(cfg.annotation_checkbox, &state.plot_state.show_annotation);
+                }
+                if (!cfg.legend_force_off) {
+                    ImGui::Checkbox(cfg.legend_checkbox, &state.plot_state.show_legend);
+                }
+
+                if (cfg.left_list_header) ImGui::SeparatorText(cfg.left_list_header);
+                else ImGui::Separator();
+
+                ImGuiChildFlags list_flags = cfg.list_bordered ? ImGuiChildFlags_Borders : ImGuiChildFlags_None;
+                ImGui::BeginChild("##sets_scroll", ImVec2(0,0), list_flags);
+                {
+                    for (int i = 0; i < (int)data.sets.size(); ++i) {
+                        bool selected = (i == state.selected);
+                        if (ImGui::Selectable(data.labels[i].c_str(), selected, 0, ImVec2(dnd_w,0))) {
+                            state.selected = i;
+                            state.plot_state.initialized = false;
+                            state.plot_state.update_counter = detail::kUpdateCounterMax;
+                        }
+                    }
+                }
+                ImGui::EndChild();
+            }
+            ImGui::EndChild();
+
+            if (cfg.left_panel_bordered) {
+                ImGui::PopStyleVar(2);
+                ImGui::PopStyleColor();
+            }
+        }
+
+        ImGui::SameLine();
+
+        if (!data.sets.empty()) {
+            MetricsPlotConfig inner_cfg = cfg;
+            inner_cfg.force_all_visible = true;
+            const MetricsPlotData& sel = data.sets[state.selected];
+            MetricsPlot(sel, state.plot_state, inner_cfg);
+        }
+
+        ImGui::EndGroup();
+
+        ImGui::PopID();
+    }
+
+#   ifdef IMGUIX_DEMO
+    inline void DemoMetricsPlotSet() {
+        ImGui::TextUnformatted("MetricsPlotSet / Data sets demo");
+        static MetricsPlotSetData data;
+        static MetricsPlotSetState state;
+        static bool init = false;
+        if (!init) {
+            // Set 1: bars
+            MetricsPlotData bars;
+            const char* kLabels[] = {"A","B","C","D"};
+            bars.labels.assign(std::begin(kLabels), std::end(kLabels));
+            bars.values = {1.0, 2.0, 3.0, 2.5};
+            data.sets.push_back(bars);
+            data.labels.emplace_back("Bars sample");
+
+            // Set 2: lines
+            MetricsPlotData lines;
+            lines.labels = {"L1","L2"};
+            const int N = 50;
+            lines.line_x.resize(2);
+            lines.line_y.resize(2);
+            for (int s=0; s<2; ++s) {
+                lines.line_x[s].resize(N);
+                lines.line_y[s].resize(N);
+                for (int i=0; i<N; ++i) {
+                    lines.line_x[s][i] = i;
+                    lines.line_y[s][i] = (s+1)*0.5 + std::sin(0.1*i + s);
+                }
+            }
+            data.sets.push_back(lines);
+            data.labels.emplace_back("Lines sample");
+
+            init = true;
+        }
+        MetricsPlotConfig cfg;
+        cfg.id = "MetricsPlotSet_Demo";
+        cfg.left_list_header = "Data sets";
+        MetricsPlotSet(data, state, cfg);
+    }
+#   endif
+
+} // namespace ImGuiX::Widgets
+

--- a/include/imguix/widgets/plot/MetricsPlotSetData.hpp
+++ b/include/imguix/widgets/plot/MetricsPlotSetData.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef _IMGUIX_WIDGETS_PLOT_METRICS_PLOT_SET_DATA_HPP_INCLUDED
+#define _IMGUIX_WIDGETS_PLOT_METRICS_PLOT_SET_DATA_HPP_INCLUDED
+
+/// \file MetricsPlotSetData.hpp
+/// \brief Data container for a collection of MetricsPlotData.
+
+#include <string>
+#include <vector>
+
+#include <imguix/widgets/plot/MetricsPlotData.hpp>
+
+namespace ImGuiX::Widgets {
+
+    /// \brief Data sets with display labels for MetricsPlotSet.
+    struct MetricsPlotSetData {
+        std::vector<MetricsPlotData> sets; ///< Collection of data sets.
+        std::vector<std::string> labels;   ///< Labels for each data set.
+    };
+
+} // namespace ImGuiX::Widgets
+
+#endif // _IMGUIX_WIDGETS_PLOT_METRICS_PLOT_SET_DATA_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- add MetricsPlotSet widget to render selectable collections of MetricsPlotData
- introduce MetricsPlotSetUpdateEvent for publishing dataset updates
- factor out MetricsPlotSetData into a standalone header to decouple events from widget implementation
- include demo usage within widgets demo

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_SFML_BACKEND=ON -DIMGUIX_USE_GLFW_BACKEND=OFF -DIMGUIX_USE_SDL2_BACKEND=OFF -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF` (fail: target "imguix" requires target "nlohmann_json" not in any export set)
- `cmake --build build` (fail: ImGui-SFML operator mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68bf4e39c7dc832ca9c72a9306eb1f0e