### PR TITLE
fix(windows): align side panel background with title bar

### DIFF
--- a/include/imguix/windows/GlfwImGuiFramedWindow.ipp
+++ b/include/imguix/windows/GlfwImGuiFramedWindow.ipp
@@ -98,7 +98,8 @@ namespace ImGuiX::Windows {
         const float title_w = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
         ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(title_w, m_config.title_bar_height), false,
                           ImGuiWindowFlags_NoScrollbar |
-                          ImGuiWindowFlags_NoDecoration);
+                          ImGuiWindowFlags_NoDecoration |
+                          ImGuiWindowFlags_NoBackground);
 
         {
             ImVec2 p_min = ImGui::GetWindowPos();
@@ -160,6 +161,9 @@ namespace ImGuiX::Windows {
                     ImGuiWindowFlags_NoDecoration |
                     ImGuiWindowFlags_NoBackground
                 )) {
+                ImVec2 p_min = ImGui::GetWindowPos();
+                ImVec2 p_max = ImVec2(p_min.x + ImGui::GetWindowWidth(), p_min.y + ImGui::GetWindowHeight());
+                ImGui::GetWindowDrawList()->AddRectFilled(p_min, p_max, ImGui::GetColorU32(ImGuiCol_TitleBgActive));
                 drawSidePanel();
             }
             ImGui::EndChild();

