### PR TITLE
Rename theme helpers and sync ImPlot3D style

### DIFF
--- a/docs/THEMES-RU.md
+++ b/docs/THEMES-RU.md
@@ -37,7 +37,7 @@ English version: [THEMES.md](THEMES.md).
 ## Создание собственной темы
 
 Реализуйте интерфейс `ImGuiX::Themes::Theme` и переопределите методы `apply`.
-Используйте `applyDefaultImGuiStyle`, чтобы задать общие значения отступов и скруглений.
+Используйте `ApplyDefaultImGuiStyle`, чтобы задать общие значения отступов и скруглений.
 Не вызывайте `ImGui::GetColorU32` вне активного контекста ImGui.
 В конфигурациях храните «сырые» значения `ImVec4` или `ImU32` и переводите их в цвета при отрисовке.
 
@@ -45,7 +45,7 @@ English version: [THEMES.md](THEMES.md).
 class MyTheme final : public ImGuiX::Themes::Theme {
 public:
     void apply(ImGuiStyle& style) const override {
-        ImGuiX::Themes::applyDefaultImGuiStyle(style);
+        ImGuiX::Themes::ApplyDefaultImGuiStyle(style);
         style.Colors[ImGuiCol_Text] = ImVec4(1.0f, 0.8f, 0.2f, 1.0f);
         // настройте остальные цвета...
         style.Colors[ImGuiCol_InputTextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // цвет курсора

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -37,7 +37,7 @@ This document lists the color themes bundled with ImGuiX and shows how to create
 
 ## Creating a custom theme
 
-Implement the `ImGuiX::Themes::Theme` interface and override the `apply` methods. Use `applyDefaultImGuiStyle` to set common spacing and rounding values.
+Implement the `ImGuiX::Themes::Theme` interface and override the `apply` methods. Use `ApplyDefaultImGuiStyle` to set common spacing and rounding values.
 Do not call `ImGui::GetColorU32` outside an active ImGui frame.
 Store raw `ImVec4` or `ImU32` values in configuration structs and convert during rendering.
 
@@ -45,7 +45,7 @@ Store raw `ImVec4` or `ImU32` values in configuration structs and convert during
 class MyTheme final : public ImGuiX::Themes::Theme {
 public:
     void apply(ImGuiStyle& style) const override {
-        ImGuiX::Themes::applyDefaultImGuiStyle(style);
+        ImGuiX::Themes::ApplyDefaultImGuiStyle(style);
         style.Colors[ImGuiCol_Text] = ImVec4(1.0f, 0.8f, 0.2f, 1.0f);
         // set other colors...
         style.Colors[ImGuiCol_InputTextCursor] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f); // cursor color

--- a/include/imguix/core/themes/Theme.hpp
+++ b/include/imguix/core/themes/Theme.hpp
@@ -43,7 +43,7 @@ namespace ImGuiX::Themes {
     /// \brief Set baseline ImGui style parameters.
     /// \param style Style to modify.
     /// \details Used by all themes before applying color scheme.
-    inline void applyDefaultImGuiStyle(ImGuiStyle& style) {
+    inline void ApplyDefaultImGuiStyle(ImGuiStyle& style) {
         using namespace ImGuiX::Config;
 
         style.ChildRounding     = CHILD_ROUNDING;
@@ -72,7 +72,7 @@ namespace ImGuiX::Themes {
     /// \brief Set baseline ImPlot style parameters.
     /// \param style Style to modify.
     /// \details Used by all themes before applying color scheme.
-    inline void applyDefaultImPlotStyle(ImPlotStyle& style) {
+    inline void ApplyDefaultImPlotStyle(ImPlotStyle& style) {
         using namespace ImGuiX::Config;
         const ImGuiStyle& ig = ImGui::GetStyle();
 
@@ -138,7 +138,7 @@ namespace ImGuiX::Themes {
     /// \brief Set baseline ImPlot3D style parameters.
     /// \param style Style to modify.
     /// \details Used by all themes before applying color scheme.
-    inline void applyDefaultImPlot3DStyle(ImPlot3DStyle& style) {
+    inline void ApplyDefaultImPlot3DStyle(ImPlot3DStyle& style) {
         using namespace ImGuiX::Config;
 
         const ImGuiStyle& ig = ImGui::GetStyle();
@@ -157,6 +157,32 @@ namespace ImGuiX::Themes {
         style.PlotDefaultSize = PLOT_DEFAULT_SIZE;
         style.PlotMinSize     = PLOT_MIN_SIZE;
     }
+
+    // вызывайте каждый раз после смены темы ImGui
+    inline void SyncImPlot3DWithImGui() {
+        ImGuiStyle& s      = ImGui::GetStyle();
+        ImPlot3DStyle& p   = ImPlot3D::GetStyle();
+
+        const ImVec4 win   = s.Colors[ImGuiCol_WindowBg];
+        const ImVec4 frame = s.Colors[ImGuiCol_FrameBg];
+        const ImVec4 text  = s.Colors[ImGuiCol_Text];
+        const ImVec4 border= s.Colors[ImGuiCol_Border];
+        const ImVec4 popup = s.Colors[ImGuiCol_PopupBg];
+
+        p.Colors[ImPlot3DCol_FrameBg]      = frame;
+        p.Colors[ImPlot3DCol_PlotBg]       = win;
+        p.Colors[ImPlot3DCol_PlotBorder]   = border;
+        p.Colors[ImPlot3DCol_LegendBg]     = popup;
+        p.Colors[ImPlot3DCol_LegendBorder] = border;
+        p.Colors[ImPlot3DCol_LegendText]   = text;
+        p.Colors[ImPlot3DCol_TitleText]    = text;
+        p.Colors[ImPlot3DCol_InlayText]    = text;
+        p.Colors[ImPlot3DCol_AxisText]     = text;
+
+        ImVec4 grid = ImVec4(text.x, text.y, text.z, 0.25f);
+        p.Colors[ImPlot3DCol_AxisGrid] = grid;
+        p.Colors[ImPlot3DCol_AxisTick] = text;
+    }
 #   endif
     
     /// \brief Classic ImGui theme.
@@ -165,14 +191,14 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImGuiStyle& style) const override {
             ImGui::StyleColorsClassic(&style);
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
         }
 
 #       ifdef IMGUI_ENABLE_IMPLOT
         /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsClassic(&style);
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
             SyncImPlotWithImGui();
         }
 #       endif
@@ -181,7 +207,8 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImPlot3DStyle& style) const override {
             ImPlot3D::StyleColorsClassic(&style);
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
+            SyncImPlot3DWithImGui();
         }
 #       endif
     };
@@ -192,14 +219,14 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImGuiStyle& style) const override {
             ImGui::StyleColorsLight(&style);
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
         }
 
 #       ifdef IMGUI_ENABLE_IMPLOT
         /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsLight(&style);
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
             SyncImPlotWithImGui();
         }
 #       endif
@@ -208,7 +235,8 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImPlot3DStyle& style) const override {
             ImPlot3D::StyleColorsLight(&style);
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
+            SyncImPlot3DWithImGui();
         }
 #       endif
     };
@@ -220,14 +248,14 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImGuiStyle& style) const override {
             ImGui::StyleColorsDark(&style);
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
         }
 
 #       ifdef IMGUI_ENABLE_IMPLOT
         /// \copydoc Theme::apply
         void apply(ImPlotStyle& style) const override {
             ImPlot::StyleColorsDark(&style);
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
             SyncImPlotWithImGui();
         }
 #       endif
@@ -236,7 +264,8 @@ namespace ImGuiX::Themes {
         /// \copydoc Theme::apply
         void apply(ImPlot3DStyle& style) const override {
             ImPlot3D::StyleColorsDark(&style);
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
+            SyncImPlot3DWithImGui();
         }
 #       endif
     };

--- a/include/imguix/themes/CorporateGreyTheme.hpp
+++ b/include/imguix/themes/CorporateGreyTheme.hpp
@@ -17,7 +17,7 @@
 /// \author NewYaroslav
 /// \date 2025
 
-#include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme base + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -103,7 +103,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_NavWindowingHighlight]  = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
             colors[ImGuiCol_NavWindowingDimBg]      = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
 
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
             style.DisabledAlpha = 0.75f;
 
 #ifdef IMGUIX_HAS_DOCKING
@@ -146,7 +146,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = Highlight;
             style.Colors[ImPlotCol_Crosshairs]    = Highlight;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -168,7 +168,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.25f, 0.25f, 0.25f, 0.45f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.45f, 0.45f, 0.45f, 0.70f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/CyberY2KTheme.hpp
+++ b/include/imguix/themes/CyberY2KTheme.hpp
@@ -12,10 +12,10 @@
 ///
 /// Notes:
 ///  - repeated colors are grouped in CyberY2KConstants
-///  - layout/rounding is unified via applyDefaultImGuiStyle
+///  - layout/rounding is unified via ApplyDefaultImGuiStyle
 ///  - includes optional ImPlot/ImPlot3D styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -177,7 +177,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unify sizes/roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingPreview] = Cyan;
@@ -215,7 +215,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]      = ImVec4(0.000f, 0.898f, 1.000f, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]     = ImVec4(0.000f, 0.898f, 1.000f, 1.00f);
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 
@@ -241,7 +241,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.164f, 0.204f, 0.251f, 0.60f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.902f, 0.945f, 1.000f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/CyberpunkUITheme.hpp
+++ b/include/imguix/themes/CyberpunkUITheme.hpp
@@ -12,10 +12,10 @@
 ///
 /// Notes:
 ///  - repeated colors are grouped in CyberpunkUIConstants
-///  - layout/rounding is unified via applyDefaultImGuiStyle
+///  - layout/rounding is unified via ApplyDefaultImGuiStyle
 ///  - includes optional ImPlot/ImPlot3D styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -174,7 +174,7 @@ namespace ImGuiX::Themes {
             // Dimming overlays for windowing and modals.
 
             // Baseline sizes/roundings from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #if IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingPreview] = Cyan;
@@ -214,7 +214,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]      = ImVec4(0.000f, 0.898f, 1.000f, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]     = ImVec4(0.000f, 0.898f, 1.000f, 1.00f);
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 
@@ -241,7 +241,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.164f, 0.204f, 0.251f, 0.60f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.902f, 0.945f, 1.000f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkCharcoalTheme.hpp
+++ b/include/imguix/themes/DarkCharcoalTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on the issue discussion: https://github.com/ocornut/imgui/issues/707
 /// (Dark Charcoal variant), adapted to:
 ///  - use named color constants
-///  - unify paddings/roundings via applyDefaultImGuiStyle
+///  - unify paddings/roundings via ApplyDefaultImGuiStyle
 ///  - provide matching ImPlot styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -177,7 +177,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unify sizes/roundings from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             // In the original snippet, Docking colors were commented; we set reasonable matches.
@@ -221,7 +221,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(1.000f, 0.391f, 0.000f, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.000f, 0.391f, 0.000f, 1.00f);
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -245,7 +245,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.35f, 0.35f, 0.35f, 0.55f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.60f, 0.60f, 0.60f, 0.80f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkGraphiteTheme.hpp
+++ b/include/imguix/themes/DarkGraphiteTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -171,7 +171,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Apply unified roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingEmptyBg]        = ImVec4(0.20f, 0.20f, 0.20f, 1.00f);
@@ -212,7 +212,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = AccentBlue;
             style.Colors[ImPlotCol_Crosshairs]    = AccentBlue;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -236,7 +236,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.34f, 0.35f, 0.38f, 0.55f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.62f, 0.64f, 0.68f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DarkTealTheme.hpp
+++ b/include/imguix/themes/DarkTealTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette from: https://github.com/ocornut/imgui/issues/707 (dark variants),
 /// adapted to:
 ///  - use named color constants
-///  - unify paddings/roundings via applyDefaultImGuiStyle
+///  - unify paddings/roundings via ApplyDefaultImGuiStyle
 ///  - provide matching ImPlot styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -180,7 +180,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unify sizes/roundings from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingEmptyBg]        = WindowBg;
@@ -223,7 +223,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(0.26f, 0.59f, 0.98f, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = AccentBase;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -247,7 +247,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.25f, 0.35f, 0.42f, 0.50f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.55f, 0.65f, 0.70f, 0.85f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/DeepDarkTheme.hpp
+++ b/include/imguix/themes/DeepDarkTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -187,7 +187,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unified roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             // Original snippet had docking colors commented out; we pick sane defaults.
@@ -231,7 +231,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(1.00f, 0.00f, 0.00f, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(1.00f, 0.00f, 0.00f, 1.00f);
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -255,7 +255,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.35f, 0.35f, 0.35f, 0.40f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.65f, 0.65f, 0.65f, 0.70f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/GoldBlackTheme.hpp
+++ b/include/imguix/themes/GoldBlackTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -172,7 +172,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unify sizes/roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingEmptyBg]        = WindowBg;
@@ -215,7 +215,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(GoldBright.x, GoldBright.y, GoldBright.z, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = GoldBright;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -239,7 +239,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.40f, 0.32f, 0.18f, 0.45f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.75f, 0.60f, 0.30f, 0.85f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/GreenBlueTheme.hpp
+++ b/include/imguix/themes/GreenBlueTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -184,7 +184,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unified roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             // Original snippet had docking colors commented; apply consistent values.
@@ -228,7 +228,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(0.13f, 0.75f, 1.00f, 0.65f); // cyan, semi-opaque
             style.Colors[ImPlotCol_Crosshairs]    = ImVec4(0.13f, 0.75f, 0.75f, 1.00f); // teal
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -252,7 +252,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.35f, 0.35f, 0.36f, 0.55f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.60f, 0.60f, 0.62f, 0.85f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/LightBlueTheme.hpp
+++ b/include/imguix/themes/LightBlueTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling (light)
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -168,7 +168,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unify sizes/roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingPreview] = Blue;
@@ -206,7 +206,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(0.26f, 0.59f, 0.98f, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -230,7 +230,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.75f, 0.75f, 0.75f, 0.60f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/LightGreenTheme.hpp
+++ b/include/imguix/themes/LightGreenTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling (light)
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -167,7 +167,7 @@ namespace ImGuiX::Themes {
             // Subtle dimming overlays for windowing and modals.
 
             // Unify sizes/roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingPreview] = ButtonHovered;
@@ -205,7 +205,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(0.26f, 0.59f, 0.98f, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -229,7 +229,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.75f, 0.75f, 0.75f, 0.60f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/NightOwlTheme.hpp
+++ b/include/imguix/themes/NightOwlTheme.hpp
@@ -12,7 +12,7 @@
 ///
 /// Notes:
 ///  - repeated colors are grouped in NightOwlConstants
-///  - layout/rounding is unified via applyDefaultImGuiStyle
+///  - layout/rounding is unified via ApplyDefaultImGuiStyle
 ///  - includes optional ImPlot/ImPlot3D styling
 
 #include <imguix/core/themes/Theme.hpp>
@@ -204,7 +204,7 @@ namespace ImGuiX::Themes {
 #endif
 
             // Unify sizes/roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
@@ -241,7 +241,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]      = PlotSelection;
             style.Colors[ImPlotCol_Crosshairs]     = PlotCrosshairs;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 
@@ -268,7 +268,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = PlotAxisGrid;
             style.Colors[ImPlot3DCol_AxisTick]     = PlotAxisTick;
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/NordTheme.hpp
+++ b/include/imguix/themes/NordTheme.hpp
@@ -202,7 +202,7 @@ public:
         c[ImGuiCol_DockingEmptyBg] = ImVec4(WindowBg.x, WindowBg.y, WindowBg.z, 1.0f);
 #endif
 
-        applyDefaultImGuiStyle(style);
+        ApplyDefaultImGuiStyle(style);
     }
 
 #ifdef IMGUI_ENABLE_IMPLOT
@@ -233,7 +233,7 @@ public:
         style.Colors[ImPlotCol_Selection]    = PlotSelection;
         style.Colors[ImPlotCol_Crosshairs]   = PlotCrosshairs;
 
-        applyDefaultImPlotStyle(style);
+        ApplyDefaultImPlotStyle(style);
     }
 #endif
 
@@ -259,7 +259,7 @@ public:
         style.Colors[ImPlot3DCol_AxisGrid]     = PlotAxisGrid;
         style.Colors[ImPlot3DCol_AxisTick]     = PlotAxisTick;
 
-        applyDefaultImPlot3DStyle(style);
+        ApplyDefaultImPlot3DStyle(style);
     }
 #endif
 };

--- a/include/imguix/themes/OSXTheme.hpp
+++ b/include/imguix/themes/OSXTheme.hpp
@@ -9,10 +9,10 @@
 /// https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling (light)
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -159,7 +159,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_ModalWindowDimBg]      = ModalWindowDimBg;
 
             // Unified roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingEmptyBg]        = WindowBg;
