### PR TITLE
Fix ImPlot annotation usage and boolean loops

### DIFF
--- a/include/imguix/widgets/plot/DualMetricBarsPlot.ipp
+++ b/include/imguix/widgets/plot/DualMetricBarsPlot.ipp
@@ -82,15 +82,25 @@ namespace ImGuiX::Widgets {
                     double px = positions[i];
                     if (show1) {
                         std::snprintf(buf, sizeof buf, fmt1, data.metric1[i]);
-                        ImPlot::Annotation(px + off1, data.metric1[i],
-                                           ImPlotTextFlags_None, buf,
-                                           ImVec2(-5,-5));
+                        ImPlot::Annotation(
+                                px + off1,
+                                data.metric1[i],
+                                ImGui::GetStyleColorVec4(ImGuiCol_Text),
+                                ImVec2(-5, -5),
+                                false,
+                                "%s",
+                                buf);
                     }
                     if (show2) {
                         std::snprintf(buf, sizeof buf, fmt2, data.metric2[i]);
-                        ImPlot::Annotation(px + off2, data.metric2[i],
-                                           ImPlotTextFlags_None, buf,
-                                           ImVec2(5,-5));
+                        ImPlot::Annotation(
+                                px + off2,
+                                data.metric2[i],
+                                ImGui::GetStyleColorVec4(ImGuiCol_Text),
+                                ImVec2(5, -5),
+                                false,
+                                "%s",
+                                buf);
                     }
                 }
             }

--- a/include/imguix/widgets/plot/DualMetricBarsSet.ipp
+++ b/include/imguix/widgets/plot/DualMetricBarsSet.ipp
@@ -23,12 +23,12 @@ namespace ImGuiX::Widgets {
         {
             ImGui::BeginChild("##left", ImVec2(list_w, 200), ImGuiChildFlags_Borders);
             if (ImGui::Button("Select All")) {
-                for (bool& b : state.selected) b = true;
+                for (auto& b : state.selected) b = true;
                 state.plot_state.update_counter = 0;
             }
             ImGui::SameLine();
             if (ImGui::Button("Reset")) {
-                for (bool& b : state.selected) b = false;
+                for (auto& b : state.selected) b = false;
                 state.plot_state.update_counter = 0;
             }
             ImGui::Separator();


### PR DESCRIPTION
## Summary
- update DualMetricBarsPlot annotations to new ImPlot API
- iterate over selection state using `auto&` to avoid `vector<bool>` reference errors

## Testing
- `cmake -S . -B build -DIMGUIX_BUILD_EXAMPLES=OFF -DIMGUIX_BUILD_TESTS=ON -DIMGUIX_USE_SFML_BACKEND=OFF -DIMGUIX_IMGUI_FREETYPE=OFF -DIMGUIX_USE_IMPLOT=ON -DIMGUIX_USE_IMPLOT3D=OFF -DIMGUIX_USE_IMNODEFLOW=OFF -DIMGUIX_USE_IMGUIFILEDIALOG=OFF -DIMGUIX_USE_IMTEXTEDITOR=OFF -DIMGUIX_USE_PFD=OFF -DIMGUIX_USE_IMCMD=OFF -DIMGUIX_USE_IMCOOLBAR=OFF -DIMGUIX_USE_IMSPINNER=OFF -DIMGUIX_USE_IMGUI_MD=OFF -DIMGUIX_IMGUI_STDLIB=ON -DIMGUIX_DEPS_MODE=BUNDLED -DCMAKE_BUILD_TYPE=Release` *(fails: `nlohmann_json: no system package and no submodule at libs/json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c087ae043c832c9b1ab7d59648eb17