--- a/include/imguix/windows/GlfwImGuiFramedWindow.ipp
+++ b/include/imguix/windows/GlfwImGuiFramedWindow.ipp
@@ -96,7 +96,9 @@ namespace ImGuiX::Windows {
 
         ImGui::SetCursorPos(ImVec2(inset, inset));
         const float title_w = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
-        ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(title_w, m_config.title_bar_height), false,
+        ImGui::BeginChild(u8"##imguix_title_bar",
+                          ImVec2(title_w, m_config.title_bar_height),
+                          ImGuiChildFlags_AlwaysUseWindowPadding,
                           ImGuiWindowFlags_NoScrollbar |
                           ImGuiWindowFlags_NoDecoration |
                           ImGuiWindowFlags_NoBackground);
@@ -121,7 +123,9 @@ namespace ImGuiX::Windows {
 
         ImGui::EndChild();
 
-        const ImVec2 body_start(inset, padded_start.y + m_config.title_bar_height);
+        const float body_y = inset + m_config.title_bar_height;
+        const float body_h = ImMax(0.0f, ImGui::GetWindowSize().y - body_y - inset);
+        const ImVec2 body_start(inset, body_y);
         const float body_width = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
         const float requested_side_panel_width =
             m_config.side_panel_width > 0 ? static_cast<float>(m_config.side_panel_width) : 0.0f;
@@ -155,8 +159,8 @@ namespace ImGuiX::Windows {
             ImGui::SetCursorPos(body_start);
             if (ImGui::BeginChild(
                     u8"##imguix_side_panel",
-                    ImVec2(side_panel_width, 0.0f),
-                    ImGuiChildFlags_None,
+                    ImVec2(side_panel_width, body_h),
+                    ImGuiChildFlags_AlwaysUseWindowPadding,
                     ImGuiWindowFlags_NoScrollbar |
                     ImGuiWindowFlags_NoDecoration |
                     ImGuiWindowFlags_NoBackground
@@ -171,7 +175,7 @@ namespace ImGuiX::Windows {
 
             if (ImGui::BeginChild(
                     u8"##imguix_main_region",
-                    ImVec2(main_region_width, 0.0f),
+                    ImVec2(main_region_width, body_h),
                     ImGuiChildFlags_AlwaysUseWindowPadding,
                     ImGuiWindowFlags_NoScrollbar |
                     ImGuiWindowFlags_NoDecoration |

--- a/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
+++ b/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
@@ -100,7 +100,9 @@ namespace ImGuiX::Windows {
 
         ImGui::SetCursorPos(ImVec2(inset, inset));
         const float title_w = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
-        ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(title_w, m_config.title_bar_height), false,
+        ImGui::BeginChild(u8"##imguix_title_bar",
+                          ImVec2(title_w, m_config.title_bar_height),
+                          ImGuiChildFlags_AlwaysUseWindowPadding,
                           ImGuiWindowFlags_NoScrollbar |
                           ImGuiWindowFlags_NoDecoration |
                           ImGuiWindowFlags_NoBackground);
@@ -125,7 +127,9 @@ namespace ImGuiX::Windows {
 
         ImGui::EndChild();
 
-        const ImVec2 body_start(inset, padded_start.y + m_config.title_bar_height);
+        const float body_y = inset + m_config.title_bar_height;
+        const float body_h = ImMax(0.0f, ImGui::GetWindowSize().y - body_y - inset);
+        const ImVec2 body_start(inset, body_y);
         const float body_width = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
         const float requested_side_panel_width =
             m_config.side_panel_width > 0 ? static_cast<float>(m_config.side_panel_width) : 0.0f;
@@ -159,8 +163,8 @@ namespace ImGuiX::Windows {
             ImGui::SetCursorPos(body_start);
             if (ImGui::BeginChild(
                 u8"##imguix_side_panel",
-                ImVec2(side_panel_width, 0.0f),
-                ImGuiChildFlags_None,
+                ImVec2(side_panel_width, body_h),
+                ImGuiChildFlags_AlwaysUseWindowPadding,
                 ImGuiWindowFlags_NoScrollbar |
                 ImGuiWindowFlags_NoDecoration |
                 ImGuiWindowFlags_NoBackground
@@ -175,7 +179,7 @@ namespace ImGuiX::Windows {
 
             if (ImGui::BeginChild(
                     u8"##imguix_main_region",
-                    ImVec2(main_region_width, 0.0f),
+                    ImVec2(main_region_width, body_h),
                     ImGuiChildFlags_AlwaysUseWindowPadding,
                     ImGuiWindowFlags_NoScrollbar |
                     ImGuiWindowFlags_NoDecoration |

--- a/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
+++ b/include/imguix/windows/Sdl2ImGuiFramedWindow.ipp
@@ -102,7 +102,8 @@ namespace ImGuiX::Windows {
         const float title_w = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
         ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(title_w, m_config.title_bar_height), false,
                           ImGuiWindowFlags_NoScrollbar |
-                          ImGuiWindowFlags_NoDecoration);
+                          ImGuiWindowFlags_NoDecoration |
+                          ImGuiWindowFlags_NoBackground);
 
         {
             ImVec2 p_min = ImGui::GetWindowPos();
@@ -164,6 +165,9 @@ namespace ImGuiX::Windows {
                 ImGuiWindowFlags_NoDecoration |
                 ImGuiWindowFlags_NoBackground
             )) {
+                ImVec2 p_min = ImGui::GetWindowPos();
+                ImVec2 p_max = ImVec2(p_min.x + ImGui::GetWindowWidth(), p_min.y + ImGui::GetWindowHeight());
+                ImGui::GetWindowDrawList()->AddRectFilled(p_min, p_max, ImGui::GetColorU32(ImGuiCol_TitleBgActive));
                 drawSidePanel();
             }
             ImGui::EndChild();

--- a/include/imguix/windows/SfmlImGuiFramedWindow.ipp
+++ b/include/imguix/windows/SfmlImGuiFramedWindow.ipp
@@ -150,7 +150,9 @@ namespace ImGuiX::Windows {
         // --- Title bar
         ImGui::SetCursorPos(ImVec2(inset, inset));
         const float title_w = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
-        ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(title_w, m_config.title_bar_height), false,
+        ImGui::BeginChild(u8"##imguix_title_bar",
+                          ImVec2(title_w, m_config.title_bar_height),
+                          ImGuiChildFlags_AlwaysUseWindowPadding,
                           ImGuiWindowFlags_NoScrollbar | 
                           ImGuiWindowFlags_NoDecoration |
                           ImGuiWindowFlags_NoBackground);
@@ -176,7 +178,9 @@ namespace ImGuiX::Windows {
 
         ImGui::EndChild();
 
-        const ImVec2 body_start(inset, padded_start.y + m_config.title_bar_height);
+        const float body_y = inset + m_config.title_bar_height;
+        const float body_h = ImMax(0.0f, ImGui::GetWindowSize().y - body_y - inset);
+        const ImVec2 body_start(inset, body_y);
         const float body_width = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
         const float requested_side_panel_width =
             m_config.side_panel_width > 0 ? static_cast<float>(m_config.side_panel_width) : 0.0f;
@@ -212,8 +216,8 @@ namespace ImGuiX::Windows {
             ImGui::SetCursorPos(body_start);
             if (ImGui::BeginChild(
                     u8"##imguix_side_panel",
-                    ImVec2(side_panel_width, 0.0f),
-                    ImGuiChildFlags_None,
+                    ImVec2(side_panel_width, body_h),
+                    ImGuiChildFlags_AlwaysUseWindowPadding,
                     ImGuiWindowFlags_NoScrollbar |
                     ImGuiWindowFlags_NoDecoration |
                     ImGuiWindowFlags_NoBackground
@@ -228,7 +232,7 @@ namespace ImGuiX::Windows {
 
             if (ImGui::BeginChild(
                     u8"##imguix_main_region",
-                    ImVec2(main_region_width, 0.0f),
+                    ImVec2(main_region_width, body_h),
                     ImGuiChildFlags_AlwaysUseWindowPadding,
                     ImGuiWindowFlags_NoScrollbar |
                     ImGuiWindowFlags_NoDecoration |

--- a/include/imguix/windows/SfmlImGuiFramedWindow.ipp
+++ b/include/imguix/windows/SfmlImGuiFramedWindow.ipp
@@ -152,7 +152,8 @@ namespace ImGuiX::Windows {
         const float title_w = ImMax(0.0f, ImGui::GetWindowSize().x - 2.0f * inset);
         ImGui::BeginChild(u8"##imguix_title_bar", ImVec2(title_w, m_config.title_bar_height), false,
                           ImGuiWindowFlags_NoScrollbar | 
-                          ImGuiWindowFlags_NoDecoration);
+                          ImGuiWindowFlags_NoDecoration |
+                          ImGuiWindowFlags_NoBackground);
                  
         {
             ImVec2 p_min = ImGui::GetWindowPos();
@@ -217,12 +218,14 @@ namespace ImGuiX::Windows {
                     ImGuiWindowFlags_NoDecoration |
                     ImGuiWindowFlags_NoBackground
                 )) {
+                ImVec2 p_min = ImGui::GetWindowPos();
+                ImVec2 p_max = ImVec2(p_min.x + ImGui::GetWindowWidth(), p_min.y + ImGui::GetWindowHeight());
+                ImGui::GetWindowDrawList()->AddRectFilled(p_min, p_max, ImGui::GetColorU32(ImGuiCol_TitleBgActive));
                 drawSidePanel();
             }
             ImGui::EndChild();
             ImGui::SameLine(0.0f, 0.0f);
 
-<<<<<<< HEAD
             if (ImGui::BeginChild(
                     u8"##imguix_main_region",
                     ImVec2(main_region_width, 0.0f),


### PR DESCRIPTION
Make title bar and side panel child windows transparent and paint both backgrounds explicitly with ImGuiCol_TitleBgActive via AddRectFilled.

Also remove a stray merge marker from SfmlImGuiFramedWindow.ipp.