@@ -202,7 +202,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(Blue.x, Blue.y, Blue.z, 0.55f);
             style.Colors[ImPlotCol_Crosshairs]    = Blue;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -226,7 +226,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.78f, 0.78f, 0.78f, 0.60f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.35f, 0.35f, 0.35f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/PearlLightTheme.hpp
+++ b/include/imguix/themes/PearlLightTheme.hpp
@@ -7,10 +7,10 @@
 ///
 /// Each theme:
 ///  - uses named color constants in its own namespace
-///  - calls applyDefaultImGuiStyle(style) to unify paddings/roundings/etc
+///  - calls ApplyDefaultImGuiStyle(style) to unify paddings/roundings/etc
 ///  - defines ImPlot colors to match the palette
 
-#include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme base + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -141,7 +141,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_NavWindowingDimBg]     = NavDimBg;
 
             // Unify sizes/roundings from theme_config.hpp
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingEmptyBg]        = ChildBg;
@@ -183,7 +183,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]    = AccentBase;
             style.Colors[ImPlotCol_Crosshairs]   = AccentBase;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -207,7 +207,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.75f, 0.75f, 0.75f, 0.60f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.40f, 0.40f, 0.40f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/SlateDarkTheme.hpp
+++ b/include/imguix/themes/SlateDarkTheme.hpp
@@ -7,10 +7,10 @@
 ///
 /// Each theme:
 ///  - uses named color constants in its own namespace
-///  - calls applyDefaultImGuiStyle(style) to unify paddings/roundings/etc
+///  - calls ApplyDefaultImGuiStyle(style) to unify paddings/roundings/etc
 ///  - defines ImPlot colors to match the palette
 
-#include <imguix/core/themes/Theme.hpp> // Theme base + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme base + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -141,7 +141,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_NavWindowingDimBg]     = NavDimBg;
 
             // Unify sizes/roundings from theme_config.hpp
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingEmptyBg]        = ChildBg;
@@ -183,7 +183,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]    = AccentBase;
             style.Colors[ImPlotCol_Crosshairs]   = AccentBase;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -207,7 +207,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.30f, 0.30f, 0.30f, 0.50f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.55f, 0.55f, 0.55f, 0.80f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/TokyoNightStormTheme.hpp
+++ b/include/imguix/themes/TokyoNightStormTheme.hpp
@@ -12,7 +12,7 @@
 ///
 /// Notes:
 ///  - constants grouped in TokyoNightStormConstants
-///  - sizing unified via applyDefaultImGuiStyle/ImPlot/ImPlot3D
+///  - sizing unified via ApplyDefaultImGuiStyle/ImPlot/ImPlot3D
 
 #include <imguix/core/themes/Theme.hpp>
 
@@ -196,7 +196,7 @@ public:
         c[ImGuiCol_DockingEmptyBg] = ImVec4(WindowBg.x, WindowBg.y, WindowBg.z, 1.0f);
 #endif
 
-        applyDefaultImGuiStyle(style);
+        ApplyDefaultImGuiStyle(style);
     }
 
 #ifdef IMGUI_ENABLE_IMPLOT
@@ -227,7 +227,7 @@ public:
         style.Colors[ImPlotCol_Selection]    = PlotSelection;
         style.Colors[ImPlotCol_Crosshairs]   = PlotCrosshairs;
 
-        applyDefaultImPlotStyle(style);
+        ApplyDefaultImPlotStyle(style);
     }
 #endif
 
@@ -253,7 +253,7 @@ public:
         style.Colors[ImPlot3DCol_AxisGrid]     = PlotAxisGrid;
         style.Colors[ImPlot3DCol_AxisTick]     = PlotAxisTick;
 
-        applyDefaultImPlot3DStyle(style);
+        ApplyDefaultImPlot3DStyle(style);
     }
 #endif
 };

--- a/include/imguix/themes/TokyoNightTheme.hpp
+++ b/include/imguix/themes/TokyoNightTheme.hpp
@@ -12,7 +12,7 @@
 ///
 /// Notes:
 ///  - repeated colors are grouped in TokyoNightConstants
-///  - layout/rounding is unified via applyDefaultImGuiStyle
+///  - layout/rounding is unified via ApplyDefaultImGuiStyle
 ///  - includes optional ImPlot/ImPlot3D styling
 
 #include <imguix/core/themes/Theme.hpp>
@@ -204,7 +204,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_DockingPreview] = AccentCyan;
             colors[ImGuiCol_DockingEmptyBg] = ImVec4(WindowBg.x, WindowBg.y, WindowBg.z, 1.0f);
 #endif
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
@@ -236,7 +236,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]      = PlotSelection;
             style.Colors[ImPlotCol_Crosshairs]     = PlotCrosshairs;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 
@@ -263,7 +263,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = PlotAxisGrid;
             style.Colors[ImPlot3DCol_AxisTick]     = PlotAxisTick;
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/VisualStudioDarkTheme.hpp
+++ b/include/imguix/themes/VisualStudioDarkTheme.hpp
@@ -8,10 +8,10 @@
 /// Based on palette ideas from: https://github.com/ocornut/imgui/issues/707
 /// Adaptations:
 ///  - repeated colors moved to named constants
-///  - unified layout via applyDefaultImGuiStyle
+///  - unified layout via ApplyDefaultImGuiStyle
 ///  - added matching ImPlot styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -160,7 +160,7 @@ namespace ImGuiX::Themes {
             colors[ImGuiCol_TabUnfocusedActive]    = TabUnfocusedActive;
 
             // Unified roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
 
 #ifdef IMGUIX_HAS_DOCKING
             colors[ImGuiCol_DockingEmptyBg]        = Bg;
@@ -202,7 +202,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]     = ImVec4(PanelActive.x, PanelActive.y, PanelActive.z, 0.65f);
             style.Colors[ImPlotCol_Crosshairs]    = PanelActive;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 #ifdef IMGUI_ENABLE_IMPLOT3D
@@ -226,7 +226,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = ImVec4(0.32f, 0.32f, 0.34f, 0.55f);
             style.Colors[ImPlot3DCol_AxisTick]     = ImVec4(0.60f, 0.60f, 0.62f, 0.90f);
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };

--- a/include/imguix/themes/Y2KTheme.hpp
+++ b/include/imguix/themes/Y2KTheme.hpp
@@ -12,10 +12,10 @@
 ///
 /// Notes:
 ///  - repeated colors are grouped in Y2KConstants
-///  - layout/rounding is unified via applyDefaultImGuiStyle
+///  - layout/rounding is unified via ApplyDefaultImGuiStyle
 ///  - includes optional ImPlot/ImPlot3D styling
 
-#include <imguix/core/themes/Theme.hpp> // Theme + applyDefaultImGuiStyle
+#include <imguix/core/themes/Theme.hpp> // Theme + ApplyDefaultImGuiStyle
 
 namespace ImGuiX::Themes {
 
@@ -208,7 +208,7 @@ namespace ImGuiX::Themes {
 #endif
 
             // Unify sizes/roundings/paddings/borders from config
-            applyDefaultImGuiStyle(style);
+            ApplyDefaultImGuiStyle(style);
         }
 
 #ifdef IMGUI_ENABLE_IMPLOT
@@ -241,7 +241,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlotCol_Selection]      = PlotSelection;
             style.Colors[ImPlotCol_Crosshairs]     = PlotCrosshairs;
 
-            applyDefaultImPlotStyle(style);
+            ApplyDefaultImPlotStyle(style);
         }
 #endif
 
@@ -266,7 +266,7 @@ namespace ImGuiX::Themes {
             style.Colors[ImPlot3DCol_AxisGrid]     = PlotAxisGrid;
             style.Colors[ImPlot3DCol_AxisTick]     = PlotAxisTick;
 
-            applyDefaultImPlot3DStyle(style);
+            ApplyDefaultImPlot3DStyle(style);
         }
 #endif
     };


### PR DESCRIPTION
## Summary
- Rename default style helpers to ApplyDefaultImGuiStyle/ApplyDefaultImPlotStyle/ApplyDefaultImPlot3DStyle
- Add SyncImPlot3DWithImGui to align 3D plot colors with ImGui and use it in built-in themes
- Update theme headers and docs to reference the new helper names

## Testing
- `cmake -S . -B build` *(fails: Found SFML but requested component 'System' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6cc28dbc832c91c2bcc9515c8cfc